### PR TITLE
proposed changes to be compatible with the network simulator integration

### DIFF
--- a/astra-sim/system/PacketBundle.cc
+++ b/astra-sim/system/PacketBundle.cc
@@ -54,10 +54,15 @@ void PacketBundle::send_to_NPU() {
 void PacketBundle::call(EventType event, CallData* data) {
   if (needs_processing == true) {
     needs_processing = false;
+    if (sys->mem == nullptr){
+	this->delay = 10;
+    }else{
+
     this->delay =
       sys->mem->get_local_mem_runtime((uint64_t)size) // write
       + sys->mem->get_local_mem_runtime((uint64_t)size) // read
       + sys->mem->get_local_mem_runtime((uint64_t)size); // read
+    }
     sys->try_register_event(
         this, EventType::CommProcessingFinished, data, this->delay);
     return;

--- a/astra-sim/system/Sys.cc
+++ b/astra-sim/system/Sys.cc
@@ -554,7 +554,7 @@ void Sys::try_register_event(
       make_tuple(callable, event, callData));
   if (should_schedule) {
     timespec_t tmp;
-    tmp.time_val = Sys::boostedTick() + cycles;
+    tmp.time_val = cycles;
     BasicEventHandlerData* data =
         new BasicEventHandlerData(id, EventType::CallEvents);
     data->sys_id = id;

--- a/astra-sim/system/Sys.cc
+++ b/astra-sim/system/Sys.cc
@@ -161,7 +161,7 @@ Sys::Sys(
   this->roofline = nullptr;
 
   this->mem = mem;
-  this->mem->set_sys(id, this);
+ // this->mem->set_sys(id, this);
   this->local_mem_bw = 0;
 
   this->memBus = nullptr;


### PR DESCRIPTION
Hi Astrasim Team, 

I updated AstraSim with following changes:
(1) the current version of AstraSim assumes that the sys->mem is not null, I added the fix when the sys->mem is NULL,  to be compatible with the network simulators implementation;
(2) the time in the sim_schedule is the delta in the past network simulator implementation, now it is the absolute time. I still revert it to be the delta to be compatible with the past network simulator integration. I am happy to talk if you think using absolute time is better. 

Thanks,
-Yanfang