### PR TITLE
Change `generate_time()` argument to Tick to prevent overflow

### DIFF
--- a/astra-sim/system/Sys.cc
+++ b/astra-sim/system/Sys.cc
@@ -1753,7 +1753,7 @@ void Sys::handleEvent(void* arg) {
     delete rcehd;
   }
 }
-timespec_t Sys::generate_time(int cycles) {
+timespec_t Sys::generate_time(Tick cycles) {
   timespec_t tmp = NI->sim_get_time();
   double addition = cycles * ((double)CLOCK_PERIOD);
   tmp.time_val = addition;

--- a/astra-sim/system/Sys.cc
+++ b/astra-sim/system/Sys.cc
@@ -418,8 +418,7 @@ int Sys::get_priority(SchedulingPolicy pref_scheduling) {
     } else {
       return priority_counter--;
     }
-  }
-  else{
+  } else {
     sys_panic("comm priority is unknown!");
     return -1;
   }
@@ -1566,7 +1565,7 @@ void Sys::insert_stream(std::list<BaseStream*>* queue, BaseStream* baseStream) {
     }
   } else if (
       intra_dimension_scheduling == IntraDimensionScheduling::SmallestFirst) {
-    if(baseStream->phases_to_go.size()==1){
+    if (baseStream->phases_to_go.size() == 1) {
       it = queue->end();
     }
     while (it != queue->end()) {
@@ -1574,8 +1573,12 @@ void Sys::insert_stream(std::list<BaseStream*>* queue, BaseStream* baseStream) {
         std::advance(it, 1);
         continue;
       } else if (
-          std::max((*it)->my_current_phase.initial_data_size,(*it)->my_current_phase.final_data_size) <
-          std::max(baseStream->my_current_phase.initial_data_size,baseStream->my_current_phase.final_data_size)) {
+          std::max(
+              (*it)->my_current_phase.initial_data_size,
+              (*it)->my_current_phase.final_data_size) <
+          std::max(
+              baseStream->my_current_phase.initial_data_size,
+              baseStream->my_current_phase.final_data_size)) {
         std::advance(it, 1);
         continue;
       } else {

--- a/astra-sim/system/Sys.hh
+++ b/astra-sim/system/Sys.hh
@@ -323,7 +323,7 @@ class Sys : public Callable {
   int determine_chunk_size(uint64_t size, ComType type);
   int get_priority(SchedulingPolicy pref_scheduling);
   static void handleEvent(void* arg);
-  timespec_t generate_time(int cycles);
+  timespec_t generate_time(Tick cycles);
 };
 } // namespace AstraSim
 #endif


### PR DESCRIPTION
Fixed `generate_time(int cycles)` into `generate_time(Tick cycles)` (`Tick` is `unsigned long long`)