### PR TITLE
fix issue_comm error

### DIFF
--- a/astra-sim/workload/Workload.cc
+++ b/astra-sim/workload/Workload.cc
@@ -124,7 +124,11 @@ void Workload::issue(shared_ptr<Chakra::ETFeederNode> node) {
            << ",node->id=" << node->getChakraNode()->id()
            << ",node->name=" << node->getChakraNode()->name() << endl;
     }
-    issue_comm(node);
+    if (node->getChakraNode()->comm_size() == 0) {
+      skip_invalid(node);
+    } else {
+      issue_comm(node);
+    }
   } else if (
       node->getChakraNode()->node_type() == ChakraNodeType::INVALID_NODE) {
     skip_invalid(node);


### PR DESCRIPTION
If the `comm_size` of a `COMM_COLL_NODE` node is 0 and the `issue_comm` function is called, the child nodes of this node cannot be released.