### PR TITLE
Make ns3-interface submodule track main branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,4 @@
 [submodule "extern/network_backend/ns3-interface"]
 	path = extern/network_backend/ns3-interface
 	url = https://github.com/astra-sim/astra-network-ns3.git
+	branch = main


### PR DESCRIPTION
The old ns3-interface recently went through some branch clipping (some old branches were deleted/main branch is updated to reflect changes) & content change (a README will be added soon, etc.)
This PR will let us avoid having to create a commit every time there is a change in the ns3-interface submodule