### PR TITLE
will/clang: Fix header files' formatting using clang-format

### DIFF
--- a/astra-sim/system/AstraComputeAPI.hh
+++ b/astra-sim/system/AstraComputeAPI.hh
@@ -6,21 +6,26 @@ LICENSE file in the root directory of this source tree.
 #ifndef __COMPUTE_HH__
 #define __COMPUTE_HH__
 #include <cassert>
+#include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <string>
-#include <cstdint>
-namespace AstraSim{
-class ComputeMetaData{
-    public:
-        uint64_t compute_delay; //delay in nanoseconds
+namespace AstraSim {
+class ComputeMetaData {
+ public:
+  uint64_t compute_delay; // delay in nanoseconds
 };
-class ComputeAPI{
-    public:
-        //These should be the last 2 lines of this function
-        //fun_arg->compute_delay=20;
-        //(*msg_handler)(fun_arg);
-        virtual void compute(uint64_t M, uint64_t K, uint64_t N, void (*msg_handler)(void *fun_arg), ComputeMetaData* fun_arg)=0;
+class ComputeAPI {
+ public:
+  // These should be the last 2 lines of this function
+  // fun_arg->compute_delay=20;
+  //(*msg_handler)(fun_arg);
+  virtual void compute(
+      uint64_t M,
+      uint64_t K,
+      uint64_t N,
+      void (*msg_handler)(void* fun_arg),
+      ComputeMetaData* fun_arg) = 0;
 };
-}
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/AstraMemoryAPI.hh
+++ b/astra-sim/system/AstraMemoryAPI.hh
@@ -6,20 +6,20 @@ LICENSE file in the root directory of this source tree.
 #ifndef __ASTRAMEMORYAPI_HH__
 #define __ASTRAMEMORYAPI_HH__
 #include <cassert>
+#include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <string>
-#include <cstdint>
-namespace AstraSim{
-class AstraMemoryAPI{
-    public:
-        virtual  uint64_t mem_read(uint64_t size)=0;
-        virtual  uint64_t mem_write(uint64_t size)=0;
-        virtual  uint64_t npu_mem_read(uint64_t size)=0;
-        virtual  uint64_t npu_mem_write(uint64_t size)=0;
-        virtual  uint64_t nic_mem_read(uint64_t size)=0;
-        virtual  uint64_t nic_mem_write(uint64_t size)=0;
-        virtual ~AstraMemoryAPI()= default;
+namespace AstraSim {
+class AstraMemoryAPI {
+ public:
+  virtual uint64_t mem_read(uint64_t size) = 0;
+  virtual uint64_t mem_write(uint64_t size) = 0;
+  virtual uint64_t npu_mem_read(uint64_t size) = 0;
+  virtual uint64_t npu_mem_write(uint64_t size) = 0;
+  virtual uint64_t nic_mem_read(uint64_t size) = 0;
+  virtual uint64_t nic_mem_write(uint64_t size) = 0;
+  virtual ~AstraMemoryAPI() = default;
 };
-}
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/AstraNetworkAPI.hh
+++ b/astra-sim/system/AstraNetworkAPI.hh
@@ -11,52 +11,81 @@ LICENSE file in the root directory of this source tree.
 #include <string>
 #include "AstraMemoryAPI.hh"
 #include "AstraSimDataAPI.hh"
-namespace AstraSim{
+namespace AstraSim {
 struct sim_comm {
-    std::string comm_name;
+  std::string comm_name;
 };
 
-enum time_type_e {SE, MS, US, NS, FS};
+enum time_type_e { SE, MS, US, NS, FS };
 
 struct timespec_t {
-    time_type_e time_res;
-    double time_val;
+  time_type_e time_res;
+  double time_val;
 };
-enum req_type_e {UINT8, BFLOAT16, FP32};
+enum req_type_e { UINT8, BFLOAT16, FP32 };
 struct sim_request {
-    uint32_t srcRank;
-    uint32_t dstRank;
-    uint32_t tag;
-    req_type_e reqType;
-    uint32_t reqCount;
-    uint32_t vnet;
-    uint32_t layerNum;
+  uint32_t srcRank;
+  uint32_t dstRank;
+  uint32_t tag;
+  req_type_e reqType;
+  uint32_t reqCount;
+  uint32_t vnet;
+  uint32_t layerNum;
 };
 
 class MetaData {
-public:
-    timespec_t timestamp;
+ public:
+  timespec_t timestamp;
 };
 
-class AstraNetworkAPI{
-public:
-    bool enabled;
-    int rank;
+class AstraNetworkAPI {
+ public:
+  bool enabled;
+  int rank;
 
-    virtual int sim_comm_size(sim_comm comm, int* size)=0;
-    virtual int sim_comm_get_rank(){return rank;};
-    virtual int sim_comm_set_rank(int rank){this->rank=rank;return this->rank;};
-    virtual int sim_finish()=0;
-    virtual double sim_time_resolution()=0;
-    virtual int sim_init(AstraMemoryAPI* MEM)=0;
-    virtual timespec_t sim_get_time()=0;
-    virtual void sim_schedule(timespec_t delta, void (*fun_ptr)(void *fun_arg), void *fun_arg)=0;
-    virtual int sim_send(void *buffer, int count, int type, int dst, int tag, sim_request *request, void (*msg_handler)(void *fun_arg), void* fun_arg)=0;
-    virtual int sim_recv(void *buffer, int count, int type, int src, int tag, sim_request *request, void (*msg_handler)(void *fun_arg), void* fun_arg)=0;
-    virtual void pass_front_end_report(AstraSimDataAPI astraSimDataAPI){return;};
+  virtual int sim_comm_size(sim_comm comm, int* size) = 0;
+  virtual int sim_comm_get_rank() {
+    return rank;
+  };
+  virtual int sim_comm_set_rank(int rank) {
+    this->rank = rank;
+    return this->rank;
+  };
+  virtual int sim_finish() = 0;
+  virtual double sim_time_resolution() = 0;
+  virtual int sim_init(AstraMemoryAPI* MEM) = 0;
+  virtual timespec_t sim_get_time() = 0;
+  virtual void sim_schedule(
+      timespec_t delta,
+      void (*fun_ptr)(void* fun_arg),
+      void* fun_arg) = 0;
+  virtual int sim_send(
+      void* buffer,
+      int count,
+      int type,
+      int dst,
+      int tag,
+      sim_request* request,
+      void (*msg_handler)(void* fun_arg),
+      void* fun_arg) = 0;
+  virtual int sim_recv(
+      void* buffer,
+      int count,
+      int type,
+      int src,
+      int tag,
+      sim_request* request,
+      void (*msg_handler)(void* fun_arg),
+      void* fun_arg) = 0;
+  virtual void pass_front_end_report(AstraSimDataAPI astraSimDataAPI) {
+    return;
+  };
 
-    AstraNetworkAPI(int rank){this->rank=rank;enabled= true;};
-    virtual ~AstraNetworkAPI() {}; // ADDED BY PALLAVI
+  AstraNetworkAPI(int rank) {
+    this->rank = rank;
+    enabled = true;
+  };
+  virtual ~AstraNetworkAPI(){}; // ADDED BY PALLAVI
 };
-}
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/AstraSimDataAPI.hh
+++ b/astra-sim/system/AstraSimDataAPI.hh
@@ -5,32 +5,33 @@ LICENSE file in the root directory of this source tree.
 
 #ifndef __ASTRASIMDATAAPI_HH__
 #define __ASTRASIMDATAAPI_HH__
-#include <list>
 #include <iostream>
-namespace AstraSim{
-class LayerData{
-    public:
-        std::string layer_name;
-        double total_forward_pass_compute;
-        double total_weight_grad_compute;
-        double total_input_grad_compute;
-        double total_waiting_for_fwd_comm;
-        double total_waiting_for_wg_comm;
-        double total_waiting_for_ig_comm;
-        double total_fwd_comm;
-        double total_weight_grad_comm;
-        double total_input_grad_comm;
-        std::list<std::pair<int,double>> avg_queuing_delay; //int is phase #, double is latency
-        std::list<std::pair<int,double>> avg_network_message_dealy; //int is phase #, double is latency
-
+#include <list>
+namespace AstraSim {
+class LayerData {
+ public:
+  std::string layer_name;
+  double total_forward_pass_compute;
+  double total_weight_grad_compute;
+  double total_input_grad_compute;
+  double total_waiting_for_fwd_comm;
+  double total_waiting_for_wg_comm;
+  double total_waiting_for_ig_comm;
+  double total_fwd_comm;
+  double total_weight_grad_comm;
+  double total_input_grad_comm;
+  std::list<std::pair<int, double>>
+      avg_queuing_delay; // int is phase #, double is latency
+  std::list<std::pair<int, double>>
+      avg_network_message_dealy; // int is phase #, double is latency
 };
-class AstraSimDataAPI{
-    public:
-      std::string run_name;
-      std::list<LayerData> layers_stats;
-      double workload_finished_time;
-      double total_compute;
-      double total_exposed_comm;
+class AstraSimDataAPI {
+ public:
+  std::string run_name;
+  std::list<LayerData> layers_stats;
+  double workload_finished_time;
+  double total_compute;
+  double total_exposed_comm;
 };
-}
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/BaseStream.hh
+++ b/astra-sim/system/BaseStream.hh
@@ -6,69 +6,70 @@ LICENSE file in the root directory of this source tree.
 #ifndef __BASESTREAM_HH__
 #define __BASESTREAM_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "Common.hh"
+#include <tuple>
+#include <vector>
 #include "Callable.hh"
-#include "StreamStat.hh"
 #include "CollectivePhase.hh"
+#include "Common.hh"
 #include "DataSet.hh"
+#include "StreamStat.hh"
 #include "Sys.hh"
 #include "astra-sim/system/topology/LogicalTopology.hh"
 
-namespace AstraSim{
-    class RecvPacketEventHadndlerData;
-    class BaseStream:public Callable,public  StreamStat{
-    public:
-        static std::map<int,int> synchronizer;
-        static std::map<int,int> ready_counter;
-        static std::map<int,std::list<BaseStream *>> suspended_streams;
-        virtual ~BaseStream()=default;
-        int stream_num;
-        int total_packets_sent;
-        SchedulingPolicy preferred_scheduling;
-        std::list<CollectivePhase> phases_to_go;
-        int current_queue_id;
-        CollectivePhase my_current_phase;
-        ComType current_com_type;
-        Tick creation_time;
-        Sys *owner;
-        DataSet *dataset;
-        int steps_finished;
-        int initial_data_size;
-        int priority;
-        StreamState state;
-        bool initialized;
+namespace AstraSim {
+class RecvPacketEventHadndlerData;
+class BaseStream : public Callable, public StreamStat {
+ public:
+  static std::map<int, int> synchronizer;
+  static std::map<int, int> ready_counter;
+  static std::map<int, std::list<BaseStream*>> suspended_streams;
+  virtual ~BaseStream() = default;
+  int stream_num;
+  int total_packets_sent;
+  SchedulingPolicy preferred_scheduling;
+  std::list<CollectivePhase> phases_to_go;
+  int current_queue_id;
+  CollectivePhase my_current_phase;
+  ComType current_com_type;
+  Tick creation_time;
+  Sys* owner;
+  DataSet* dataset;
+  int steps_finished;
+  int initial_data_size;
+  int priority;
+  StreamState state;
+  bool initialized;
 
-        Tick last_phase_change;
+  Tick last_phase_change;
 
-        int test;
-        int test2;
-        uint64_t phase_latencies[10];
+  int test;
+  int test2;
+  uint64_t phase_latencies[10];
 
-        void changeState(StreamState state);
-        virtual void consume(RecvPacketEventHadndlerData *message)=0;
-        virtual void init()=0;
+  void changeState(StreamState state);
+  virtual void consume(RecvPacketEventHadndlerData* message) = 0;
+  virtual void init() = 0;
 
-        BaseStream(int stream_num,Sys *owner,std::list<CollectivePhase> phases_to_go);
-        void declare_ready();
-        bool is_ready();
-        void consume_ready();
-        void suspend_ready();
-        void resume_ready(int st_num);
-        void destruct_ready();
-
-    };
-}
+  BaseStream(
+      int stream_num,
+      Sys* owner,
+      std::list<CollectivePhase> phases_to_go);
+  void declare_ready();
+  bool is_ready();
+  void consume_ready();
+  void suspend_ready();
+  void resume_ready(int st_num);
+  void destruct_ready();
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/BasicEventHandlerData.hh
+++ b/astra-sim/system/BasicEventHandlerData.hh
@@ -6,28 +6,27 @@ LICENSE file in the root directory of this source tree.
 #ifndef __BASICEVENTHANDLERDATA_HH__
 #define __BASICEVENTHANDLERDATA_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "Common.hh"
+#include <tuple>
+#include <vector>
 #include "CallData.hh"
+#include "Common.hh"
 
-namespace AstraSim{
-    class BasicEventHandlerData:public CallData{
-    public:
-        int nodeId;
-        EventType event;
-        BasicEventHandlerData(int nodeId, EventType event);
-    };
-}
+namespace AstraSim {
+class BasicEventHandlerData : public CallData {
+ public:
+  int nodeId;
+  EventType event;
+  BasicEventHandlerData(int nodeId, EventType event);
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/CallData.hh
+++ b/astra-sim/system/CallData.hh
@@ -5,10 +5,10 @@ LICENSE file in the root directory of this source tree.
 
 #ifndef __CALLDATA_HH__
 #define __CALLDATA_HH__
-namespace AstraSim{
-class CallData{
-    public:
-        ~CallData()= default;
+namespace AstraSim {
+class CallData {
+ public:
+  ~CallData() = default;
 };
-}
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/Callable.hh
+++ b/astra-sim/system/Callable.hh
@@ -6,27 +6,26 @@ LICENSE file in the root directory of this source tree.
 #ifndef __CALLABLE_HH__
 #define __CALLABLE_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "Common.hh"
+#include <tuple>
+#include <vector>
 #include "CallData.hh"
+#include "Common.hh"
 
-namespace AstraSim{
-    class Callable{
-    public:
-        virtual ~Callable() = default;
-        virtual void call(EventType type,CallData *data)=0;
-    };
-}
+namespace AstraSim {
+class Callable {
+ public:
+  virtual ~Callable() = default;
+  virtual void call(EventType type, CallData* data) = 0;
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/CollectivePhase.hh
+++ b/astra-sim/system/CollectivePhase.hh
@@ -6,37 +6,36 @@ LICENSE file in the root directory of this source tree.
 #ifndef __COLLECTIVEPHASE_HH__
 #define __COLLECTIVEPHASE_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
+#include <tuple>
+#include <vector>
 #include "Common.hh"
 
-namespace AstraSim{
-    class Sys;
-    class Algorithm;
-    class BaseStream;
-    class CollectivePhase{
-    public:
-        Sys *generator;
-        int queue_id;
-        int initial_data_size;
-        int final_data_size;
-        bool enabled;
-        ComType comm_type;
-        Algorithm *algorithm;
-        CollectivePhase(Sys *generator,int queue_id,Algorithm *algorithm);
-        CollectivePhase();
-        void init(BaseStream *stream);
-    };
-}
+namespace AstraSim {
+class Sys;
+class Algorithm;
+class BaseStream;
+class CollectivePhase {
+ public:
+  Sys* generator;
+  int queue_id;
+  int initial_data_size;
+  int final_data_size;
+  bool enabled;
+  ComType comm_type;
+  Algorithm* algorithm;
+  CollectivePhase(Sys* generator, int queue_id, Algorithm* algorithm);
+  CollectivePhase();
+  void init(BaseStream* stream);
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/Common.hh
+++ b/astra-sim/system/Common.hh
@@ -6,17 +6,71 @@ LICENSE file in the root directory of this source tree.
 #ifndef __COMMON_HH__
 #define __COMMON_HH__
 #include "AstraNetworkAPI.hh"
-namespace AstraSim{
-    #define CLOCK_PERIOD 1
-    typedef unsigned long long Tick;
-    enum class ComType {None,Reduce_Scatter, All_Gatehr, All_Reduce,All_to_All,All_Reduce_All_to_All};
-    enum class CollectiveBarrier{Blocking,Non_Blocking};
-    enum class SchedulingPolicy {LIFO,FIFO,HIGHEST,None};
-    enum class InjectionPolicy {Infinite,Aggressive,SemiAggressive,ExtraAggressive,Normal};
-    enum class PacketRouting {Hardware,Software};
-    enum class BusType {Both,Shared,Mem};
-    enum class StreamState {Created,Transferring,Ready,Executing,Zombie,Dead};
-    enum class EventType {RendezvousSend,RendezvousRecv,CallEvents,PacketReceived,WaitForVnetTurn,General,TX_DMA,RX_DMA,Wight_Grad_Comm_Finished,Input_Grad_Comm_Finished,Fwd_Comm_Finished,Wight_Grad_Comm_Finished_After_Delay,Input_Grad_Comm_Finished_After_Delay,Fwd_Comm_Finished_After_Delay,Workload_Wait,Reduction_Ready,Rec_Finished,Send_Finished,
-        Processing_Finished,Delivered,NPU_to_MA,MA_to_NPU,Read_Port_Free,Write_Port_Free,Apply_Boost,Stream_Transfer_Started,Stream_Ready,Consider_Process,Consider_Retire,Consider_Send_Back,StreamInit,StreamsFinishedIncrease,CommProcessingFinished,NotInitialized};
-}
+namespace AstraSim {
+#define CLOCK_PERIOD 1
+typedef unsigned long long Tick;
+enum class ComType {
+  None,
+  Reduce_Scatter,
+  All_Gatehr,
+  All_Reduce,
+  All_to_All,
+  All_Reduce_All_to_All
+};
+enum class CollectiveBarrier { Blocking, Non_Blocking };
+enum class SchedulingPolicy { LIFO, FIFO, HIGHEST, None };
+enum class InjectionPolicy {
+  Infinite,
+  Aggressive,
+  SemiAggressive,
+  ExtraAggressive,
+  Normal
+};
+enum class PacketRouting { Hardware, Software };
+enum class BusType { Both, Shared, Mem };
+enum class StreamState {
+  Created,
+  Transferring,
+  Ready,
+  Executing,
+  Zombie,
+  Dead
+};
+enum class EventType {
+  RendezvousSend,
+  RendezvousRecv,
+  CallEvents,
+  PacketReceived,
+  WaitForVnetTurn,
+  General,
+  TX_DMA,
+  RX_DMA,
+  Wight_Grad_Comm_Finished,
+  Input_Grad_Comm_Finished,
+  Fwd_Comm_Finished,
+  Wight_Grad_Comm_Finished_After_Delay,
+  Input_Grad_Comm_Finished_After_Delay,
+  Fwd_Comm_Finished_After_Delay,
+  Workload_Wait,
+  Reduction_Ready,
+  Rec_Finished,
+  Send_Finished,
+  Processing_Finished,
+  Delivered,
+  NPU_to_MA,
+  MA_to_NPU,
+  Read_Port_Free,
+  Write_Port_Free,
+  Apply_Boost,
+  Stream_Transfer_Started,
+  Stream_Ready,
+  Consider_Process,
+  Consider_Retire,
+  Consider_Send_Back,
+  StreamInit,
+  StreamsFinishedIncrease,
+  CommProcessingFinished,
+  NotInitialized
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/DMA_Request.hh
+++ b/astra-sim/system/DMA_Request.hh
@@ -6,33 +6,37 @@ LICENSE file in the root directory of this source tree.
 #ifndef __DMAREQUEST_HH__
 #define __DMAREQUEST_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "Common.hh"
+#include <tuple>
+#include <vector>
 #include "Callable.hh"
+#include "Common.hh"
 
-namespace AstraSim{
-    class DMA_Request{
-    public:
-        int id;
-        int slots;
-        int latency;
-        bool executed;
-        int bytes;
-        Callable *stream_owner;
-        DMA_Request(int id,int slots,int latency,int bytes);
-        DMA_Request(int id,int slots,int latency,int bytes,Callable *stream_owner);
-    };
-}
+namespace AstraSim {
+class DMA_Request {
+ public:
+  int id;
+  int slots;
+  int latency;
+  bool executed;
+  int bytes;
+  Callable* stream_owner;
+  DMA_Request(int id, int slots, int latency, int bytes);
+  DMA_Request(
+      int id,
+      int slots,
+      int latency,
+      int bytes,
+      Callable* stream_owner);
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/DataSet.hh
+++ b/astra-sim/system/DataSet.hh
@@ -6,42 +6,41 @@ LICENSE file in the root directory of this source tree.
 #ifndef __DATASET_HH__
 #define __DATASET_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "Common.hh"
-#include "Callable.hh"
+#include <tuple>
+#include <vector>
 #include "CallData.hh"
+#include "Callable.hh"
+#include "Common.hh"
 #include "StreamStat.hh"
 
-namespace AstraSim{
-    class DataSet:public Callable,public StreamStat{
-    public:
-        static int id_auto_increment;
-        int my_id;
-        int total_streams;
-        int finished_streams;
-        bool finished;
-        Tick finish_tick;
-        Tick creation_tick;
-        std::pair<Callable *,EventType> *notifier;
+namespace AstraSim {
+class DataSet : public Callable, public StreamStat {
+ public:
+  static int id_auto_increment;
+  int my_id;
+  int total_streams;
+  int finished_streams;
+  bool finished;
+  Tick finish_tick;
+  Tick creation_tick;
+  std::pair<Callable*, EventType>* notifier;
 
-        DataSet(int total_streams);
-        void set_notifier(Callable *layer,EventType event);
-        void notify_stream_finished(StreamStat *data);
-        void call(EventType event,CallData *data);
-        bool is_finished();
-        //~DataSet()= default;
-    };
-}
+  DataSet(int total_streams);
+  void set_notifier(Callable* layer, EventType event);
+  void notify_stream_finished(StreamStat* data);
+  void call(EventType event, CallData* data);
+  bool is_finished();
+  //~DataSet()= default;
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/IntData.hh
+++ b/astra-sim/system/IntData.hh
@@ -5,14 +5,14 @@ LICENSE file in the root directory of this source tree.
 
 #ifndef __INDATA_HH__
 #define __INDATA_HH__
-namespace AstraSim{
-    class IntData:public CallData{
-    public:
-        int data;
-        //~IntData()= default;
-        IntData(int d){
-            data=d;
-        }
-    };
-}
+namespace AstraSim {
+class IntData : public CallData {
+ public:
+  int data;
+  //~IntData()= default;
+  IntData(int d) {
+    data = d;
+  }
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/LogGP.hh
+++ b/astra-sim/system/LogGP.hh
@@ -6,63 +6,80 @@ LICENSE file in the root directory of this source tree.
 #ifndef __LOGGP_HH__
 #define __LOGGP_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "Common.hh"
+#include <tuple>
+#include <vector>
 #include "Callable.hh"
-#include "MemMovRequest.hh"
+#include "Common.hh"
 #include "MemBus.hh"
+#include "MemMovRequest.hh"
 
-namespace AstraSim{
-    class Sys;
-    class LogGP:public Callable{
-    public:
-        enum class State{Free,waiting,Sending,Receiving};
-        enum class ProcState{Free,Processing};
-        int request_num;
-        std::string name;
-        Tick L;
-        Tick o;
-        Tick g;
-        double G;
-        Tick last_trans;
-        State curState;
-        State prevState;
-        ProcState processing_state;
-        std::list<MemMovRequest> sends;
-        std::list<MemMovRequest> receives;
-        std::list<MemMovRequest> processing;
+namespace AstraSim {
+class Sys;
+class LogGP : public Callable {
+ public:
+  enum class State { Free, waiting, Sending, Receiving };
+  enum class ProcState { Free, Processing };
+  int request_num;
+  std::string name;
+  Tick L;
+  Tick o;
+  Tick g;
+  double G;
+  Tick last_trans;
+  State curState;
+  State prevState;
+  ProcState processing_state;
+  std::list<MemMovRequest> sends;
+  std::list<MemMovRequest> receives;
+  std::list<MemMovRequest> processing;
 
-        std::list<MemMovRequest> retirements;
-        std::list<MemMovRequest> pre_send;
-        std::list<MemMovRequest> pre_process;
-        std::list<MemMovRequest>::iterator talking_it;
+  std::list<MemMovRequest> retirements;
+  std::list<MemMovRequest> pre_send;
+  std::list<MemMovRequest> pre_process;
+  std::list<MemMovRequest>::iterator talking_it;
 
-        LogGP *partner;
-        Sys *generator;
-        EventType trigger_event;
-        int subsequent_reads;
-        int THRESHOLD;
-        int local_reduction_delay;
-        LogGP(std::string name,Sys *generator,Tick L,Tick o,Tick g,double G,EventType trigger_event);
-        void process_next_read();
-        void request_read(int bytes,bool processed,bool send_back,Callable *callable);
-        void switch_to_receiver(MemMovRequest mr,Tick offset);
-        void call(EventType event,CallData *data);
-        MemBus *NPU_MEM;
-        void attach_mem_bus(Sys *generator,Tick L,Tick o,Tick g,double G,bool model_shared_bus,int communication_delay);
-        ~LogGP();
-    };
-}
+  LogGP* partner;
+  Sys* generator;
+  EventType trigger_event;
+  int subsequent_reads;
+  int THRESHOLD;
+  int local_reduction_delay;
+  LogGP(
+      std::string name,
+      Sys* generator,
+      Tick L,
+      Tick o,
+      Tick g,
+      double G,
+      EventType trigger_event);
+  void process_next_read();
+  void request_read(
+      int bytes,
+      bool processed,
+      bool send_back,
+      Callable* callable);
+  void switch_to_receiver(MemMovRequest mr, Tick offset);
+  void call(EventType event, CallData* data);
+  MemBus* NPU_MEM;
+  void attach_mem_bus(
+      Sys* generator,
+      Tick L,
+      Tick o,
+      Tick g,
+      double G,
+      bool model_shared_bus,
+      int communication_delay);
+  ~LogGP();
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/MemBus.hh
+++ b/astra-sim/system/MemBus.hh
@@ -6,37 +6,56 @@ LICENSE file in the root directory of this source tree.
 #ifndef __MEMBUS_HH__
 #define __MEMBUS_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "Common.hh"
+#include <tuple>
+#include <vector>
 #include "Callable.hh"
+#include "Common.hh"
 
-namespace AstraSim{
-    class Sys;
-    class LogGP;
-    class MemBus{
-    public:
-        enum class Transmition{Fast,Usual};
-        LogGP *NPU_side;
-        LogGP *MA_side;
-        Sys *generator;
-        int communication_delay;
-        bool model_shared_bus;
-        ~MemBus();
-        MemBus(std::string side1,std::string side2,Sys *generator,Tick L,Tick o,Tick g,double G,bool model_shared_bus,int communication_delay,bool attach);
-        void send_from_NPU_to_MA(Transmition transmition,int bytes,bool processed,bool send_back,Callable *callable);
-        void send_from_MA_to_NPU(Transmition transmition,int bytes,bool processed,bool send_back,Callable *callable);
-    };
-}
+namespace AstraSim {
+class Sys;
+class LogGP;
+class MemBus {
+ public:
+  enum class Transmition { Fast, Usual };
+  LogGP* NPU_side;
+  LogGP* MA_side;
+  Sys* generator;
+  int communication_delay;
+  bool model_shared_bus;
+  ~MemBus();
+  MemBus(
+      std::string side1,
+      std::string side2,
+      Sys* generator,
+      Tick L,
+      Tick o,
+      Tick g,
+      double G,
+      bool model_shared_bus,
+      int communication_delay,
+      bool attach);
+  void send_from_NPU_to_MA(
+      Transmition transmition,
+      int bytes,
+      bool processed,
+      bool send_back,
+      Callable* callable);
+  void send_from_MA_to_NPU(
+      Transmition transmition,
+      int bytes,
+      bool processed,
+      bool send_back,
+      Callable* callable);
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/MemMovRequest.hh
+++ b/astra-sim/system/MemMovRequest.hh
@@ -6,54 +6,61 @@ LICENSE file in the root directory of this source tree.
 #ifndef __MEMMOVREQUEST_HH__
 #define __MEMMOVREQUEST_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "Common.hh"
+#include <tuple>
+#include <vector>
 #include "Callable.hh"
+#include "Common.hh"
 #include "SharedBusStat.hh"
 
-namespace AstraSim{
-    class Sys;
-    class LogGP;
-    class MemMovRequest:public Callable,public SharedBusStat{
-    public:
-        static int id;
-        int my_id;
-        int size;
-        int latency;
-        Callable *callable;
-        bool processed;
-        bool send_back;
-        bool mem_bus_finished;
-        Sys *generator;
-        EventType callEvent=EventType::General;
-        LogGP *loggp;
-        std::list<MemMovRequest>::iterator pointer;
-        void call(EventType event,CallData *data);
+namespace AstraSim {
+class Sys;
+class LogGP;
+class MemMovRequest : public Callable, public SharedBusStat {
+ public:
+  static int id;
+  int my_id;
+  int size;
+  int latency;
+  Callable* callable;
+  bool processed;
+  bool send_back;
+  bool mem_bus_finished;
+  Sys* generator;
+  EventType callEvent = EventType::General;
+  LogGP* loggp;
+  std::list<MemMovRequest>::iterator pointer;
+  void call(EventType event, CallData* data);
 
-        Tick total_transfer_queue_time;
-        Tick total_transfer_time;
-        Tick total_processing_queue_time;
-        Tick total_processing_time;
-        Tick start_time;
-        int request_num;
-        MemMovRequest(int request_num,Sys *generator,LogGP *loggp,int size,int latency,Callable *callable,bool processed,bool send_back);
-        void wait_wait_for_mem_bus(std::list<MemMovRequest>::iterator pointer);
-        void set_iterator(std::list<MemMovRequest>::iterator pointer){
-            this->pointer=pointer;
-        }
-        //~MemMovRequest()= default;
-    };
-}
+  Tick total_transfer_queue_time;
+  Tick total_transfer_time;
+  Tick total_processing_queue_time;
+  Tick total_processing_time;
+  Tick start_time;
+  int request_num;
+  MemMovRequest(
+      int request_num,
+      Sys* generator,
+      LogGP* loggp,
+      int size,
+      int latency,
+      Callable* callable,
+      bool processed,
+      bool send_back);
+  void wait_wait_for_mem_bus(std::list<MemMovRequest>::iterator pointer);
+  void set_iterator(std::list<MemMovRequest>::iterator pointer) {
+    this->pointer = pointer;
+  }
+  //~MemMovRequest()= default;
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/MyPacket.hh
+++ b/astra-sim/system/MyPacket.hh
@@ -6,42 +6,40 @@ LICENSE file in the root directory of this source tree.
 #ifndef __MYPACKET_HH__
 #define __MYPACKET_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "Common.hh"
+#include <tuple>
+#include <vector>
 #include "Callable.hh"
+#include "Common.hh"
 
-namespace AstraSim{
-    class MyPacket:public Callable
-    {
-    public:
-        int cycles_needed;
-        //FIFOMovement *fMovement;
-        //FIFO* dest;
-        int fm_id;
-        int stream_num;
-        Callable *notifier;
-        Callable *sender;
-        int preferred_vnet;
-        int preferred_dest;
-        int preferred_src;
-        Tick ready_time;
-        //MyPacket(int cycles_needed, FIFOMovement *fMovement, FIFO *dest);
-        MyPacket(int preferred_vnet,int preferred_src ,int preferred_dest);
-        void set_notifier(Callable* c);
-        void call(EventType event,CallData *data);
-        //~MyPacket()= default;
-    };
-}
+namespace AstraSim {
+class MyPacket : public Callable {
+ public:
+  int cycles_needed;
+  // FIFOMovement *fMovement;
+  // FIFO* dest;
+  int fm_id;
+  int stream_num;
+  Callable* notifier;
+  Callable* sender;
+  int preferred_vnet;
+  int preferred_dest;
+  int preferred_src;
+  Tick ready_time;
+  // MyPacket(int cycles_needed, FIFOMovement *fMovement, FIFO *dest);
+  MyPacket(int preferred_vnet, int preferred_src, int preferred_dest);
+  void set_notifier(Callable* c);
+  void call(EventType event, CallData* data);
+  //~MyPacket()= default;
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/NetworkStat.hh
+++ b/astra-sim/system/NetworkStat.hh
@@ -6,48 +6,48 @@ LICENSE file in the root directory of this source tree.
 #ifndef __NETWORKSTAT_HH__
 #define __NETWORKSTAT_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
+#include <tuple>
+#include <vector>
 #include "Common.hh"
 
-namespace AstraSim{
-class NetworkStat{
-public:
-    std::list<double> net_message_latency;
-    int net_message_counter;
-    NetworkStat(){
-        net_message_counter=0;
+namespace AstraSim {
+class NetworkStat {
+ public:
+  std::list<double> net_message_latency;
+  int net_message_counter;
+  NetworkStat() {
+    net_message_counter = 0;
+  }
+  void update_network_stat(NetworkStat* networkStat) {
+    if (net_message_latency.size() < networkStat->net_message_latency.size()) {
+      int dif =
+          networkStat->net_message_latency.size() - net_message_latency.size();
+      for (int i = 0; i < dif; i++) {
+        net_message_latency.push_back(0);
+      }
     }
-    void update_network_stat(NetworkStat *networkStat){
-        if(net_message_latency.size()<networkStat->net_message_latency.size()){
-            int dif=networkStat->net_message_latency.size()-net_message_latency.size();
-            for(int i=0;i<dif;i++){
-                net_message_latency.push_back(0);
-            }
-        }
-        std::list<double>::iterator it=net_message_latency.begin();
-        for(auto &ml:networkStat->net_message_latency){
-            (*it)+=ml;
-            std::advance(it,1);
-        }
-        net_message_counter++;
+    std::list<double>::iterator it = net_message_latency.begin();
+    for (auto& ml : networkStat->net_message_latency) {
+      (*it) += ml;
+      std::advance(it, 1);
     }
-    void take_network_stat_average(){
-        for(auto &ml:net_message_latency){
-            ml/=net_message_counter;
-        }
+    net_message_counter++;
+  }
+  void take_network_stat_average() {
+    for (auto& ml : net_message_latency) {
+      ml /= net_message_counter;
     }
+  }
 };
-}
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/PacketBundle.hh
+++ b/astra-sim/system/PacketBundle.hh
@@ -6,44 +6,56 @@ LICENSE file in the root directory of this source tree.
 #ifndef __PACKETBUNDLE_HH__
 #define __PACKETBUNDLE_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "Common.hh"
-#include "Callable.hh"
-#include "MyPacket.hh"
+#include <tuple>
+#include <vector>
 #include "BaseStream.hh"
+#include "Callable.hh"
+#include "Common.hh"
 #include "MemBus.hh"
+#include "MyPacket.hh"
 
-namespace AstraSim{
-    class Sys;
-    class PacketBundle:public Callable{
-    public:
-        std::list<MyPacket*> locked_packets;
-        bool processed;
-        bool send_back;
-        int size;
-        Sys *generator;
-        BaseStream *stream;
-        Tick creation_time;
-        MemBus::Transmition transmition;
-        PacketBundle(Sys *generator,BaseStream *stream,std::list<MyPacket*> locked_packets, bool processed, bool send_back, int size,MemBus::Transmition transmition);
-        PacketBundle(Sys *generator,BaseStream *stream, bool processed, bool send_back, int size,MemBus::Transmition transmition);
-        void send_to_MA();
-        void send_to_NPU();
-        Tick delay;
-        void call(EventType event,CallData *data);
-        //~PacketBundle()= default;
-    };
-}
+namespace AstraSim {
+class Sys;
+class PacketBundle : public Callable {
+ public:
+  std::list<MyPacket*> locked_packets;
+  bool processed;
+  bool send_back;
+  int size;
+  Sys* generator;
+  BaseStream* stream;
+  Tick creation_time;
+  MemBus::Transmition transmition;
+  PacketBundle(
+      Sys* generator,
+      BaseStream* stream,
+      std::list<MyPacket*> locked_packets,
+      bool processed,
+      bool send_back,
+      int size,
+      MemBus::Transmition transmition);
+  PacketBundle(
+      Sys* generator,
+      BaseStream* stream,
+      bool processed,
+      bool send_back,
+      int size,
+      MemBus::Transmition transmition);
+  void send_to_MA();
+  void send_to_NPU();
+  Tick delay;
+  void call(EventType event, CallData* data);
+  //~PacketBundle()= default;
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/QueueLevelHandler.hh
+++ b/astra-sim/system/QueueLevelHandler.hh
@@ -6,33 +6,32 @@ LICENSE file in the root directory of this source tree.
 #ifndef __QUEUELEVELHANDLER_HH__
 #define __QUEUELEVELHANDLER_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
+#include <tuple>
+#include <vector>
 #include "astra-sim/system/topology/RingTopology.hh"
 
-namespace AstraSim{
-    class QueueLevelHandler{
-    public:
-        std::vector<int> queues;
-        int allocator;
-        int first_allocator;
-        int last_allocator;
-        int level;
-        QueueLevelHandler(int level,int start,int end);
-        std::pair<int,RingTopology::Direction> get_next_queue_id();
-        std::pair<int,RingTopology::Direction> get_next_queue_id_first();
-        std::pair<int,RingTopology::Direction> get_next_queue_id_last();
-    };
-}
+namespace AstraSim {
+class QueueLevelHandler {
+ public:
+  std::vector<int> queues;
+  int allocator;
+  int first_allocator;
+  int last_allocator;
+  int level;
+  QueueLevelHandler(int level, int start, int end);
+  std::pair<int, RingTopology::Direction> get_next_queue_id();
+  std::pair<int, RingTopology::Direction> get_next_queue_id_first();
+  std::pair<int, RingTopology::Direction> get_next_queue_id_last();
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/QueueLevels.hh
+++ b/astra-sim/system/QueueLevels.hh
@@ -6,31 +6,32 @@ LICENSE file in the root directory of this source tree.
 #ifndef __QUEUELEVELS_HH__
 #define __QUEUELEVELS_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
+#include <tuple>
+#include <vector>
 #include "QueueLevelHandler.hh"
 #include "astra-sim/system/topology/RingTopology.hh"
 
-namespace AstraSim{
-    class QueueLevels{
-    public:
-        std::vector<QueueLevelHandler> levels;
-        std::pair<int,RingTopology::Direction> get_next_queue_at_level(int level);
-        std::pair<int,RingTopology::Direction> get_next_queue_at_level_first(int level);
-        std::pair<int,RingTopology::Direction> get_next_queue_at_level_last(int level);
-        QueueLevels(int levels, int queues_per_level,int offset);
-        QueueLevels(std::vector<int> lv,int offset);
-    };
-}
+namespace AstraSim {
+class QueueLevels {
+ public:
+  std::vector<QueueLevelHandler> levels;
+  std::pair<int, RingTopology::Direction> get_next_queue_at_level(int level);
+  std::pair<int, RingTopology::Direction> get_next_queue_at_level_first(
+      int level);
+  std::pair<int, RingTopology::Direction> get_next_queue_at_level_last(
+      int level);
+  QueueLevels(int levels, int queues_per_level, int offset);
+  QueueLevels(std::vector<int> lv, int offset);
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/RecvPacketEventHadndlerData.hh
+++ b/astra-sim/system/RecvPacketEventHadndlerData.hh
@@ -6,31 +6,36 @@ LICENSE file in the root directory of this source tree.
 #ifndef __RECVPACKETEVENTHADNDLERDATA_HH__
 #define __RECVPACKETEVENTHADNDLERDATA_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "BasicEventHandlerData.hh"
+#include <tuple>
+#include <vector>
 #include "BaseStream.hh"
+#include "BasicEventHandlerData.hh"
 
-namespace AstraSim{
-    class RecvPacketEventHadndlerData:public BasicEventHandlerData,public MetaData{
-    public:
-        BaseStream *owner;
-        int vnet;
-        int stream_num;
-        bool message_end;
-        Tick ready_time;
-        RecvPacketEventHadndlerData(BaseStream *owner,int nodeId, EventType event,int vnet,int stream_num);
-    };
-}
+namespace AstraSim {
+class RecvPacketEventHadndlerData : public BasicEventHandlerData,
+                                    public MetaData {
+ public:
+  BaseStream* owner;
+  int vnet;
+  int stream_num;
+  bool message_end;
+  Tick ready_time;
+  RecvPacketEventHadndlerData(
+      BaseStream* owner,
+      int nodeId,
+      EventType event,
+      int vnet,
+      int stream_num);
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/RendezvousRecvData.hh
+++ b/astra-sim/system/RendezvousRecvData.hh
@@ -6,30 +6,38 @@ LICENSE file in the root directory of this source tree.
 #ifndef __RENDEZVOUSRECVDATA_HH__
 #define __RENDEZVOUSRECVDATA_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
+#include <tuple>
+#include <vector>
+#include "BasicEventHandlerData.hh"
 #include "Common.hh"
 #include "SimRecvCaller.hh"
-#include "BasicEventHandlerData.hh"
 
-namespace AstraSim{
-    class Sys;
-    class RendezvousRecvData:public BasicEventHandlerData,public MetaData{
-    public:
-        SimRecvCaller *recv;
-        RendezvousRecvData(int nodeId,Sys* generator,void *buffer, int count, int type, int src,
-                           int tag, sim_request request, void (*msg_handler)(void *fun_arg), void* fun_arg);
-    };
-}
+namespace AstraSim {
+class Sys;
+class RendezvousRecvData : public BasicEventHandlerData, public MetaData {
+ public:
+  SimRecvCaller* recv;
+  RendezvousRecvData(
+      int nodeId,
+      Sys* generator,
+      void* buffer,
+      int count,
+      int type,
+      int src,
+      int tag,
+      sim_request request,
+      void (*msg_handler)(void* fun_arg),
+      void* fun_arg);
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/RendezvousSendData.hh
+++ b/astra-sim/system/RendezvousSendData.hh
@@ -6,30 +6,38 @@ LICENSE file in the root directory of this source tree.
 #ifndef __RENDEZVOUSSENDDATA_HH__
 #define __RENDEZVOUSSENDDATA_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "Common.hh"
+#include <tuple>
+#include <vector>
 #include "BasicEventHandlerData.hh"
+#include "Common.hh"
 #include "SimSendCaller.hh"
 
-namespace AstraSim{
-    class Sys;
-    class RendezvousSendData:public BasicEventHandlerData,public MetaData{
-    public:
-        SimSendCaller *send;
-        RendezvousSendData(int nodeId,Sys* generator,void *buffer, int count, int type, int dst,
-                           int tag, sim_request request, void (*msg_handler)(void *fun_arg), void* fun_arg);
-    };
-}
+namespace AstraSim {
+class Sys;
+class RendezvousSendData : public BasicEventHandlerData, public MetaData {
+ public:
+  SimSendCaller* send;
+  RendezvousSendData(
+      int nodeId,
+      Sys* generator,
+      void* buffer,
+      int count,
+      int type,
+      int dst,
+      int tag,
+      sim_request request,
+      void (*msg_handler)(void* fun_arg),
+      void* fun_arg);
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/SharedBusStat.hh
+++ b/astra-sim/system/SharedBusStat.hh
@@ -6,129 +6,162 @@ LICENSE file in the root directory of this source tree.
 #ifndef __SHAREDBUSSTAT_HH__
 #define __SHAREDBUSSTAT_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
+#include <tuple>
+#include <vector>
 #include "CallData.hh"
 
-namespace AstraSim{
-class SharedBusStat:public CallData{
-public:
-    double total_shared_bus_transfer_queue_delay;
-    double total_shared_bus_transfer_delay;
-    double total_shared_bus_processing_queue_delay;
-    double total_shared_bus_processing_delay;
+namespace AstraSim {
+class SharedBusStat : public CallData {
+ public:
+  double total_shared_bus_transfer_queue_delay;
+  double total_shared_bus_transfer_delay;
+  double total_shared_bus_processing_queue_delay;
+  double total_shared_bus_processing_delay;
 
-    double total_mem_bus_transfer_queue_delay;
-    double total_mem_bus_transfer_delay;
-    double total_mem_bus_processing_queue_delay;
-    double total_mem_bus_processing_delay;
-    int mem_request_counter;
-    int shared_request_counter;
-    SharedBusStat(BusType busType,double total_bus_transfer_queue_delay,double total_bus_transfer_delay,
-                  double total_bus_processing_queue_delay,double total_bus_processing_delay){
-        if(busType==BusType::Shared){
-            this->total_shared_bus_transfer_queue_delay=total_bus_transfer_queue_delay;
-            this->total_shared_bus_transfer_delay=total_bus_transfer_delay;
-            this->total_shared_bus_processing_queue_delay=total_bus_processing_queue_delay;
-            this->total_shared_bus_processing_delay=total_bus_processing_delay;
+  double total_mem_bus_transfer_queue_delay;
+  double total_mem_bus_transfer_delay;
+  double total_mem_bus_processing_queue_delay;
+  double total_mem_bus_processing_delay;
+  int mem_request_counter;
+  int shared_request_counter;
+  SharedBusStat(
+      BusType busType,
+      double total_bus_transfer_queue_delay,
+      double total_bus_transfer_delay,
+      double total_bus_processing_queue_delay,
+      double total_bus_processing_delay) {
+    if (busType == BusType::Shared) {
+      this->total_shared_bus_transfer_queue_delay =
+          total_bus_transfer_queue_delay;
+      this->total_shared_bus_transfer_delay = total_bus_transfer_delay;
+      this->total_shared_bus_processing_queue_delay =
+          total_bus_processing_queue_delay;
+      this->total_shared_bus_processing_delay = total_bus_processing_delay;
 
-            this->total_mem_bus_transfer_queue_delay=0;
-            this->total_mem_bus_transfer_delay=0;
-            this->total_mem_bus_processing_queue_delay=0;
-            this->total_mem_bus_processing_delay=0;
-        }
-        else{
-            this->total_shared_bus_transfer_queue_delay=0;
-            this->total_shared_bus_transfer_delay=0;
-            this->total_shared_bus_processing_queue_delay=0;
-            this->total_shared_bus_processing_delay=0;
+      this->total_mem_bus_transfer_queue_delay = 0;
+      this->total_mem_bus_transfer_delay = 0;
+      this->total_mem_bus_processing_queue_delay = 0;
+      this->total_mem_bus_processing_delay = 0;
+    } else {
+      this->total_shared_bus_transfer_queue_delay = 0;
+      this->total_shared_bus_transfer_delay = 0;
+      this->total_shared_bus_processing_queue_delay = 0;
+      this->total_shared_bus_processing_delay = 0;
 
-            this->total_mem_bus_transfer_queue_delay=total_bus_transfer_queue_delay;
-            this->total_mem_bus_transfer_delay=total_bus_transfer_delay;
-            this->total_mem_bus_processing_queue_delay=total_bus_processing_queue_delay;
-            this->total_mem_bus_processing_delay=total_bus_processing_delay;
-        }
-        shared_request_counter=0;
-        mem_request_counter=0;
+      this->total_mem_bus_transfer_queue_delay = total_bus_transfer_queue_delay;
+      this->total_mem_bus_transfer_delay = total_bus_transfer_delay;
+      this->total_mem_bus_processing_queue_delay =
+          total_bus_processing_queue_delay;
+      this->total_mem_bus_processing_delay = total_bus_processing_delay;
     }
-    void update_bus_stats(BusType busType,SharedBusStat *sharedBusStat){
-        if(busType==BusType::Shared){
-            total_shared_bus_transfer_queue_delay+=sharedBusStat->total_shared_bus_transfer_queue_delay;
-            total_shared_bus_transfer_delay+=sharedBusStat->total_shared_bus_transfer_delay;
-            total_shared_bus_processing_queue_delay+=sharedBusStat->total_shared_bus_processing_queue_delay;
-            total_shared_bus_processing_delay+=sharedBusStat->total_shared_bus_processing_delay;
-            shared_request_counter++;
-        }
-        else if(busType==BusType::Mem){
-            total_mem_bus_transfer_queue_delay+=sharedBusStat->total_mem_bus_transfer_queue_delay;
-            total_mem_bus_transfer_delay+=sharedBusStat->total_mem_bus_transfer_delay;
-            total_mem_bus_processing_queue_delay+=sharedBusStat->total_mem_bus_processing_queue_delay;
-            total_mem_bus_processing_delay+=sharedBusStat->total_mem_bus_processing_delay;
-            mem_request_counter++;
-        }
-        else{
-            total_shared_bus_transfer_queue_delay+=sharedBusStat->total_shared_bus_transfer_queue_delay;
-            total_shared_bus_transfer_delay+=sharedBusStat->total_shared_bus_transfer_delay;
-            total_shared_bus_processing_queue_delay+=sharedBusStat->total_shared_bus_processing_queue_delay;
-            total_shared_bus_processing_delay+=sharedBusStat->total_shared_bus_processing_delay;
-            total_mem_bus_transfer_queue_delay+=sharedBusStat->total_mem_bus_transfer_queue_delay;
-            total_mem_bus_transfer_delay+=sharedBusStat->total_mem_bus_transfer_delay;
-            total_mem_bus_processing_queue_delay+=sharedBusStat->total_mem_bus_processing_queue_delay;
-            total_mem_bus_processing_delay+=sharedBusStat->total_mem_bus_processing_delay;
-            shared_request_counter++;
-            mem_request_counter++;
-        }
+    shared_request_counter = 0;
+    mem_request_counter = 0;
+  }
+  void update_bus_stats(BusType busType, SharedBusStat* sharedBusStat) {
+    if (busType == BusType::Shared) {
+      total_shared_bus_transfer_queue_delay +=
+          sharedBusStat->total_shared_bus_transfer_queue_delay;
+      total_shared_bus_transfer_delay +=
+          sharedBusStat->total_shared_bus_transfer_delay;
+      total_shared_bus_processing_queue_delay +=
+          sharedBusStat->total_shared_bus_processing_queue_delay;
+      total_shared_bus_processing_delay +=
+          sharedBusStat->total_shared_bus_processing_delay;
+      shared_request_counter++;
+    } else if (busType == BusType::Mem) {
+      total_mem_bus_transfer_queue_delay +=
+          sharedBusStat->total_mem_bus_transfer_queue_delay;
+      total_mem_bus_transfer_delay +=
+          sharedBusStat->total_mem_bus_transfer_delay;
+      total_mem_bus_processing_queue_delay +=
+          sharedBusStat->total_mem_bus_processing_queue_delay;
+      total_mem_bus_processing_delay +=
+          sharedBusStat->total_mem_bus_processing_delay;
+      mem_request_counter++;
+    } else {
+      total_shared_bus_transfer_queue_delay +=
+          sharedBusStat->total_shared_bus_transfer_queue_delay;
+      total_shared_bus_transfer_delay +=
+          sharedBusStat->total_shared_bus_transfer_delay;
+      total_shared_bus_processing_queue_delay +=
+          sharedBusStat->total_shared_bus_processing_queue_delay;
+      total_shared_bus_processing_delay +=
+          sharedBusStat->total_shared_bus_processing_delay;
+      total_mem_bus_transfer_queue_delay +=
+          sharedBusStat->total_mem_bus_transfer_queue_delay;
+      total_mem_bus_transfer_delay +=
+          sharedBusStat->total_mem_bus_transfer_delay;
+      total_mem_bus_processing_queue_delay +=
+          sharedBusStat->total_mem_bus_processing_queue_delay;
+      total_mem_bus_processing_delay +=
+          sharedBusStat->total_mem_bus_processing_delay;
+      shared_request_counter++;
+      mem_request_counter++;
     }
-    void update_bus_stats(BusType busType,SharedBusStat sharedBusStat){
-        if(busType==BusType::Shared){
-            total_shared_bus_transfer_queue_delay+=sharedBusStat.total_shared_bus_transfer_queue_delay;
-            total_shared_bus_transfer_delay+=sharedBusStat.total_shared_bus_transfer_delay;
-            total_shared_bus_processing_queue_delay+=sharedBusStat.total_shared_bus_processing_queue_delay;
-            total_shared_bus_processing_delay+=sharedBusStat.total_shared_bus_processing_delay;
-            shared_request_counter++;
-        }
-        else if(busType==BusType::Mem){
-            total_mem_bus_transfer_queue_delay+=sharedBusStat.total_mem_bus_transfer_queue_delay;
-            total_mem_bus_transfer_delay+=sharedBusStat.total_mem_bus_transfer_delay;
-            total_mem_bus_processing_queue_delay+=sharedBusStat.total_mem_bus_processing_queue_delay;
-            total_mem_bus_processing_delay+=sharedBusStat.total_mem_bus_processing_delay;
-            mem_request_counter++;
-        }
-        else{
-            total_shared_bus_transfer_queue_delay+=sharedBusStat.total_shared_bus_transfer_queue_delay;
-            total_shared_bus_transfer_delay+=sharedBusStat.total_shared_bus_transfer_delay;
-            total_shared_bus_processing_queue_delay+=sharedBusStat.total_shared_bus_processing_queue_delay;
-            total_shared_bus_processing_delay+=sharedBusStat.total_shared_bus_processing_delay;
-            total_mem_bus_transfer_queue_delay+=sharedBusStat.total_mem_bus_transfer_queue_delay;
-            total_mem_bus_transfer_delay+=sharedBusStat.total_mem_bus_transfer_delay;
-            total_mem_bus_processing_queue_delay+=sharedBusStat.total_mem_bus_processing_queue_delay;
-            total_mem_bus_processing_delay+=sharedBusStat.total_mem_bus_processing_delay;
-            shared_request_counter++;
-            mem_request_counter++;
-        }
+  }
+  void update_bus_stats(BusType busType, SharedBusStat sharedBusStat) {
+    if (busType == BusType::Shared) {
+      total_shared_bus_transfer_queue_delay +=
+          sharedBusStat.total_shared_bus_transfer_queue_delay;
+      total_shared_bus_transfer_delay +=
+          sharedBusStat.total_shared_bus_transfer_delay;
+      total_shared_bus_processing_queue_delay +=
+          sharedBusStat.total_shared_bus_processing_queue_delay;
+      total_shared_bus_processing_delay +=
+          sharedBusStat.total_shared_bus_processing_delay;
+      shared_request_counter++;
+    } else if (busType == BusType::Mem) {
+      total_mem_bus_transfer_queue_delay +=
+          sharedBusStat.total_mem_bus_transfer_queue_delay;
+      total_mem_bus_transfer_delay +=
+          sharedBusStat.total_mem_bus_transfer_delay;
+      total_mem_bus_processing_queue_delay +=
+          sharedBusStat.total_mem_bus_processing_queue_delay;
+      total_mem_bus_processing_delay +=
+          sharedBusStat.total_mem_bus_processing_delay;
+      mem_request_counter++;
+    } else {
+      total_shared_bus_transfer_queue_delay +=
+          sharedBusStat.total_shared_bus_transfer_queue_delay;
+      total_shared_bus_transfer_delay +=
+          sharedBusStat.total_shared_bus_transfer_delay;
+      total_shared_bus_processing_queue_delay +=
+          sharedBusStat.total_shared_bus_processing_queue_delay;
+      total_shared_bus_processing_delay +=
+          sharedBusStat.total_shared_bus_processing_delay;
+      total_mem_bus_transfer_queue_delay +=
+          sharedBusStat.total_mem_bus_transfer_queue_delay;
+      total_mem_bus_transfer_delay +=
+          sharedBusStat.total_mem_bus_transfer_delay;
+      total_mem_bus_processing_queue_delay +=
+          sharedBusStat.total_mem_bus_processing_queue_delay;
+      total_mem_bus_processing_delay +=
+          sharedBusStat.total_mem_bus_processing_delay;
+      shared_request_counter++;
+      mem_request_counter++;
     }
-    void take_bus_stats_average(){
-        total_shared_bus_transfer_queue_delay/=shared_request_counter;
-        total_shared_bus_transfer_delay/=shared_request_counter;
-        total_shared_bus_processing_queue_delay/=shared_request_counter;
-        total_shared_bus_processing_delay/=shared_request_counter;
+  }
+  void take_bus_stats_average() {
+    total_shared_bus_transfer_queue_delay /= shared_request_counter;
+    total_shared_bus_transfer_delay /= shared_request_counter;
+    total_shared_bus_processing_queue_delay /= shared_request_counter;
+    total_shared_bus_processing_delay /= shared_request_counter;
 
-        total_mem_bus_transfer_queue_delay/=mem_request_counter;
-        total_mem_bus_transfer_delay/=mem_request_counter;
-        total_mem_bus_processing_queue_delay/=mem_request_counter;
-        total_mem_bus_processing_delay/=mem_request_counter;
-    }
+    total_mem_bus_transfer_queue_delay /= mem_request_counter;
+    total_mem_bus_transfer_delay /= mem_request_counter;
+    total_mem_bus_processing_queue_delay /= mem_request_counter;
+    total_mem_bus_processing_delay /= mem_request_counter;
+  }
 };
-}
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/SimRecvCaller.hh
+++ b/astra-sim/system/SimRecvCaller.hh
@@ -6,38 +6,46 @@ LICENSE file in the root directory of this source tree.
 #ifndef __SIMRECVCALLER_HH__
 #define __SIMRECVCALLER_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "Common.hh"
+#include <tuple>
+#include <vector>
 #include "CallData.hh"
 #include "Callable.hh"
+#include "Common.hh"
 
-namespace AstraSim{
-    class Sys;
-    class SimRecvCaller:public Callable{
-    public:
-        void *buffer;
-        int count;
-        int type;
-        int src;
-        int tag;
-        sim_request request;
-        void (*msg_handler)(void *fun_arg);
-        void* fun_arg;
-        void call(EventType type,CallData *data);
-        Sys* generator;
-        SimRecvCaller(Sys* generator,void *buffer, int count, int type, int src, int tag, sim_request request, void (*msg_handler)(void *fun_arg), void* fun_arg);
-    };
-}
+namespace AstraSim {
+class Sys;
+class SimRecvCaller : public Callable {
+ public:
+  void* buffer;
+  int count;
+  int type;
+  int src;
+  int tag;
+  sim_request request;
+  void (*msg_handler)(void* fun_arg);
+  void* fun_arg;
+  void call(EventType type, CallData* data);
+  Sys* generator;
+  SimRecvCaller(
+      Sys* generator,
+      void* buffer,
+      int count,
+      int type,
+      int src,
+      int tag,
+      sim_request request,
+      void (*msg_handler)(void* fun_arg),
+      void* fun_arg);
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/SimSendCaller.hh
+++ b/astra-sim/system/SimSendCaller.hh
@@ -6,38 +6,46 @@ LICENSE file in the root directory of this source tree.
 #ifndef __SIMSENDCALLER_HH__
 #define __SIMSENDCALLER_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "Common.hh"
+#include <tuple>
+#include <vector>
 #include "CallData.hh"
 #include "Callable.hh"
+#include "Common.hh"
 
-namespace AstraSim{
-    class Sys;
-    class SimSendCaller:public Callable{
-    public:
-        void *buffer;
-        int count;
-        int type;
-        int dst;
-        int tag;
-        sim_request request;
-        void (*msg_handler)(void *fun_arg);
-        void* fun_arg;
-        void call(EventType type,CallData *data);
-        Sys* generator;
-        SimSendCaller(Sys* generator,void *buffer, int count, int type, int dst, int tag, sim_request request, void (*msg_handler)(void *fun_arg), void* fun_arg);
-    };
-}
+namespace AstraSim {
+class Sys;
+class SimSendCaller : public Callable {
+ public:
+  void* buffer;
+  int count;
+  int type;
+  int dst;
+  int tag;
+  sim_request request;
+  void (*msg_handler)(void* fun_arg);
+  void* fun_arg;
+  void call(EventType type, CallData* data);
+  Sys* generator;
+  SimSendCaller(
+      Sys* generator,
+      void* buffer,
+      int count,
+      int type,
+      int dst,
+      int tag,
+      sim_request request,
+      void (*msg_handler)(void* fun_arg),
+      void* fun_arg);
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/StatData.hh
+++ b/astra-sim/system/StatData.hh
@@ -6,33 +6,32 @@ LICENSE file in the root directory of this source tree.
 #ifndef __STATDATA_HH__
 #define __STATDATA_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "Common.hh"
+#include <tuple>
+#include <vector>
 #include "CallData.hh"
-namespace AstraSim{
-    class StatData:public CallData{
-    public:
-        Tick start;
-        Tick waiting;
-        Tick end;
-        //~StatData()= default;
-        StatData(){
-            start=0;
-            waiting=0;
-            end=0;
-        }
-    };
-}
+#include "Common.hh"
+namespace AstraSim {
+class StatData : public CallData {
+ public:
+  Tick start;
+  Tick waiting;
+  Tick end;
+  //~StatData()= default;
+  StatData() {
+    start = 0;
+    waiting = 0;
+    end = 0;
+  }
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/StreamBaseline.hh
+++ b/astra-sim/system/StreamBaseline.hh
@@ -6,34 +6,37 @@ LICENSE file in the root directory of this source tree.
 #ifndef __STREAMBASELINE_HH__
 #define __STREAMBASELINE_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "Common.hh"
+#include <tuple>
+#include <vector>
 #include "BaseStream.hh"
 #include "CollectivePhase.hh"
+#include "Common.hh"
 #include "RecvPacketEventHadndlerData.hh"
 
-namespace AstraSim{
-    class Sys;
-    class StreamBaseline: public BaseStream
-    {
-    public:
-        StreamBaseline(Sys *owner,DataSet *dataset,int stream_num,std::list<CollectivePhase> phases_to_go,int priority);
-        void init();
-        void call(EventType event,CallData *data);
-        void consume(RecvPacketEventHadndlerData *message);
-        //~StreamBaseline()= default;
-    };
-}
+namespace AstraSim {
+class Sys;
+class StreamBaseline : public BaseStream {
+ public:
+  StreamBaseline(
+      Sys* owner,
+      DataSet* dataset,
+      int stream_num,
+      std::list<CollectivePhase> phases_to_go,
+      int priority);
+  void init();
+  void call(EventType event, CallData* data);
+  void consume(RecvPacketEventHadndlerData* message);
+  //~StreamBaseline()= default;
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/StreamStat.hh
+++ b/astra-sim/system/StreamStat.hh
@@ -6,55 +6,54 @@ LICENSE file in the root directory of this source tree.
 #ifndef __STREAMSTAT_HH__
 #define __STREAMSTAT_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
+#include <tuple>
+#include <vector>
 #include "Common.hh"
-#include "SharedBusStat.hh"
 #include "NetworkStat.hh"
+#include "SharedBusStat.hh"
 
-namespace AstraSim{
-class StreamStat:public SharedBusStat,public NetworkStat{
-public:
-    std::list<double > queuing_delay;
-    int stream_stat_counter;
-    //~StreamStat()= default;
-    StreamStat():SharedBusStat(BusType::Shared,0,0,0,0){
-        stream_stat_counter=0;
+namespace AstraSim {
+class StreamStat : public SharedBusStat, public NetworkStat {
+ public:
+  std::list<double> queuing_delay;
+  int stream_stat_counter;
+  //~StreamStat()= default;
+  StreamStat() : SharedBusStat(BusType::Shared, 0, 0, 0, 0) {
+    stream_stat_counter = 0;
+  }
+  void update_stream_stats(StreamStat* streamStat) {
+    update_bus_stats(BusType::Both, streamStat);
+    update_network_stat(streamStat);
+    if (queuing_delay.size() < streamStat->queuing_delay.size()) {
+      int dif = streamStat->queuing_delay.size() - queuing_delay.size();
+      for (int i = 0; i < dif; i++) {
+        queuing_delay.push_back(0);
+      }
     }
-    void update_stream_stats(StreamStat *streamStat){
-        update_bus_stats(BusType::Both,streamStat);
-        update_network_stat(streamStat);
-        if(queuing_delay.size()<streamStat->queuing_delay.size()){
-            int dif=streamStat->queuing_delay.size()-queuing_delay.size();
-            for(int i=0;i<dif;i++){
-                queuing_delay.push_back(0);
-            }
-        }
-        std::list<double>::iterator it=queuing_delay.begin();
-        for(auto &tick:streamStat->queuing_delay){
-            (*it)+=tick;
-            std::advance(it,1);
-        }
-        stream_stat_counter++;
+    std::list<double>::iterator it = queuing_delay.begin();
+    for (auto& tick : streamStat->queuing_delay) {
+      (*it) += tick;
+      std::advance(it, 1);
     }
-    void take_stream_stats_average(){
-        take_bus_stats_average();
-        take_network_stat_average();
-        for(auto &tick:queuing_delay){
-            tick/=stream_stat_counter;
-        }
+    stream_stat_counter++;
+  }
+  void take_stream_stats_average() {
+    take_bus_stats_average();
+    take_network_stat_average();
+    for (auto& tick : queuing_delay) {
+      tick /= stream_stat_counter;
     }
+  }
 };
-}
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/Sys.cc
+++ b/astra-sim/system/Sys.cc
@@ -248,11 +248,12 @@ Sys::Sys(
       total_disabled++;
     }
   }
-  std::vector<int> levels{local_queus,
-                          vertical_queues,
-                          horizontal_queues,
-                          perpendicular_queues,
-                          fourth_queues};
+  std::vector<int> levels{
+      local_queus,
+      vertical_queues,
+      horizontal_queues,
+      perpendicular_queues,
+      fourth_queues};
   int total_levels = 0;
   for (auto l : levels) {
     total_levels += l;

--- a/astra-sim/system/Sys.hh
+++ b/astra-sim/system/Sys.hh
@@ -6,195 +6,357 @@ LICENSE file in the root directory of this source tree.
 #ifndef __SYSTEM_HH__
 #define __SYSTEM_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "Common.hh"
-#include "AstraNetworkAPI.hh"
+#include <tuple>
+#include <vector>
 #include "AstraMemoryAPI.hh"
-#include "CollectivePhase.hh"
+#include "AstraNetworkAPI.hh"
 #include "Callable.hh"
+#include "CollectivePhase.hh"
+#include "Common.hh"
 #include "astra-sim/workload/Workload.hh"
 
-namespace AstraSim{
-    class MemBus;
-    class BaseStream;
-    class StreamBaseline;
-    class DataSet;
-    class SimSendCaller;
-    class SimRecvCaller;
-    class QueueLevels;
-    class Workload;
-    class LogicalTopology;
-    class Sys:public Callable
-    {
-    public:
-        class SchedulerUnit{
-            public:
-                Sys *sys;
-                int ready_list_threshold;
-                int queue_threshold;
-                int max_running_streams;
-                std::map<int,int> running_streams;
-                std::map<int,std::list<BaseStream*>::iterator> stream_pointer;
-                SchedulerUnit(Sys *sys,std::vector<int> queues,int max_running_streams,int ready_list_threshold,int queue_threshold);
-                void notify_stream_removed(int vnet);
-                void notify_stream_added(int vnet);
-                void notify_stream_added_into_ready_list();
-        };
-        SchedulerUnit *scheduler_unit;
-        enum class CollectiveOptimization{Baseline,LocalBWAware};
-        enum class CollectiveImplementation{AllToAll,DoubleBinaryTreeLocalAllToAll,LocalRingNodeA2AGlobalDBT,HierarchicalRing,DoubleBinaryTree};
-        ~Sys();
-        AstraNetworkAPI *NI;
-        AstraMemoryAPI *MEM;
-        int finished_workloads;
-        int id;
+namespace AstraSim {
+class MemBus;
+class BaseStream;
+class StreamBaseline;
+class DataSet;
+class SimSendCaller;
+class SimRecvCaller;
+class QueueLevels;
+class Workload;
+class LogicalTopology;
+class Sys : public Callable {
+ public:
+  class SchedulerUnit {
+   public:
+    Sys* sys;
+    int ready_list_threshold;
+    int queue_threshold;
+    int max_running_streams;
+    std::map<int, int> running_streams;
+    std::map<int, std::list<BaseStream*>::iterator> stream_pointer;
+    SchedulerUnit(
+        Sys* sys,
+        std::vector<int> queues,
+        int max_running_streams,
+        int ready_list_threshold,
+        int queue_threshold);
+    void notify_stream_removed(int vnet);
+    void notify_stream_added(int vnet);
+    void notify_stream_added_into_ready_list();
+  };
+  SchedulerUnit* scheduler_unit;
+  enum class CollectiveOptimization { Baseline, LocalBWAware };
+  enum class CollectiveImplementation {
+    AllToAll,
+    DoubleBinaryTreeLocalAllToAll,
+    LocalRingNodeA2AGlobalDBT,
+    HierarchicalRing,
+    DoubleBinaryTree
+  };
+  ~Sys();
+  AstraNetworkAPI* NI;
+  AstraMemoryAPI* MEM;
+  int finished_workloads;
+  int id;
 
-        CollectiveImplementation collectiveImplementation;
-        CollectiveOptimization collectiveOptimization;
+  CollectiveImplementation collectiveImplementation;
+  CollectiveOptimization collectiveOptimization;
 
-        std::chrono::high_resolution_clock::time_point start_sim_time;
-        std::chrono::high_resolution_clock::time_point end_sim_time;
+  std::chrono::high_resolution_clock::time_point start_sim_time;
+  std::chrono::high_resolution_clock::time_point end_sim_time;
 
-        std::list<Callable *> registered_for_finished_stream_event;
+  std::list<Callable*> registered_for_finished_stream_event;
 
-        int local_dim;
-        int vertical_dim;
-        int horizontal_dim;
-        int perpendicular_dim;
-        int fourth_dim;
-        int local_queus;
-        int vertical_queues;
-        int horizontal_queues;int perpendicular_queues;
-        int fourth_queues;
-        int priority_counter;
-        bool boost_mode;
-        bool rendezvous_enabled;
-        bool initialized;
+  int local_dim;
+  int vertical_dim;
+  int horizontal_dim;
+  int perpendicular_dim;
+  int fourth_dim;
+  int local_queus;
+  int vertical_queues;
+  int horizontal_queues;
+  int perpendicular_queues;
+  int fourth_queues;
+  int priority_counter;
+  bool boost_mode;
+  bool rendezvous_enabled;
+  bool initialized;
 
-        int processing_latency;
-        int communication_delay;
+  int processing_latency;
+  int communication_delay;
 
-        int preferred_dataset_splits;
-        PacketRouting alltoall_routing;
-        InjectionPolicy injection_policy;
-        float compute_scale;
-        float comm_scale;
-        float injection_scale;
-        int local_reduction_delay;
-        uint64_t pending_events;
-        std::string method;
+  int preferred_dataset_splits;
+  PacketRouting alltoall_routing;
+  InjectionPolicy injection_policy;
+  float compute_scale;
+  float comm_scale;
+  float injection_scale;
+  int local_reduction_delay;
+  uint64_t pending_events;
+  std::string method;
 
-        //for test
-        Workload *workload;
-        MemBus *memBus;
-        int all_queues;
-        //for supporting LIFO
-        std::list<BaseStream*> ready_list;
-        SchedulingPolicy scheduling_policy;
-        int first_phase_streams;
-        int total_running_streams;
-        std::map<int,std::list<BaseStream*>> active_Streams;
-        std::map<int,std::list<int>> stream_priorities;
+  // for test
+  Workload* workload;
+  MemBus* memBus;
+  int all_queues;
+  // for supporting LIFO
+  std::list<BaseStream*> ready_list;
+  SchedulingPolicy scheduling_policy;
+  int first_phase_streams;
+  int total_running_streams;
+  std::map<int, std::list<BaseStream*>> active_Streams;
+  std::map<int, std::list<int>> stream_priorities;
 
-        QueueLevels *vLevels;
-        std::map<std::string,LogicalTopology*> logical_topologies;
-        std::map<Tick,std::list<std::tuple<Callable*,EventType,CallData *>>> event_queue;
-        static int total_nodes;
-        static Tick offset;
-        static std::vector<Sys*> all_generators;
-        static uint8_t *dummy_data;
-        //for reports
-        uint64_t streams_injected;
-        uint64_t streams_finished;
-        int stream_counter;
-        bool enabled;
+  QueueLevels* vLevels;
+  std::map<std::string, LogicalTopology*> logical_topologies;
+  std::map<Tick, std::list<std::tuple<Callable*, EventType, CallData*>>>
+      event_queue;
+  static int total_nodes;
+  static Tick offset;
+  static std::vector<Sys*> all_generators;
+  static uint8_t* dummy_data;
+  // for reports
+  uint64_t streams_injected;
+  uint64_t streams_finished;
+  int stream_counter;
+  bool enabled;
 
+  std::string inp_scheduling_policy;
+  std::string inp_packet_routing;
+  std::string inp_injection_policy;
+  std::string inp_collective_implementation;
+  std::string inp_collective_optimization;
+  float inp_L;
+  float inp_o;
+  float inp_g;
+  float inp_G;
+  int inp_model_shared_bus;
+  bool model_shared_bus;
+  int inp_boost_mode;
 
-        std::string inp_scheduling_policy;
-        std::string inp_packet_routing;
-        std::string inp_injection_policy;
-        std::string inp_collective_implementation;
-        std::string inp_collective_optimization;
-        float inp_L;
-        float inp_o;
-        float inp_g;
-        float inp_G;
-        int inp_model_shared_bus;
-        bool model_shared_bus;
-        int inp_boost_mode;
+  void register_for_finished_stream(Callable* callable);
+  void increase_finished_streams(int amount);
+  void register_event(
+      Callable* callable,
+      EventType event,
+      CallData* callData,
+      int cycles);
+  void insert_into_ready_list(BaseStream* stream);
+  void ask_for_schedule(int max);
+  void schedule(int num);
 
-        void register_for_finished_stream(Callable *callable);
-        void increase_finished_streams(int amount);
-        void register_event(Callable *callable,EventType event,CallData *callData,int cycles);
-        void insert_into_ready_list(BaseStream *stream);
-        void ask_for_schedule(int max);
-        void schedule(int num);
+  void register_phases(
+      BaseStream* stream,
+      std::list<CollectivePhase> phases_to_go);
+  void call(EventType type, CallData* data);
+  void try_register_event(
+      Callable* callable,
+      EventType event,
+      CallData* callData,
+      Tick& cycles);
+  void call_events();
+  void workload_finished() {
+    finished_workloads++;
+  };
+  static Tick boostedTick();
+  static void exiting();
+  int nextPowerOf2(int n);
+  static void sys_panic(std::string msg);
+  void exitSimLoop(std::string msg);
+  bool seprate_log;
 
+  Sys(AstraNetworkAPI* NI,
+      AstraMemoryAPI* MEM,
+      int id,
+      int num_passes,
+      int local_dim,
+      int vertical_dim,
+      int horizontal_dim,
+      int perpendicular_dim,
+      int fourth_dim,
+      int local_queus,
+      int vertical_queues,
+      int horizontal_queues,
+      int perpendicular_queues,
+      int fourth_queues,
+      std::string my_sys,
+      std::string my_workload,
+      float comm_scale,
+      float compute_scale,
+      float injection_scale,
+      int total_stat_rows,
+      int stat_row,
+      std::string path,
+      std::string run_name,
+      bool seprate_log,
+      bool rendezvous_enabled);
 
-        void register_phases(BaseStream *stream,std::list<CollectivePhase> phases_to_go);
-        void call(EventType type,CallData *data);
-        void try_register_event(Callable *callable,EventType event,CallData *callData,Tick &cycles);
-        void call_events();
-        void workload_finished(){finished_workloads++;};
-        static Tick boostedTick();
-        static void exiting();
-        int nextPowerOf2(int n);
-        static void sys_panic(std::string msg);
-        void exitSimLoop(std::string msg);
-        bool seprate_log;
-
-        Sys(AstraNetworkAPI *NI,AstraMemoryAPI *MEM,int id,int num_passes,int local_dim, int vertical_dim,int horizontal_dim,
-                 int perpendicular_dim,int fourth_dim,int local_queus,int vertical_queues,int horizontal_queues,
-                 int perpendicular_queues,int fourth_queues,std::string my_sys,
-                 std::string my_workload,float comm_scale,float compute_scale,float injection_scale,int total_stat_rows,int stat_row,
-                 std::string path,std::string run_name,bool seprate_log,bool rendezvous_enabled);
-
-        void iterate();
-        bool initialize_sys(std::string name);
-        std::string trim(const std::string& str,const std::string& whitespace);
-        bool parse_var(std::string var,std::string value);
-        bool post_process_inputs();
-        int front_end_sim_send(Tick delay,void *buffer, int count, int type, int dst, int tag, sim_request *request, void (*msg_handler)(void *fun_arg), void* fun_arg);
-        int front_end_sim_recv(Tick delay,void *buffer, int count, int type, int src, int tag, sim_request *request, void (*msg_handler)(void *fun_arg), void* fun_arg);
-        int sim_send(Tick delay,void *buffer, int count, int type, int dst, int tag, sim_request *request, void (*msg_handler)(void *fun_arg), void* fun_arg);
-        int sim_recv(Tick delay,void *buffer, int count, int type, int src, int tag, sim_request *request, void (*msg_handler)(void *fun_arg), void* fun_arg);
-        int rendezvous_sim_send(Tick delay,void *buffer, int count, int type, int dst, int tag, sim_request *request,
-                                void (*msg_handler)(void *fun_arg), void* fun_arg);
-        int rendezvous_sim_recv(Tick delay,void *buffer, int count, int type, int src, int tag, sim_request *request,
-                     void (*msg_handler)(void *fun_arg), void* fun_arg);
-        Tick mem_read(uint64_t bytes);
-        Tick mem_write(uint64_t bytes);
-        static int get_layer_numbers(std::string workload_input);
-        DataSet * generate_all_reduce(int size,bool local, bool vertical, bool horizontal,SchedulingPolicy pref_scheduling,int layer);
-        DataSet * generate_all_to_all(int size,bool local, bool vertical, bool horizontal,SchedulingPolicy pref_scheduling,int layer);
-        DataSet * generate_all_gather(int size,bool local, bool vertical, bool horizontal,SchedulingPolicy pref_scheduling,int layer);
-        DataSet * generate_reduce_scatter(int size,bool local, bool vertical, bool horizontal,SchedulingPolicy pref_scheduling,int layer);
-        DataSet *generate_alltoall_all_to_all(int size,bool local_run, bool horizontal_run,SchedulingPolicy pref_scheduling,int layer);
-        DataSet *generate_alltoall_all_reduce(int size,bool local_run, bool horizontal_run,SchedulingPolicy pref_scheduling,int layer);
-        DataSet *generate_tree_all_reduce(int size,bool local_run, bool horizontal_run,SchedulingPolicy pref_scheduling,int layer);
-        DataSet *generate_hierarchical_all_to_all(int size,bool local_run,bool vertical_run, bool horizontal_run, SchedulingPolicy pref_scheduling,int layer);
-        DataSet *generate_hierarchical_all_reduce(int size,bool local_run, bool vertical_run, bool horizontal_run, SchedulingPolicy pref_scheduling,int layer);
-        DataSet *generate_hierarchical_all_gather(int size,bool local_run, bool vertical_run, bool horizontal_run, SchedulingPolicy pref_scheduling,int layer);
-        DataSet *generate_hierarchical_reduce_scatter(int size,bool local_run, bool vertical_run, bool horizontal_run, SchedulingPolicy pref_scheduling,int layer);
-        DataSet *generate_LocalRingNodeA2AGlobalDBT_all_reduce(int size,bool local_run, bool vertical_run, bool horizontal_run, SchedulingPolicy pref_scheduling,int layer);
-        void insert_stream(std::list<BaseStream*> *queue,BaseStream *baseStream);
-        void proceed_to_next_vnet_baseline(StreamBaseline *stream);
-        int determine_chunk_size(int size,ComType type);
-        int get_priority(SchedulingPolicy pref_scheduling);
-        static void handleEvent(void *arg);
-        timespec_t generate_time(int cycles);
-    };
-}
+  void iterate();
+  bool initialize_sys(std::string name);
+  std::string trim(const std::string& str, const std::string& whitespace);
+  bool parse_var(std::string var, std::string value);
+  bool post_process_inputs();
+  int front_end_sim_send(
+      Tick delay,
+      void* buffer,
+      int count,
+      int type,
+      int dst,
+      int tag,
+      sim_request* request,
+      void (*msg_handler)(void* fun_arg),
+      void* fun_arg);
+  int front_end_sim_recv(
+      Tick delay,
+      void* buffer,
+      int count,
+      int type,
+      int src,
+      int tag,
+      sim_request* request,
+      void (*msg_handler)(void* fun_arg),
+      void* fun_arg);
+  int sim_send(
+      Tick delay,
+      void* buffer,
+      int count,
+      int type,
+      int dst,
+      int tag,
+      sim_request* request,
+      void (*msg_handler)(void* fun_arg),
+      void* fun_arg);
+  int sim_recv(
+      Tick delay,
+      void* buffer,
+      int count,
+      int type,
+      int src,
+      int tag,
+      sim_request* request,
+      void (*msg_handler)(void* fun_arg),
+      void* fun_arg);
+  int rendezvous_sim_send(
+      Tick delay,
+      void* buffer,
+      int count,
+      int type,
+      int dst,
+      int tag,
+      sim_request* request,
+      void (*msg_handler)(void* fun_arg),
+      void* fun_arg);
+  int rendezvous_sim_recv(
+      Tick delay,
+      void* buffer,
+      int count,
+      int type,
+      int src,
+      int tag,
+      sim_request* request,
+      void (*msg_handler)(void* fun_arg),
+      void* fun_arg);
+  Tick mem_read(uint64_t bytes);
+  Tick mem_write(uint64_t bytes);
+  static int get_layer_numbers(std::string workload_input);
+  DataSet* generate_all_reduce(
+      int size,
+      bool local,
+      bool vertical,
+      bool horizontal,
+      SchedulingPolicy pref_scheduling,
+      int layer);
+  DataSet* generate_all_to_all(
+      int size,
+      bool local,
+      bool vertical,
+      bool horizontal,
+      SchedulingPolicy pref_scheduling,
+      int layer);
+  DataSet* generate_all_gather(
+      int size,
+      bool local,
+      bool vertical,
+      bool horizontal,
+      SchedulingPolicy pref_scheduling,
+      int layer);
+  DataSet* generate_reduce_scatter(
+      int size,
+      bool local,
+      bool vertical,
+      bool horizontal,
+      SchedulingPolicy pref_scheduling,
+      int layer);
+  DataSet* generate_alltoall_all_to_all(
+      int size,
+      bool local_run,
+      bool horizontal_run,
+      SchedulingPolicy pref_scheduling,
+      int layer);
+  DataSet* generate_alltoall_all_reduce(
+      int size,
+      bool local_run,
+      bool horizontal_run,
+      SchedulingPolicy pref_scheduling,
+      int layer);
+  DataSet* generate_tree_all_reduce(
+      int size,
+      bool local_run,
+      bool horizontal_run,
+      SchedulingPolicy pref_scheduling,
+      int layer);
+  DataSet* generate_hierarchical_all_to_all(
+      int size,
+      bool local_run,
+      bool vertical_run,
+      bool horizontal_run,
+      SchedulingPolicy pref_scheduling,
+      int layer);
+  DataSet* generate_hierarchical_all_reduce(
+      int size,
+      bool local_run,
+      bool vertical_run,
+      bool horizontal_run,
+      SchedulingPolicy pref_scheduling,
+      int layer);
+  DataSet* generate_hierarchical_all_gather(
+      int size,
+      bool local_run,
+      bool vertical_run,
+      bool horizontal_run,
+      SchedulingPolicy pref_scheduling,
+      int layer);
+  DataSet* generate_hierarchical_reduce_scatter(
+      int size,
+      bool local_run,
+      bool vertical_run,
+      bool horizontal_run,
+      SchedulingPolicy pref_scheduling,
+      int layer);
+  DataSet* generate_LocalRingNodeA2AGlobalDBT_all_reduce(
+      int size,
+      bool local_run,
+      bool vertical_run,
+      bool horizontal_run,
+      SchedulingPolicy pref_scheduling,
+      int layer);
+  void insert_stream(std::list<BaseStream*>* queue, BaseStream* baseStream);
+  void proceed_to_next_vnet_baseline(StreamBaseline* stream);
+  int determine_chunk_size(int size, ComType type);
+  int get_priority(SchedulingPolicy pref_scheduling);
+  static void handleEvent(void* arg);
+  timespec_t generate_time(int cycles);
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/collective/Algorithm.hh
+++ b/astra-sim/system/collective/Algorithm.hh
@@ -6,44 +6,43 @@ LICENSE file in the root directory of this source tree.
 #ifndef __ALGORITHM_HH__
 #define __ALGORITHM_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "astra-sim/system/Common.hh"
-#include "astra-sim/system/Callable.hh"
+#include <tuple>
+#include <vector>
 #include "astra-sim/system/BaseStream.hh"
 #include "astra-sim/system/CallData.hh"
+#include "astra-sim/system/Callable.hh"
+#include "astra-sim/system/Common.hh"
 #include "astra-sim/system/topology/LogicalTopology.hh"
 
-namespace AstraSim{
-    class Algorithm:public Callable{
-    public:
-        enum class Name{Ring,DoubleBinaryTree,AllToAll};
-        Name name;
-        int id;
-        BaseStream *stream;
-        LogicalTopology *logicalTopology;
-        int data_size;
-        int final_data_size;
-        ComType comType;
-        bool enabled;
-        int layer_num;
-        Algorithm(int layer_num);
-        virtual ~Algorithm()= default;
-        virtual void run(EventType event,CallData *data)=0;
-        virtual void exit();
-        virtual void init(BaseStream *stream);
-        virtual void call(EventType event,CallData *data);
-    };
-}
+namespace AstraSim {
+class Algorithm : public Callable {
+ public:
+  enum class Name { Ring, DoubleBinaryTree, AllToAll };
+  Name name;
+  int id;
+  BaseStream* stream;
+  LogicalTopology* logicalTopology;
+  int data_size;
+  int final_data_size;
+  ComType comType;
+  bool enabled;
+  int layer_num;
+  Algorithm(int layer_num);
+  virtual ~Algorithm() = default;
+  virtual void run(EventType event, CallData* data) = 0;
+  virtual void exit();
+  virtual void init(BaseStream* stream);
+  virtual void call(EventType event, CallData* data);
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/collective/AllToAll.hh
+++ b/astra-sim/system/collective/AllToAll.hh
@@ -6,33 +6,39 @@ LICENSE file in the root directory of this source tree.
 #ifndef __ALLTOALL_HH__
 #define __ALLTOALL_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "astra-sim/system/Common.hh"
+#include <tuple>
+#include <vector>
 #include "Ring.hh"
-#include "astra-sim/system/topology/RingTopology.hh"
 #include "astra-sim/system/CallData.hh"
+#include "astra-sim/system/Common.hh"
+#include "astra-sim/system/topology/RingTopology.hh"
 
-namespace AstraSim{
-    class AllToAll:public Ring{
-    public:
-        AllToAll(ComType type,int id,int layer_num,RingTopology *allToAllTopology,int data_size,
-                 RingTopology::Direction direction,PacketRouting routing,
-                 InjectionPolicy injection_policy,bool boost_mode);
-        void run(EventType event,CallData *data);
-        void process_max_count();
-        int get_non_zero_latency_packets();
-    };
-}
+namespace AstraSim {
+class AllToAll : public Ring {
+ public:
+  AllToAll(
+      ComType type,
+      int id,
+      int layer_num,
+      RingTopology* allToAllTopology,
+      int data_size,
+      RingTopology::Direction direction,
+      PacketRouting routing,
+      InjectionPolicy injection_policy,
+      bool boost_mode);
+  void run(EventType event, CallData* data);
+  void process_max_count();
+  int get_non_zero_latency_packets();
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/collective/DoubleBinaryTreeAllReduce.hh
+++ b/astra-sim/system/collective/DoubleBinaryTreeAllReduce.hh
@@ -6,40 +6,52 @@ LICENSE file in the root directory of this source tree.
 #ifndef __DOUBLEBINARYTREEALLREDUCE_HH__
 #define __DOUBLEBINARYTREEALLREDUCE_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "astra-sim/system/Common.hh"
-#include "astra-sim/system/CallData.hh"
-#include "astra-sim/system/topology/BinaryTree.hh"
+#include <tuple>
+#include <vector>
 #include "Algorithm.hh"
+#include "astra-sim/system/CallData.hh"
+#include "astra-sim/system/Common.hh"
+#include "astra-sim/system/topology/BinaryTree.hh"
 
-namespace AstraSim{
-    class DoubleBinaryTreeAllReduce:public Algorithm{
-    public:
-        enum class State{Begin,WaitingForTwoChildData,WaitingForOneChildData,SendingDataToParent,WaitingDataFromParent,SendingDataToChilds,End};
-        void run(EventType event,CallData *data);
-        //void call(EventType event,CallData *data);
-        //void exit();
-        int parent;
-        int left_child;
-        int reductions;
-        int right_child;
-        //BinaryTree *tree;
-        BinaryTree::Type type;
-        State state;
-        DoubleBinaryTreeAllReduce(int id,int layer_num,BinaryTree *tree,int data_size,bool boost_mode);
-        //void init(BaseStream *stream);
-    };
-}
+namespace AstraSim {
+class DoubleBinaryTreeAllReduce : public Algorithm {
+ public:
+  enum class State {
+    Begin,
+    WaitingForTwoChildData,
+    WaitingForOneChildData,
+    SendingDataToParent,
+    WaitingDataFromParent,
+    SendingDataToChilds,
+    End
+  };
+  void run(EventType event, CallData* data);
+  // void call(EventType event,CallData *data);
+  // void exit();
+  int parent;
+  int left_child;
+  int reductions;
+  int right_child;
+  // BinaryTree *tree;
+  BinaryTree::Type type;
+  State state;
+  DoubleBinaryTreeAllReduce(
+      int id,
+      int layer_num,
+      BinaryTree* tree,
+      int data_size,
+      bool boost_mode);
+  // void init(BaseStream *stream);
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/collective/Ring.hh
+++ b/astra-sim/system/collective/Ring.hh
@@ -6,70 +6,77 @@ LICENSE file in the root directory of this source tree.
 #ifndef __RING_HH__
 #define __RING_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "astra-sim/system/Common.hh"
+#include <tuple>
+#include <vector>
 #include "Algorithm.hh"
-#include "astra-sim/system/topology/RingTopology.hh"
+#include "astra-sim/system/Common.hh"
 #include "astra-sim/system/MemBus.hh"
 #include "astra-sim/system/MyPacket.hh"
+#include "astra-sim/system/topology/RingTopology.hh"
 
-namespace AstraSim{
-    class Ring:public Algorithm{
-    public:
-        //enum class Type{AllReduce,AllGather,ReduceScatter,AllToAll};
-        RingTopology::Direction dimension;
-        RingTopology::Direction direction;
-        MemBus::Transmition transmition;
-        int zero_latency_packets;
-        int non_zero_latency_packets;
-        int id;
-        int current_receiver;
-        int current_sender;
-        int nodes_in_ring;
-        int stream_count;
-        int max_count;
-        int remained_packets_per_max_count;
-        int remained_packets_per_message;
-        int parallel_reduce;
-        PacketRouting routing;
-        InjectionPolicy injection_policy;
-        std::list<MyPacket> packets;
-        bool toggle;
-        long free_packets;
-        long total_packets_sent;
-        long total_packets_received;
-        int msg_size;
-        std::list<MyPacket*> locked_packets;
-        bool processed;
-        bool send_back;
-        bool NPU_to_MA;
+namespace AstraSim {
+class Ring : public Algorithm {
+ public:
+  // enum class Type{AllReduce,AllGather,ReduceScatter,AllToAll};
+  RingTopology::Direction dimension;
+  RingTopology::Direction direction;
+  MemBus::Transmition transmition;
+  int zero_latency_packets;
+  int non_zero_latency_packets;
+  int id;
+  int current_receiver;
+  int current_sender;
+  int nodes_in_ring;
+  int stream_count;
+  int max_count;
+  int remained_packets_per_max_count;
+  int remained_packets_per_message;
+  int parallel_reduce;
+  PacketRouting routing;
+  InjectionPolicy injection_policy;
+  std::list<MyPacket> packets;
+  bool toggle;
+  long free_packets;
+  long total_packets_sent;
+  long total_packets_received;
+  int msg_size;
+  std::list<MyPacket*> locked_packets;
+  bool processed;
+  bool send_back;
+  bool NPU_to_MA;
 
-        Ring(ComType type,int id,int layer_num,RingTopology *ring_topology,int data_size, RingTopology::Direction direction,
-             PacketRouting routing,InjectionPolicy injection_policy,bool boost_mode);
-        virtual void run(EventType event,CallData *data);
-        void process_stream_count();
-        //void call(EventType event,CallData *data);
-        void release_packets();
-        virtual void process_max_count();
-        void reduce();
-        bool iteratable();
-        virtual int get_non_zero_latency_packets();
-        void insert_packet(Callable *sender);
-        bool ready();
+  Ring(
+      ComType type,
+      int id,
+      int layer_num,
+      RingTopology* ring_topology,
+      int data_size,
+      RingTopology::Direction direction,
+      PacketRouting routing,
+      InjectionPolicy injection_policy,
+      bool boost_mode);
+  virtual void run(EventType event, CallData* data);
+  void process_stream_count();
+  // void call(EventType event,CallData *data);
+  void release_packets();
+  virtual void process_max_count();
+  void reduce();
+  bool iteratable();
+  virtual int get_non_zero_latency_packets();
+  void insert_packet(Callable* sender);
+  bool ready();
 
-        void exit();
-    };
-}
+  void exit();
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/memory/SimpleMemory.hh
+++ b/astra-sim/system/memory/SimpleMemory.hh
@@ -7,26 +7,30 @@ LICENSE file in the root directory of this source tree.
 #define __SIMPLEMEMORY_HH__
 #include "astra-sim/system/AstraMemoryAPI.hh"
 #include "astra-sim/system/AstraNetworkAPI.hh"
-namespace AstraSim{
-class SimpleMemory: public AstraMemoryAPI{
-public:
-    double last_request_serviced;
-    double npu_access_bw_GB;
-    double nic_access_bw_GB;
-    double access_latency;
-    uint64_t nic_read_request_count;
-    uint64_t nic_write_request_count;
-    uint64_t npu_read_request_count;
-    uint64_t npu_write_request_count;
-    AstraNetworkAPI *NI;
-    SimpleMemory(AstraNetworkAPI *NI,double access_latency,double npu_access_bw_GB,double nic_access_bw_GB);
-    void set_network_api(AstraNetworkAPI *astraNetworkApi);
-    uint64_t npu_mem_read(uint64_t size);
-    uint64_t npu_mem_write(uint64_t size);
-    uint64_t nic_mem_read(uint64_t size);
-    uint64_t nic_mem_write(uint64_t size);
-    uint64_t mem_read(uint64_t size);
-    uint64_t mem_write(uint64_t size);
+namespace AstraSim {
+class SimpleMemory : public AstraMemoryAPI {
+ public:
+  double last_request_serviced;
+  double npu_access_bw_GB;
+  double nic_access_bw_GB;
+  double access_latency;
+  uint64_t nic_read_request_count;
+  uint64_t nic_write_request_count;
+  uint64_t npu_read_request_count;
+  uint64_t npu_write_request_count;
+  AstraNetworkAPI* NI;
+  SimpleMemory(
+      AstraNetworkAPI* NI,
+      double access_latency,
+      double npu_access_bw_GB,
+      double nic_access_bw_GB);
+  void set_network_api(AstraNetworkAPI* astraNetworkApi);
+  uint64_t npu_mem_read(uint64_t size);
+  uint64_t npu_mem_write(uint64_t size);
+  uint64_t nic_mem_read(uint64_t size);
+  uint64_t nic_mem_write(uint64_t size);
+  uint64_t mem_read(uint64_t size);
+  uint64_t mem_write(uint64_t size);
 };
-}
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/topology/BasicLogicalTopology.hh
+++ b/astra-sim/system/topology/BasicLogicalTopology.hh
@@ -6,32 +6,39 @@ LICENSE file in the root directory of this source tree.
 #ifndef __BASICLOGICALTOPOLOGY_HH__
 #define __BASICLOGICALTOPOLOGY_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "astra-sim/system/Common.hh"
+#include <tuple>
+#include <vector>
 #include "LogicalTopology.hh"
+#include "astra-sim/system/Common.hh"
 
-namespace AstraSim{
-    class BasicLogicalTopology: public LogicalTopology{
-    public:
-        enum class BasicTopology{Ring,BinaryTree};
-        BasicTopology basic_topology;
-        BasicLogicalTopology(BasicTopology basic_topology){this->basic_topology=basic_topology;
-            this->complexity=LogicalTopology::Complexity::Basic;}
-        virtual ~BasicLogicalTopology()=default;
-        int get_num_of_dimensions() override{return 1;};
-        BasicLogicalTopology* get_basic_topology_at_dimension(int dimension,ComType type) override{return this;}
-    };
-}
+namespace AstraSim {
+class BasicLogicalTopology : public LogicalTopology {
+ public:
+  enum class BasicTopology { Ring, BinaryTree };
+  BasicTopology basic_topology;
+  BasicLogicalTopology(BasicTopology basic_topology) {
+    this->basic_topology = basic_topology;
+    this->complexity = LogicalTopology::Complexity::Basic;
+  }
+  virtual ~BasicLogicalTopology() = default;
+  int get_num_of_dimensions() override {
+    return 1;
+  };
+  BasicLogicalTopology* get_basic_topology_at_dimension(
+      int dimension,
+      ComType type) override {
+    return this;
+  }
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/topology/BinaryTree.hh
+++ b/astra-sim/system/topology/BinaryTree.hh
@@ -6,44 +6,53 @@ LICENSE file in the root directory of this source tree.
 #ifndef __BINARYTREE_HH__
 #define __BINARYTREE_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "astra-sim/system/Common.hh"
+#include <tuple>
+#include <vector>
 #include "BasicLogicalTopology.hh"
 #include "Node.hh"
+#include "astra-sim/system/Common.hh"
 
-namespace AstraSim{
-    class BinaryTree:public BasicLogicalTopology{
-    public:
-        enum class TreeType{RootMax,RootMin};
-        enum class Type{Leaf,Root,Intermediate};
-        int total_tree_nodes;
-        int start;
-        TreeType tree_type;
-        int stride;
-        Node *tree;
-        virtual ~BinaryTree();
-        std::map<int,Node*> node_list;
-        BinaryTree(int id,TreeType tree_type,int total_tree_nodes,int start,int stride);
-        Node* initialize_tree(int depth,Node* parent);
-        void build_tree(Node* node);
-        int get_parent_id(int id);
-        int get_left_child_id(int id);
-        int get_right_child_id(int id);
-        Type get_node_type(int id);
-        bool is_enabled(int id){if(id%stride==0){return true;}return false;};
-        void print(Node *node);
-    };
-}
+namespace AstraSim {
+class BinaryTree : public BasicLogicalTopology {
+ public:
+  enum class TreeType { RootMax, RootMin };
+  enum class Type { Leaf, Root, Intermediate };
+  int total_tree_nodes;
+  int start;
+  TreeType tree_type;
+  int stride;
+  Node* tree;
+  virtual ~BinaryTree();
+  std::map<int, Node*> node_list;
+  BinaryTree(
+      int id,
+      TreeType tree_type,
+      int total_tree_nodes,
+      int start,
+      int stride);
+  Node* initialize_tree(int depth, Node* parent);
+  void build_tree(Node* node);
+  int get_parent_id(int id);
+  int get_left_child_id(int id);
+  int get_right_child_id(int id);
+  Type get_node_type(int id);
+  bool is_enabled(int id) {
+    if (id % stride == 0) {
+      return true;
+    }
+    return false;
+  };
+  void print(Node* node);
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/topology/ComplexLogicalTopology.hh
+++ b/astra-sim/system/topology/ComplexLogicalTopology.hh
@@ -6,29 +6,36 @@ LICENSE file in the root directory of this source tree.
 #ifndef __COMPLEXLOGICALTOPOLOGY_HH__
 #define __COMPLEXLOGICALTOPOLOGY_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "astra-sim/system/Common.hh"
+#include <tuple>
+#include <vector>
 #include "LogicalTopology.hh"
+#include "astra-sim/system/Common.hh"
 
-namespace AstraSim{
-    class ComplexLogicalTopology: public LogicalTopology{
-    public:
-        ComplexLogicalTopology(){this->complexity=LogicalTopology::Complexity::Complex;}
-        virtual ~ComplexLogicalTopology()=default;
-        virtual int get_num_of_dimensions() override{return 1;}
-        virtual BasicLogicalTopology* get_basic_topology_at_dimension(int dimension,ComType type) override{return NULL;};
-    };
-}
+namespace AstraSim {
+class ComplexLogicalTopology : public LogicalTopology {
+ public:
+  ComplexLogicalTopology() {
+    this->complexity = LogicalTopology::Complexity::Complex;
+  }
+  virtual ~ComplexLogicalTopology() = default;
+  virtual int get_num_of_dimensions() override {
+    return 1;
+  }
+  virtual BasicLogicalTopology* get_basic_topology_at_dimension(
+      int dimension,
+      ComType type) override {
+    return NULL;
+  };
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/topology/ComputeNode.hh
+++ b/astra-sim/system/topology/ComputeNode.hh
@@ -5,9 +5,7 @@ LICENSE file in the root directory of this source tree.
 
 #ifndef __COMPUTENODE_HH__
 #define __COMPUTENODE_HH__
-namespace AstraSim{
-    class ComputeNode{
-
-    };
-}
+namespace AstraSim {
+class ComputeNode {};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/topology/DoubleBinaryTreeTopology.hh
+++ b/astra-sim/system/topology/DoubleBinaryTreeTopology.hh
@@ -6,31 +6,35 @@ LICENSE file in the root directory of this source tree.
 #ifndef __DOUBLEBINARYTREETOPOLOGY_HH__
 #define __DOUBLEBINARYTREETOPOLOGY_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "astra-sim/system/Common.hh"
+#include <tuple>
+#include <vector>
 #include "ComplexLogicalTopology.hh"
 #include "LocalRingGlobalBinaryTree.hh"
-namespace AstraSim{
-    class DoubleBinaryTreeTopology:public ComplexLogicalTopology{
-    public:
-        int counter;
-        LocalRingGlobalBinaryTree *DBMAX;
-        LocalRingGlobalBinaryTree *DBMIN;
-        LogicalTopology *get_topology();
-        ~DoubleBinaryTreeTopology();
-        DoubleBinaryTreeTopology(int id,int total_tree_nodes,int start,int stride,int local_dim);
-    };
-}
+#include "astra-sim/system/Common.hh"
+namespace AstraSim {
+class DoubleBinaryTreeTopology : public ComplexLogicalTopology {
+ public:
+  int counter;
+  LocalRingGlobalBinaryTree* DBMAX;
+  LocalRingGlobalBinaryTree* DBMIN;
+  LogicalTopology* get_topology();
+  ~DoubleBinaryTreeTopology();
+  DoubleBinaryTreeTopology(
+      int id,
+      int total_tree_nodes,
+      int start,
+      int stride,
+      int local_dim);
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/topology/LocalRingGlobalBinaryTree.hh
+++ b/astra-sim/system/topology/LocalRingGlobalBinaryTree.hh
@@ -6,31 +6,36 @@ LICENSE file in the root directory of this source tree.
 #ifndef __LOCALRINGGLOBALBINARYTREE_HH__
 #define __LOCALRINGGLOBALBINARYTREE_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "astra-sim/system/Common.hh"
-#include "RingTopology.hh"
+#include <tuple>
+#include <vector>
 #include "BinaryTree.hh"
 #include "ComplexLogicalTopology.hh"
+#include "RingTopology.hh"
+#include "astra-sim/system/Common.hh"
 
-namespace AstraSim{
-    class LocalRingGlobalBinaryTree:public ComplexLogicalTopology{
-    public:
-        RingTopology *local_dimension;
-        BinaryTree *global_dimension;
-        LocalRingGlobalBinaryTree(int id,BinaryTree::TreeType tree_type,int total_tree_nodes,int start,int stride,int local_dim);
-        ~LocalRingGlobalBinaryTree();
-    };
-}
+namespace AstraSim {
+class LocalRingGlobalBinaryTree : public ComplexLogicalTopology {
+ public:
+  RingTopology* local_dimension;
+  BinaryTree* global_dimension;
+  LocalRingGlobalBinaryTree(
+      int id,
+      BinaryTree::TreeType tree_type,
+      int total_tree_nodes,
+      int start,
+      int stride,
+      int local_dim);
+  ~LocalRingGlobalBinaryTree();
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/topology/LocalRingNodeA2AGlobalDBT.hh
+++ b/astra-sim/system/topology/LocalRingNodeA2AGlobalDBT.hh
@@ -6,29 +6,33 @@ LICENSE file in the root directory of this source tree.
 #ifndef __LOCALRINGNODEA2AGLOBALDBT_HH__
 #define __LOCALRINGNODEA2AGLOBALDBT_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "astra-sim/system/Common.hh"
+#include <tuple>
+#include <vector>
 #include "ComplexLogicalTopology.hh"
 #include "DoubleBinaryTreeTopology.hh"
+#include "astra-sim/system/Common.hh"
 
-namespace AstraSim{
-    class LocalRingNodeA2AGlobalDBT:public ComplexLogicalTopology{
-    public:
-        DoubleBinaryTreeTopology *global_all_reduce_dimension;
-        LocalRingNodeA2AGlobalDBT(int id,int total_tree_nodes,int start,int stride,int local_dim);
-        ~LocalRingNodeA2AGlobalDBT();
-    };
-}
+namespace AstraSim {
+class LocalRingNodeA2AGlobalDBT : public ComplexLogicalTopology {
+ public:
+  DoubleBinaryTreeTopology* global_all_reduce_dimension;
+  LocalRingNodeA2AGlobalDBT(
+      int id,
+      int total_tree_nodes,
+      int start,
+      int stride,
+      int local_dim);
+  ~LocalRingNodeA2AGlobalDBT();
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/topology/LogicalTopology.hh
+++ b/astra-sim/system/topology/LogicalTopology.hh
@@ -6,17 +6,19 @@ LICENSE file in the root directory of this source tree.
 #ifndef __LOGICALTOPOLOGY_HH__
 #define __LOGICALTOPOLOGY_HH__
 #include "astra-sim/system/Common.hh"
-namespace AstraSim{
-    class BasicLogicalTopology;
-    class LogicalTopology{
-    public:
-        enum class Complexity{Basic,Complex};
-        Complexity complexity;
-        virtual LogicalTopology* get_topology();
-        static int get_reminder(int number,int divisible);
-        virtual ~LogicalTopology()= default;
-        virtual int get_num_of_dimensions()=0;
-        virtual BasicLogicalTopology* get_basic_topology_at_dimension(int dimension,ComType type)=0;
-    };
-}
+namespace AstraSim {
+class BasicLogicalTopology;
+class LogicalTopology {
+ public:
+  enum class Complexity { Basic, Complex };
+  Complexity complexity;
+  virtual LogicalTopology* get_topology();
+  static int get_reminder(int number, int divisible);
+  virtual ~LogicalTopology() = default;
+  virtual int get_num_of_dimensions() = 0;
+  virtual BasicLogicalTopology* get_basic_topology_at_dimension(
+      int dimension,
+      ComType type) = 0;
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/topology/Node.hh
+++ b/astra-sim/system/topology/Node.hh
@@ -6,30 +6,29 @@ LICENSE file in the root directory of this source tree.
 #ifndef __NODE_HH__
 #define __NODE_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "astra-sim/system/Common.hh"
+#include <tuple>
+#include <vector>
 #include "ComputeNode.hh"
+#include "astra-sim/system/Common.hh"
 
-namespace AstraSim{
-    class Node:public ComputeNode{
-    public:
-        int id;
-        Node *parent;
-        Node *left_child;
-        Node *right_child;
-        Node(int id,Node *parent,Node *left_child,Node *right_child);
-    };
-}
+namespace AstraSim {
+class Node : public ComputeNode {
+ public:
+  int id;
+  Node* parent;
+  Node* left_child;
+  Node* right_child;
+  Node(int id, Node* parent, Node* left_child, Node* right_child);
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/topology/RingTopology.hh
+++ b/astra-sim/system/topology/RingTopology.hh
@@ -6,43 +6,48 @@ LICENSE file in the root directory of this source tree.
 #ifndef __RINGTOPOLOGY_HH__
 #define __RINGTOPOLOGY_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "astra-sim/system/Common.hh"
+#include <tuple>
+#include <vector>
 #include "BasicLogicalTopology.hh"
+#include "astra-sim/system/Common.hh"
 
-namespace AstraSim{
-    class RingTopology:public BasicLogicalTopology{
-    public:
-        enum class Direction{Clockwise,Anticlockwise};
-        enum class Dimension{Local,Vertical,Horizontal};
-        std::string name;
-        int id;
-        int next_node_id;
-        int previous_node_id;
-        int offset;
-        int total_nodes_in_ring;
-        int index_in_ring;
-        Dimension dimension;
-        RingTopology(Dimension dimension,int id,int total_nodes_in_ring,int index_in_ring,int offset);
-        void find_neighbors();
-        virtual int get_receiver_node(int node_id,Direction direction);
-        virtual int get_sender_node(int node_id,Direction direction);
-        int get_nodes_in_ring();
-        bool is_enabled();
-    private:
-        std::map<int,int> id_to_index;
-    };
-}
+namespace AstraSim {
+class RingTopology : public BasicLogicalTopology {
+ public:
+  enum class Direction { Clockwise, Anticlockwise };
+  enum class Dimension { Local, Vertical, Horizontal };
+  std::string name;
+  int id;
+  int next_node_id;
+  int previous_node_id;
+  int offset;
+  int total_nodes_in_ring;
+  int index_in_ring;
+  Dimension dimension;
+  RingTopology(
+      Dimension dimension,
+      int id,
+      int total_nodes_in_ring,
+      int index_in_ring,
+      int offset);
+  void find_neighbors();
+  virtual int get_receiver_node(int node_id, Direction direction);
+  virtual int get_sender_node(int node_id, Direction direction);
+  int get_nodes_in_ring();
+  bool is_enabled();
+
+ private:
+  std::map<int, int> id_to_index;
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/system/topology/Torus3D.hh
+++ b/astra-sim/system/topology/Torus3D.hh
@@ -6,31 +6,30 @@ LICENSE file in the root directory of this source tree.
 #ifndef __TORUS3D_HH__
 #define __TORUS3D_HH__
 
-#include <map>
+#include <assert.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <list>
-#include <vector>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <list>
+#include <map>
 #include <sstream>
-#include <assert.h>
-#include "astra-sim/system/Common.hh"
+#include <tuple>
+#include <vector>
 #include "ComplexLogicalTopology.hh"
 #include "RingTopology.hh"
+#include "astra-sim/system/Common.hh"
 
-namespace AstraSim{
-    class Torus3D:public ComplexLogicalTopology{
-    public:
-        RingTopology *local_dimension;
-        RingTopology *vertical_dimension;
-        RingTopology *horizontal_dimension;
-        Torus3D(int id,int total_nodes,int local_dim,int vertical_dim);
-        ~Torus3D();
-    };
-}
+namespace AstraSim {
+class Torus3D : public ComplexLogicalTopology {
+ public:
+  RingTopology* local_dimension;
+  RingTopology* vertical_dimension;
+  RingTopology* horizontal_dimension;
+  Torus3D(int id, int total_nodes, int local_dim, int vertical_dim);
+  ~Torus3D();
+};
+} // namespace AstraSim
 #endif

--- a/astra-sim/workload/CSVWriter.hh
+++ b/astra-sim/workload/CSVWriter.hh
@@ -6,36 +6,35 @@ LICENSE file in the root directory of this source tree.
 #ifndef __CSVWRITER_HH__
 #define __CSVWRITER_HH__
 
-
-#include <map>
+#include <fcntl.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <iostream>
 #include <sys/stat.h>
 #include <unistd.h>
-#include <fcntl.h>
+#include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <tuple>
 
-namespace AstraSim{
-class CSVWriter{
-public:
-    //std::fstream inFile;
-    std::fstream myFile;
-    void initialize_csv(int rows, int cols);
-    CSVWriter(std::string path,std::string name);
-    void write_cell(int row,int column,std::string data);
-    std::string path;
-    std::string name;
-    ~CSVWriter(){
-        myFile.close();
-    }
-    inline bool exists_test(const std::string& name) {
-        struct stat buffer;
-        return (stat (name.c_str(), &buffer) == 0);
-    }
+namespace AstraSim {
+class CSVWriter {
+ public:
+  // std::fstream inFile;
+  std::fstream myFile;
+  void initialize_csv(int rows, int cols);
+  CSVWriter(std::string path, std::string name);
+  void write_cell(int row, int column, std::string data);
+  std::string path;
+  std::string name;
+  ~CSVWriter() {
+    myFile.close();
+  }
+  inline bool exists_test(const std::string& name) {
+    struct stat buffer;
+    return (stat(name.c_str(), &buffer) == 0);
+  }
 };
-}
+} // namespace AstraSim
 #endif

--- a/astra-sim/workload/Layer.hh
+++ b/astra-sim/workload/Layer.hh
@@ -6,111 +6,140 @@ LICENSE file in the root directory of this source tree.
 #ifndef __LAYER_HH__
 #define __LAYER_HH__
 
-
-#include <map>
+#include <fcntl.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <iostream>
 #include <sys/stat.h>
 #include <unistd.h>
-#include <fcntl.h>
-#include "astra-sim/system/Sys.hh"
-#include "astra-sim/system/StreamStat.hh"
-#include "Workload.hh"
+#include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <tuple>
 #include "CSVWriter.hh"
+#include "Workload.hh"
+#include "astra-sim/system/StreamStat.hh"
+#include "astra-sim/system/Sys.hh"
 
-namespace AstraSim{
-    class DataSet;
-class Layer:public Callable,public StreamStat{
-public:
-    std::string id;
-    int layer_num;
-    Sys *generator;
-    Workload *workload;
+namespace AstraSim {
+class DataSet;
+class Layer : public Callable, public StreamStat {
+ public:
+  std::string id;
+  int layer_num;
+  Sys* generator;
+  Workload* workload;
 
-    int fwd_pass_compute_time;
-    ComType fwd_pass_comm_type;
-    int fwd_pass_comm_size;
-    Tick fwd_update_time;
+  int fwd_pass_compute_time;
+  ComType fwd_pass_comm_type;
+  int fwd_pass_comm_size;
+  Tick fwd_update_time;
 
-    int input_grad_compute_time;
-    ComType input_grad_comm_type;
-    int input_grad_comm_size;
-    Tick input_grad_update_time;
+  int input_grad_compute_time;
+  ComType input_grad_comm_type;
+  int input_grad_comm_size;
+  Tick input_grad_update_time;
 
-    int weight_grad_compute_time;
-    ComType weight_grad_comm_type;
-    int weight_grad_comm_size;
-    Tick weight_grad_update_time;
+  int weight_grad_compute_time;
+  ComType weight_grad_comm_type;
+  int weight_grad_comm_size;
+  Tick weight_grad_update_time;
 
-    bool needs_fwd_in_bckwd_initiation;
-    bool is_checkpoint;
-    ParallelismPolicy specific_parallellism;
+  bool needs_fwd_in_bckwd_initiation;
+  bool is_checkpoint;
+  ParallelismPolicy specific_parallellism;
 
-    int lookup_table_size;
-    int collective_counter;
+  int lookup_table_size;
+  int collective_counter;
 
+  // DataSet *fwd_pass_dataset;
+  // DataSet *input_grad_dataset;
+  // DataSet *weight_grad_dataset;
 
-    //DataSet *fwd_pass_dataset;
-    //DataSet *input_grad_dataset;
-    //DataSet *weight_grad_dataset;
+  std::map<int, DataSet*> fwd_pass_datasets;
+  std::list<Tick> started_waiting_for_fwd_pass;
+  std::map<int, DataSet*> input_grad_datasets;
+  std::list<Tick> started_waiting_for_input_grad;
+  std::map<int, DataSet*> weight_grad_datasets;
+  std::list<Tick> started_waiting_for_weight_grad;
 
-    std::map<int,DataSet*> fwd_pass_datasets;
-    std::list<Tick> started_waiting_for_fwd_pass;
-    std::map<int,DataSet*> input_grad_datasets;
-    std::list<Tick> started_waiting_for_input_grad;
-    std::map<int,DataSet*> weight_grad_datasets;
-    std::list<Tick> started_waiting_for_weight_grad;
+  // reports
+  Tick total_forward_pass_compute;
+  Tick total_input_grad_compute;
+  Tick total_weight_grad_compute;
+  Tick total_weight_grad_comm;
+  Tick total_input_grad_comm;
+  Tick total_fwd_comm;
 
+  Tick last_fwd_finished;
+  Tick last_wg_finished;
+  Tick last_ig_finished;
 
-    //reports
-    Tick total_forward_pass_compute;
-    Tick total_input_grad_compute;
-    Tick total_weight_grad_compute;
-    Tick total_weight_grad_comm;
-    Tick total_input_grad_comm;
-    Tick total_fwd_comm;
+  Tick total_waiting_for_wg_comm;
+  Tick total_waiting_for_ig_comm;
+  Tick total_waiting_for_fwd_comm;
 
-    Tick last_fwd_finished;
-    Tick last_wg_finished;
-    Tick last_ig_finished;
+  CollectiveBarrier fwd_barrier;
+  CollectiveBarrier wg_barrier;
+  CollectiveBarrier ig_barrier;
 
-    Tick total_waiting_for_wg_comm;
-    Tick total_waiting_for_ig_comm;
-    Tick total_waiting_for_fwd_comm;
-
-
-    CollectiveBarrier fwd_barrier;
-    CollectiveBarrier wg_barrier;
-    CollectiveBarrier ig_barrier;
-
-    Layer(std::string id,int layer_num,Sys *generator,Workload *workload,int fwd_pass_compute_time,ComType fwd_pass_comm_type,
-          int fwd_pass_comm_size,int input_grad_compute_time,ComType input_grad_comm_type,int input_grad_comm_size,
-          int weight_grad_compute_time,ComType weight_grad_comm_type,int weight_grad_comm_size,int weight_grad_update_time);
-    void call(EventType event,CallData *mdata);
-    Tick get_fwd_pass_compute();
-    Tick get_input_grad_compute();
-    Tick get_weight_grad_compute();
-    void increment_waiting_for_wg();
-    void increment_waiting_for_ig();
-    void increment_waiting_for_fwd();
-    bool is_fwd_pass_comm_finished();
-    bool is_input_grad_comm_finished();
-    bool is_weight_grad_comm_finished();
-    bool is_fwd_pass_comm_finished_blocking();
-    bool is_input_grad_comm_finished_blocking();
-    bool is_weight_grad_comm_finished_blocking();
-    LayerData report(std::string run_name,int layer_num,int total_rows,int stat_row,CSVWriter *detailed,CSVWriter *EndToEnd,double &total_compute,double &total_exposed, bool seprate_log);
-    void issue_forward_pass_comm(bool local,bool vertical,bool horizontal,SchedulingPolicy pref_scheduling,
-                                 CollectiveBarrier barrier);
-    void issue_input_grad_comm(bool local,bool vertical,bool horizontal,SchedulingPolicy pref_scheduling,
-                               CollectiveBarrier barrier);
-    void issue_weight_grad_comm(bool local,bool vertical,bool horizontal,SchedulingPolicy pref_scheduling,
-                                CollectiveBarrier barrier);
+  Layer(
+      std::string id,
+      int layer_num,
+      Sys* generator,
+      Workload* workload,
+      int fwd_pass_compute_time,
+      ComType fwd_pass_comm_type,
+      int fwd_pass_comm_size,
+      int input_grad_compute_time,
+      ComType input_grad_comm_type,
+      int input_grad_comm_size,
+      int weight_grad_compute_time,
+      ComType weight_grad_comm_type,
+      int weight_grad_comm_size,
+      int weight_grad_update_time);
+  void call(EventType event, CallData* mdata);
+  Tick get_fwd_pass_compute();
+  Tick get_input_grad_compute();
+  Tick get_weight_grad_compute();
+  void increment_waiting_for_wg();
+  void increment_waiting_for_ig();
+  void increment_waiting_for_fwd();
+  bool is_fwd_pass_comm_finished();
+  bool is_input_grad_comm_finished();
+  bool is_weight_grad_comm_finished();
+  bool is_fwd_pass_comm_finished_blocking();
+  bool is_input_grad_comm_finished_blocking();
+  bool is_weight_grad_comm_finished_blocking();
+  LayerData report(
+      std::string run_name,
+      int layer_num,
+      int total_rows,
+      int stat_row,
+      CSVWriter* detailed,
+      CSVWriter* EndToEnd,
+      double& total_compute,
+      double& total_exposed,
+      bool seprate_log);
+  void issue_forward_pass_comm(
+      bool local,
+      bool vertical,
+      bool horizontal,
+      SchedulingPolicy pref_scheduling,
+      CollectiveBarrier barrier);
+  void issue_input_grad_comm(
+      bool local,
+      bool vertical,
+      bool horizontal,
+      SchedulingPolicy pref_scheduling,
+      CollectiveBarrier barrier);
+  void issue_weight_grad_comm(
+      bool local,
+      bool vertical,
+      bool horizontal,
+      SchedulingPolicy pref_scheduling,
+      CollectiveBarrier barrier);
 };
-}
+} // namespace AstraSim
 #endif

--- a/astra-sim/workload/Workload.hh
+++ b/astra-sim/workload/Workload.hh
@@ -6,86 +6,110 @@ LICENSE file in the root directory of this source tree.
 #ifndef __WORKLOAD_HH__
 #define __WORKLOAD_HH__
 
-
-#include <map>
+#include <fcntl.h>
 #include <math.h>
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <tuple>
-#include <cstdint>
-#include <iostream>
 #include <sys/stat.h>
 #include <unistd.h>
-#include <fcntl.h>
+#include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <tuple>
 #include "astra-sim/system/Callable.hh"
 
-namespace AstraSim{
+namespace AstraSim {
 class Workload;
 class Sys;
 class Callable;
 class Layer;
 class CSVWriter;
-}
+} // namespace AstraSim
 
 #include "astra-sim/system/AstraSimDataAPI.hh"
 #include "astra-sim/system/Sys.hh"
 
-namespace AstraSim{
-enum class ParallelismPolicy {MicroBenchmark,Data,Transformer,TransformerFwdInBckwd,DLRM,DLRMEnhanced,Model,HybridDataModel,HybridModelData,HybridCustomized,DistributedInference,None};
-#define FREQ (1000.0/CLOCK_PERIOD)
-
-class Workload:Callable {
-public:
-    enum class LoopState {
-        Forward_Pass, Weight_Gradient, Input_Gradient,Wait_For_Sim_Finish, Forward_In_BackPass
-    };
-    ~Workload();
-    Layer **layers;
-    int SIZE;
-    Sys *generator;
-    std::string run_type;
-    Tick counter;
-    int index;
-    LoopState current_state;
-    bool delay_loaded;
-    bool seprate_log;
-    bool checkpoint_initiated;
-    bool collective_issued;
-    bool initialized;
-    int TOTAL_PASS;
-    int DLRM_LAST_BOTTOM_LAYER;
-    int pass_counter;
-    int pending_collectives;
-    ParallelismPolicy parallelismPolicy;
-    //reports
-    Tick waiting_for_comm;
-    Workload(std::string run_name,Sys *generator, std::string name, int TOTAL_PASS,int total_rows,int stat_row,std::string path,bool seprate_log);
-    ParallelismPolicy decode_parallelsim(std::string parallelism);
-    void call(EventType event, CallData *data);
-    void iterate_micro_benchmark();
-    void iterate_data_parallel();
-    void iterate_hybrid_parallel_Transformer();
-    void iterate_hybrid_parallel_Transformer_fwd_in_bckwd();
-    void iterate_hybrid_parallel_DLRM();
-    void iterate_hybrid_parallel_data_model();
-    void iterate_hybrid_parallel_model_data();
-    void iterate_hybrid_parallel_customized();
-    void iterate_model_parallel();
-    void iterate_distributed_inference();
-    bool initialize_workload(std::string name);
-    void initialize_stat_files();
-    void fire();
-    void report();
-    void check_for_sim_end();
-    static int get_layer_numbers(std::string workload_input);
-    CSVWriter *detailed;
-    CSVWriter *end_to_end;
-    std::string path;
-    std::string run_name;
-    int stat_row;
-    int total_rows;
-    bool registered_for_finished_streams;
+namespace AstraSim {
+enum class ParallelismPolicy {
+  MicroBenchmark,
+  Data,
+  Transformer,
+  TransformerFwdInBckwd,
+  DLRM,
+  DLRMEnhanced,
+  Model,
+  HybridDataModel,
+  HybridModelData,
+  HybridCustomized,
+  DistributedInference,
+  None
 };
-}
+#define FREQ (1000.0 / CLOCK_PERIOD)
+
+class Workload : Callable {
+ public:
+  enum class LoopState {
+    Forward_Pass,
+    Weight_Gradient,
+    Input_Gradient,
+    Wait_For_Sim_Finish,
+    Forward_In_BackPass
+  };
+  ~Workload();
+  Layer** layers;
+  int SIZE;
+  Sys* generator;
+  std::string run_type;
+  Tick counter;
+  int index;
+  LoopState current_state;
+  bool delay_loaded;
+  bool seprate_log;
+  bool checkpoint_initiated;
+  bool collective_issued;
+  bool initialized;
+  int TOTAL_PASS;
+  int DLRM_LAST_BOTTOM_LAYER;
+  int pass_counter;
+  int pending_collectives;
+  ParallelismPolicy parallelismPolicy;
+  // reports
+  Tick waiting_for_comm;
+  Workload(
+      std::string run_name,
+      Sys* generator,
+      std::string name,
+      int TOTAL_PASS,
+      int total_rows,
+      int stat_row,
+      std::string path,
+      bool seprate_log);
+  ParallelismPolicy decode_parallelsim(std::string parallelism);
+  void call(EventType event, CallData* data);
+  void iterate_micro_benchmark();
+  void iterate_data_parallel();
+  void iterate_hybrid_parallel_Transformer();
+  void iterate_hybrid_parallel_Transformer_fwd_in_bckwd();
+  void iterate_hybrid_parallel_DLRM();
+  void iterate_hybrid_parallel_data_model();
+  void iterate_hybrid_parallel_model_data();
+  void iterate_hybrid_parallel_customized();
+  void iterate_model_parallel();
+  void iterate_distributed_inference();
+  bool initialize_workload(std::string name);
+  void initialize_stat_files();
+  void fire();
+  void report();
+  void check_for_sim_end();
+  static int get_layer_numbers(std::string workload_input);
+  CSVWriter* detailed;
+  CSVWriter* end_to_end;
+  std::string path;
+  std::string run_name;
+  int stat_row;
+  int total_rows;
+  bool registered_for_finished_streams;
+};
+} // namespace AstraSim
 #endif


### PR DESCRIPTION
Run clang-format for every header (`.hh`) files.