### PR TITLE
Update README to discuss old dependencies for ns3

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ $ git submodule update
 3. The results of example script runs will be dumped inside `examples/results/` path. 
 
 #### Instructions for compiling & running NS3 as the network simulator
+> This version of ns3 requires gcc-5, g++-5, and python2.7. It also requires the `python` command to default to `python2.7`. 
+> Astrasim 2.0 will include a version of ns3 which does not need the above ancient dependencies.
+
 1. Check-out to the **ns3_interface_tmp2** branch by running `git checkout ns3_interface_tmp2` .
 2. Update the submodules by typing `git submodule init & git submodule update`. The ns3 backend is hosted at https://github.com/DartingMelody/ns3-interface.
 3. Go to the ns3 directory: `cd extern/network_backend/ns3-interface/simulation/` and run `./waf configure` (only required once)


### PR DESCRIPTION
Update README to indicate that one needs gcc 5 and python2.7 to run the old ns3. 
Also mention that the ns3 in AstraSim 2.0 will not need these dependencies.