### PR TITLE
Simplified Startup Messages and Exits, virtual destructor for ComputeAPI

### DIFF
--- a/astra-sim/system/AstraComputeAPI.hh
+++ b/astra-sim/system/AstraComputeAPI.hh
@@ -26,6 +26,7 @@ class ComputeAPI {
       uint64_t N,
       void (*msg_handler)(void* fun_arg),
       ComputeMetaData* fun_arg) = 0;
+  virtual ~ComputeAPI() = 0;
 };
 } // namespace AstraSim
 #endif

--- a/astra-sim/system/Sys.cc
+++ b/astra-sim/system/Sys.cc
@@ -149,7 +149,7 @@ Sys::Sys(
   }
   all_generators[id] = this;
 
-  bool result = initialize_sys(my_sys + ".txt");
+  bool result = initialize_sys(my_sys);
 
   if (result == false) {
     Tick cycle = 1;
@@ -308,7 +308,7 @@ Sys::Sys(
   workload = new Workload(
       run_name,
       this,
-      my_workload + ".txt",
+      my_workload,
       num_passes,
       total_stat_rows,
       stat_row,
@@ -811,15 +811,16 @@ bool Sys::initialize_sys(std::string name) {
   inFile.open(name);
   if (!inFile) {
     if (id == 0) {
-      std::cout << "Unable to open file: " << name << std::endl;
-      std::cout << "############ Exiting because unable to open the system "
+      std::cerr << "Unable to open file: " << name << std::endl;
+      std::cerr << "############ Exiting because unable to open the system "
                    "input file ############"
                 << std::endl;
+      std::cerr << "This error is fatal. Please check your path and filename." << std::endl;
     }
-    return false;
+    exit(1);
   } else {
     if (id == 0) {
-      std::cout << "success in openning system file" << std::endl;
+      std::cout << "Success in opening system file" << std::endl;
     }
   }
   std::string var;
@@ -1046,7 +1047,7 @@ CollectivePhase Sys::generate_collective_phase(
     }
     else{
         if(id==0) {
-            std::cout
+            std::cerr
                     << "Warning: No known collective implementation for all-reduce, switching to the default ring-based collective"
                     << std::endl;
         }
@@ -1192,7 +1193,7 @@ void Sys::call_events() {
       (std::get<0>(callable))
           ->call(std::get<1>(callable), std::get<2>(callable));
     } catch (...) {
-      std::cout << "warning! a callable is removed before call" << std::endl;
+      std::cerr << "warning! a callable is removed before call" << std::endl;
     }
   }
   if (event_queue[Sys::boostedTick()].size() > 0) {

--- a/astra-sim/system/Sys.cc
+++ b/astra-sim/system/Sys.cc
@@ -727,11 +727,11 @@ bool Sys::parse_var(std::string var, std::string value) {
     }
   } else if (var != "") {
     if (id == 0) {
-      std::cout << "######### Exiting because " << var
-                << " is undefined inside system input file #########"
+      std::cerr << "######### Exiting because " << var
+                << " is an unknown variable. Check your system input file. #########"
                 << std::endl;
     }
-    return false;
+    exit(1);
   }
   return true;
 }

--- a/astra-sim/system/fast-backend/FastBackEnd.cc
+++ b/astra-sim/system/fast-backend/FastBackEnd.cc
@@ -240,7 +240,7 @@ FastBackEnd::handleEvent (void *arg)
     }
   else
     {
-      std::cout << "Event type undefined!" << std::endl;
+      std::cerr << "Event type undefined!" << std::endl;
     }
 }
 
@@ -390,7 +390,7 @@ FastBackEnd::sim_send (void *buffer, int count, int type, int dst, int tag, sim_
         default:
           {
             // should not fall here
-            std::cout << "sim_send inflight pair error" << std::endl;
+            std::cerr << "sim_send inflight pair error" << std::endl;
             exit (-1);
           }
         }
@@ -467,7 +467,7 @@ FastBackEnd::sim_recv (void *buffer, int count, int type, int src, int tag, sim_
         default:
           {
             // should not fall here
-            std::cout << "sim_recv inflight pair error" << std::endl;
+            std::cerr << "sim_recv inflight pair error" << std::endl;
             exit (-1);
           }
         }

--- a/astra-sim/workload/CSVWriter.cc
+++ b/astra-sim/workload/CSVWriter.cc
@@ -25,9 +25,11 @@ void CSVWriter::initialize_csv(int rows, int cols) {
   } while (!myFile.is_open());
 
   if (!myFile) {
-    std::cout << "Unable to open file: " << path << std::endl;
+    std::cerr << "Unable to open file: " << path << std::endl;
+    std::cerr << "This error is fatal. Please check your path and filename." << std::endl;
+    exit(1);
   } else {
-    std::cout << "success in opening CSV file for writing the report " << std::endl;
+    std::cout << "Success in opening CSV file for writing the report " << std::endl;
   }
 
   myFile.seekp(0, std::ios_base::beg);
@@ -74,7 +76,8 @@ void CSVWriter::write_cell(int row, int column, std::string data) {
       column--;
     }
     if (*buf == '\n') {
-      std::cout << "fatal error in inserting cewll!" << std::endl;
+      std::cerr << "fatal error in inserting cewll!" << std::endl;
+      exit(1);
     }
   }
   str = str + data;

--- a/astra-sim/workload/CSVWriter.cc
+++ b/astra-sim/workload/CSVWriter.cc
@@ -10,26 +10,25 @@ CSVWriter::CSVWriter(std::string path, std::string name) {
   this->name = name;
 }
 void CSVWriter::initialize_csv(int rows, int cols) {
-  std::cout << "path to create csvs is: " << path << std::endl;
+  std::cout << "CSV path and filename: " << path + name << std::endl;
   do {
-    std::cout << "trying to open: " << path << std::endl;
     myFile.open(path + name, std::fstream::out);
   } while (!myFile.is_open());
+
   do {
     myFile.close();
   } while (myFile.is_open());
 
   do {
-    std::cout << "trying to open: " << path << std::endl;
     myFile.open(path + name, std::fstream::out | std::fstream::in);
   } while (!myFile.is_open());
 
   if (!myFile) {
     std::cerr << "Unable to open file: " << path << std::endl;
-    std::cerr << "This error is fatal. Please check your path and filename." << std::endl;
+    std::cerr << "This error is fatal. Please make sure the CSV write path exists." << std::endl;
     exit(1);
   } else {
-    std::cout << "Success in opening CSV file for writing the report " << std::endl;
+    std::cout << "Success in opening CSV file for writing the report." << std::endl;
   }
 
   myFile.seekp(0, std::ios_base::beg);

--- a/astra-sim/workload/Workload.cc
+++ b/astra-sim/workload/Workload.cc
@@ -1122,7 +1122,7 @@ int Workload::get_layer_numbers(std::string workload_input) {
     std::cerr << "This error is fatal. Please check your path and filename." << std::endl;
     exit(1);
   } else {
-    std::cout << "Success in opening file" << std::endl;
+    std::cout << "Success in opening workload file" << std::endl;
   }
   std::string dummyLine;
   std::getline(inFile, dummyLine);
@@ -1227,7 +1227,9 @@ bool Workload::initialize_workload(std::string name) {
     std::cerr << "This error is fatal. Please check your path and filename." << std::endl;
     exit(1);
   } else {
-    std::cout << "Success in opening file" << std::endl;
+    if(generator->id==0){
+      std::cout << "Success in opening workload file" << std::endl;
+    }
   }
   std::string type;
   int lines;

--- a/astra-sim/workload/Workload.cc
+++ b/astra-sim/workload/Workload.cc
@@ -1116,11 +1116,13 @@ void Workload::iterate_hybrid_parallel_DLRM() {
 }
 int Workload::get_layer_numbers(std::string workload_input) {
   std::ifstream inFile;
-  inFile.open("workload_inputs/" + workload_input + ".txt");
+  inFile.open("workload_inputs/" + workload_input);
   if (!inFile) {
-    std::cout << "Unable to open file: " << workload_input << std::endl;
+    std::cerr << "Unable to open file: " << workload_input << std::endl;
+    std::cerr << "This error is fatal. Please check your path and filename." << std::endl;
+    exit(1);
   } else {
-    std::cout << "success in openning file" << std::endl;
+    std::cout << "Success in opening file" << std::endl;
   }
   std::string dummyLine;
   std::getline(inFile, dummyLine);
@@ -1218,13 +1220,14 @@ bool Workload::initialize_workload(std::string name) {
   std::ifstream inFile;
   inFile.open(name);
   if (!inFile) {
-    std::cout << "Unable to open file: " << name << std::endl;
-    std::cout << "######### Exiting because unable to open the workload input "
+    std::cerr << "Unable to open file: " << name << std::endl;
+    std::cerr << "######### Exiting because unable to open the workload input "
                  "file #########"
               << std::endl;
-    return false;
+    std::cerr << "This error is fatal. Please check your path and filename." << std::endl;
+    exit(1);
   } else {
-    std::cout << "success in openning file" << std::endl;
+    std::cout << "Success in opening file" << std::endl;
   }
   std::string type;
   int lines;
@@ -1282,11 +1285,11 @@ bool Workload::initialize_workload(std::string name) {
           << DLRM_LAST_BOTTOM_LAYER << std::endl;
     }
   } else if (parallelismPolicy == ParallelismPolicy::None) {
-    std::cout << "######### Exiting because unable to decode the workload "
+    std::cerr << "######### Exiting because unable to decode the workload "
                  "parallelization strategy #########"
               << std::endl;
     inFile.close();
-    return false;
+    exit(1);
   }
   std::map<std::string, std::vector<bool>> general_involved_dimensions=
       decode_involved_dimensions(parallelismPolicy,model_parallel_npu_group);

--- a/examples/run_DLRM_analytical.sh
+++ b/examples/run_DLRM_analytical.sh
@@ -6,8 +6,8 @@ SCRIPT_DIR=$(dirname "$(realpath $0)")
 # Absolute paths to useful directories
 BINARY="${SCRIPT_DIR:?}"/../build/astra_analytical/build/AnalyticalAstra/bin/AnalyticalAstra
 NETWORK="${SCRIPT_DIR:?}"/../inputs/network/analytical/sample_Torus2D.json
-SYSTEM="${SCRIPT_DIR:?}"/../inputs/system/sample_torus_sys
-WORKLOAD="${SCRIPT_DIR:?}"/../inputs/workload/DLRM_HybridParallel
+SYSTEM="${SCRIPT_DIR:?}"/../inputs/system/sample_torus_sys.txt
+WORKLOAD="${SCRIPT_DIR:?}"/../inputs/workload/DLRM_HybridParallel.txt
 STATS="${SCRIPT_DIR:?}"/results/run_DLRM_analytical
 
 rm -rf "${STATS}"

--- a/examples/run_allreduce.sh
+++ b/examples/run_allreduce.sh
@@ -8,8 +8,8 @@ BINARY=""
 NETWORK=""
 CONFIG=""
 SYNTHETIC=""
-SYSTEM="${SCRIPT_DIR:?}"/../inputs/system/sample_torus_sys
-WORKLOAD="${SCRIPT_DIR:?}"/../inputs/workload/microAllReduce
+SYSTEM="${SCRIPT_DIR:?}"/../inputs/system/sample_torus_sys.txt
+WORKLOAD="${SCRIPT_DIR:?}"/../inputs/workload/microAllReduce.txt
 STATS="${SCRIPT_DIR:?}"/results/run_allreduce
 
 while getopts n: flag

--- a/examples/run_allreduce_analytical.sh
+++ b/examples/run_allreduce_analytical.sh
@@ -6,8 +6,8 @@ SCRIPT_DIR=$(dirname "$(realpath $0)")
 # Absolute paths to useful directories
 BINARY="${SCRIPT_DIR:?}"/../build/astra_analytical/build/AnalyticalAstra/bin/AnalyticalAstra
 NETWORK="${SCRIPT_DIR:?}"/../inputs/network/analytical/sample_switch.json
-SYSTEM="${SCRIPT_DIR:?}"/../inputs/system/sample_a2a_sys
-WORKLOAD="${SCRIPT_DIR:?}"/../inputs/workload/microAllReduce
+SYSTEM="${SCRIPT_DIR:?}"/../inputs/system/sample_a2a_sys.txt
+WORKLOAD="${SCRIPT_DIR:?}"/../inputs/workload/microAllReduce.txt
 STATS="${SCRIPT_DIR:?}"/results/run_allreduce_analytical
 
 rm -rf "${STATS}"

--- a/examples/run_alltoall.sh
+++ b/examples/run_alltoall.sh
@@ -8,8 +8,8 @@ BINARY=""
 NETWORK=""
 CONFIG=""
 SYNTHETIC=""
-SYSTEM="${SCRIPT_DIR:?}"/../inputs/system/sample_torus_sys
-WORKLOAD="${SCRIPT_DIR:?}"/../inputs/workload/microAllToAll
+SYSTEM="${SCRIPT_DIR:?}"/../inputs/system/sample_torus_sys.txt
+WORKLOAD="${SCRIPT_DIR:?}"/../inputs/workload/microAllToAll.txt
 STATS="${SCRIPT_DIR:?}"/results/run_alltoall
 
 while getopts n: flag

--- a/examples/run_alltoall_analytical.sh
+++ b/examples/run_alltoall_analytical.sh
@@ -6,8 +6,8 @@ SCRIPT_DIR=$(dirname "$(realpath $0)")
 # Absolute paths to useful directories
 BINARY="${SCRIPT_DIR:?}"/../build/astra_analytical/build/AnalyticalAstra/bin/AnalyticalAstra
 NETWORK="${SCRIPT_DIR:?}"/../inputs/network/analytical/sample_Torus2D.json
-SYSTEM="${SCRIPT_DIR:?}"/../inputs/system/sample_torus_sys
-WORKLOAD="${SCRIPT_DIR:?}"/../inputs/workload/microAllToAll
+SYSTEM="${SCRIPT_DIR:?}"/../inputs/system/sample_torus_sys.txt
+WORKLOAD="${SCRIPT_DIR:?}"/../inputs/workload/microAllToAll.txt
 STATS="${SCRIPT_DIR:?}"/results/run_alltoall_analytical
 
 rm -rf "${STATS}"

--- a/examples/run_multi.sh
+++ b/examples/run_multi.sh
@@ -6,8 +6,8 @@ SCRIPT_DIR=$(dirname "$(realpath $0)")
 # Absolute paths to useful directories
 BINARY="${SCRIPT_DIR:?}"/../build/astra_analytical/build/AnalyticalAstra/bin/AnalyticalAstra
 NETWORK="${SCRIPT_DIR:?}"/../inputs/network/analytical/sample_Torus2D.json
-SYSTEM="${SCRIPT_DIR:?}"/../inputs/system/sample_torus_sys
-WORKLOAD="${SCRIPT_DIR:?}"/../inputs/workload/microAllReduce
+SYSTEM="${SCRIPT_DIR:?}"/../inputs/system/sample_torus_sys.txt
+WORKLOAD="${SCRIPT_DIR:?}"/../inputs/workload/microAllReduce.txt
 STATS="${SCRIPT_DIR:?}"/results/run_multi
 
 rm -rf "${STATS}"


### PR DESCRIPTION
The code will now exit immediately on certain errors. I went through and tried to find spots where things should be send to stderr and in other spots made it so we exit with exit code 1.

I also added a virtual destructor to ComputeAPI since we see that error depending on compile time options. It may not need the `= 0` portion of it, I'm not sure what the intent with some of the things with the ComputeAPI but it compiles and runs with that included.