### PR TITLE
Remove ns3 specific statement from #include

### DIFF
--- a/astra-sim/network_frontend/ns3/AstraSimNetwork.cc
+++ b/astra-sim/network_frontend/ns3/AstraSimNetwork.cc
@@ -1,5 +1,5 @@
-#include "ns3/AstraNetworkAPI.hh"
-#include "ns3/Sys.hh"
+#include "astra-sim/system/AstraNetworkAPI.hh"
+#include "astra-sim/system/Sys.hh"
 #include "ns3/applications-module.h"
 #include "ns3/core-module.h"
 #include "ns3/csma-module.h"

--- a/astra-sim/network_frontend/ns3/AstraSimNetwork_a2a.cc
+++ b/astra-sim/network_frontend/ns3/AstraSimNetwork_a2a.cc
@@ -1,4 +1,4 @@
-#include "ns3/AstraNetworkAPI.hh"
+#include "astra-sim/system/AstraNetworkAPI.hh"
 #include<iostream>
 #include <stdio.h>
 #include <execinfo.h>
@@ -16,7 +16,7 @@
 #include "ns3/applications-module.h"
 #include "ns3/internet-module.h"
 #include "ns3/csma-module.h"
-#include "ns3/Sys.hh"
+#include "astra-sim/system/Sys.hh"
 #include <time.h> 
 // #include "RoCE.h"
 //#include<type_info>

--- a/astra-sim/network_frontend/ns3/wscript
+++ b/astra-sim/network_frontend/ns3/wscript
@@ -1,58 +1,13 @@
 ## -*- Mode: python; py-indent-offset: 4; indent-tabs-mode: nil; coding: utf-8; -*-
 
+import fnmatch 
+import glob
+import os
+
 def build(bld):
     module = bld.create_ns3_module('applications', ['internet', 'config-store', 'tools', 'point-to-point'])
     module.source = [
         'model/bulk-send-application.cc',
-		'../../../../../../astra-sim/workload/CSVWriter.cc',
-		'../../../../../../astra-sim/workload/Layer.cc',
-		'../../../../../../astra-sim/workload/Workload.cc',
-		'../../../../../../astra-sim/system/BaseStream.cc',
-        '../../../../../../astra-sim/system/BasicEventHandlerData.cc',
-        '../../../../../../astra-sim/system/CollectivePhase.cc',
-        '../../../../../../astra-sim/system/DataSet.cc',
-        '../../../../../../astra-sim/system/DMA_Request.cc',
-        '../../../../../../astra-sim/system/IntData.cc',
-        '../../../../../../astra-sim/system/LogGP.cc',
-        '../../../../../../astra-sim/system/MemBus.cc',
-        '../../../../../../astra-sim/system/MemMovRequest.cc',
-        '../../../../../../astra-sim/system/MyPacket.cc',
-        '../../../../../../astra-sim/system/NetworkStat.cc',
-        '../../../../../../astra-sim/system/PacketBundle.cc',
-        '../../../../../../astra-sim/system/QueueLevelHandler.cc',
-        '../../../../../../astra-sim/system/QueueLevels.cc',
-        '../../../../../../astra-sim/system/RecvPacketEventHadndlerData.cc',
-        '../../../../../../astra-sim/system/SendPacketEventHandlerData.cc',
-        '../../../../../../astra-sim/system/RendezvousRecvData.cc',
-        '../../../../../../astra-sim/system/RendezvousSendData.cc',
-        '../../../../../../astra-sim/system/SharedBusStat.cc',
-        '../../../../../../astra-sim/system/SimRecvCaller.cc',
-        '../../../../../../astra-sim/system/SimSendCaller.cc',
-        '../../../../../../astra-sim/system/StatData.cc',
-        '../../../../../../astra-sim/system/StreamBaseline.cc',
-        '../../../../../../astra-sim/system/StreamStat.cc',
-        '../../../../../../astra-sim/system/Sys.cc',
-        '../../../../../../astra-sim/system/Usage.cc',
-        '../../../../../../astra-sim/system/UsageTracker.cc',
-		'../../../../../../astra-sim/system/fast-backend/FastBackEnd.cc',
-		'../../../../../../astra-sim/system/collective/Algorithm.cc',
-        '../../../../../../astra-sim/system/collective/AllToAll.cc',
-        '../../../../../../astra-sim/system/collective/DoubleBinaryTreeAllReduce.cc',
-        '../../../../../../astra-sim/system/collective/HalvingDoubling.cc',
-        '../../../../../../astra-sim/system/collective/Ring.cc',
-		'../../../../../../astra-sim/system/memory/SimpleMemory.cc',
-		'../../../../../../astra-sim/system/scheduling/OfflineGreedy.cc',
-		'../../../../../../astra-sim/system/topology/BasicLogicalTopology.cc',
-        '../../../../../../astra-sim/system/topology/BinaryTree.cc',
-        '../../../../../../astra-sim/system/topology/ComplexLogicalTopology.cc',
-        '../../../../../../astra-sim/system/topology/DoubleBinaryTreeTopology.cc',
-        '../../../../../../astra-sim/system/topology/GeneralComplexTopology.cc',
-        '../../../../../../astra-sim/system/topology/LocalRingGlobalBinaryTree.cc',
-        '../../../../../../astra-sim/system/topology/LocalRingNodeA2AGlobalDBT.cc',
-        '../../../../../../astra-sim/system/topology/LogicalTopology.cc',
-        '../../../../../../astra-sim/system/topology/Node.cc',
-        '../../../../../../astra-sim/system/topology/RingTopology.cc',
-        '../../../../../../astra-sim/system/topology/Torus3D.cc',
         '../../scratch/workerQueue.cc',
 	'model/onoff-application.cc',
         'model/packet-sink.cc',
@@ -79,6 +34,15 @@ def build(bld):
 		'model/rdma-client.cc',
 		'helper/rdma-client-helper.cc',
         ]
+    
+    for dirpath, dirs, files in os.walk('./src/applications/astra-sim/'):
+        if 'network_frontend' in dirpath:
+            print(dirpath, files)
+            continue
+        for filename in fnmatch.filter(files, "*.cc"):
+            file = os.path.join(dirpath, filename)
+            file = file.replace("./src/applications/", "")
+            module.source.append(file)
 
     applications_test = bld.create_ns3_module_test_library('applications')
     applications_test.source = [
@@ -91,63 +55,6 @@ def build(bld):
         'model/bulk-send-application.h',
         '../../scratch/workerQueue.h',
 	'../../scratch/myHeader.h',
-	'../../../../../../astra-sim/workload/CSVWriter.hh',
-	'../../../../../../astra-sim/workload/Layer.hh',
-	'../../../../../../astra-sim/workload/Workload.hh',
-	'../../../../../../astra-sim/system/AstraNetworkAPI.hh',
-	'../../../../../../astra-sim/system/AstraMemoryAPI.hh',
-	'../../../../../../astra-sim/system/AstraSimDataAPI.hh',
-	'../../../../../../astra-sim/system/AstraComputeAPI.hh',
-	'../../../../../../astra-sim/system/BaseStream.hh',
-	'../../../../../../astra-sim/system/BasicEventHandlerData.hh',
-	'../../../../../../astra-sim/system/Callable.hh',
-	'../../../../../../astra-sim/system/CallData.hh',
-	'../../../../../../astra-sim/system/CollectivePhase.hh',
-	'../../../../../../astra-sim/system/Common.hh',
-	'../../../../../../astra-sim/system/DataSet.hh',
-	'../../../../../../astra-sim/system/DMA_Request.hh',
-	'../../../../../../astra-sim/system/IntData.hh',
-	'../../../../../../astra-sim/system/LogGP.hh',
-	'../../../../../../astra-sim/system/MemBus.hh',
-	'../../../../../../astra-sim/system/MemMovRequest.hh',
-	'../../../../../../astra-sim/system/MyPacket.hh',
-	'../../../../../../astra-sim/system/NetworkStat.hh',
-	'../../../../../../astra-sim/system/PacketBundle.hh',
-	'../../../../../../astra-sim/system/QueueLevelHandler.hh',
-	'../../../../../../astra-sim/system/QueueLevels.hh',
-	'../../../../../../astra-sim/system/RecvPacketEventHadndlerData.hh',
-	'../../../../../../astra-sim/system/SendPacketEventHandlerData.hh',
-	'../../../../../../astra-sim/system/RendezvousRecvData.hh',
-	'../../../../../../astra-sim/system/RendezvousSendData.hh',
-	'../../../../../../astra-sim/system/SharedBusStat.hh',
-	'../../../../../../astra-sim/system/SimRecvCaller.hh',
-	'../../../../../../astra-sim/system/SimSendCaller.hh',
-	'../../../../../../astra-sim/system/StatData.hh',
-	'../../../../../../astra-sim/system/StreamBaseline.hh',
-	'../../../../../../astra-sim/system/StreamStat.hh',
-	'../../../../../../astra-sim/system/Sys.hh',
-	'../../../../../../astra-sim/system/Usage.hh',
-	'../../../../../../astra-sim/system/UsageTracker.hh',
-	'../../../../../../astra-sim/system/fast-backend/FastBackEnd.hh',
-	'../../../../../../astra-sim/system/collective/Algorithm.hh',
-	'../../../../../../astra-sim/system/collective/AllToAll.hh',
-	'../../../../../../astra-sim/system/collective/DoubleBinaryTreeAllReduce.hh',
-	'../../../../../../astra-sim/system/collective/HalvingDoubling.hh',
-	'../../../../../../astra-sim/system/collective/Ring.hh',
-	'../../../../../../astra-sim/system/memory/SimpleMemory.hh',
-	'../../../../../../astra-sim/system/scheduling/OfflineGreedy.hh',
-	'../../../../../../astra-sim/system/topology/BasicLogicalTopology.hh',
-	'../../../../../../astra-sim/system/topology/BinaryTree.hh',
-	'../../../../../../astra-sim/system/topology/ComplexLogicalTopology.hh',
-	'../../../../../../astra-sim/system/topology/ComputeNode.hh',
-	'../../../../../../astra-sim/system/topology/DoubleBinaryTreeTopology.hh',
-	'../../../../../../astra-sim/system/topology/GeneralComplexTopology.hh',
-	'../../../../../../astra-sim/system/topology/LocalRingGlobalBinaryTree.hh',
-	'../../../../../../astra-sim/system/topology/LocalRingNodeA2AGlobalDBT.hh',
-	'../../../../../../astra-sim/system/topology/LogicalTopology.hh',
-	'../../../../../../astra-sim/system/topology/Node.hh',
-	'../../../../../../astra-sim/system/topology/RingTopology.hh',
-	'../../../../../../astra-sim/system/topology/Torus3D.hh',
 	'model/onoff-application.h',
         'model/packet-sink.h',
         'model/ping6.h',
@@ -173,5 +80,11 @@ def build(bld):
 		'model/rdma-client.h',
 		'helper/rdma-client-helper.h',
         ]
+
+    for dirpath, dirs, files in os.walk('./src/applications/astra-sim/'):
+        for filename in fnmatch.filter(files, '*.hh'):
+            file = os.path.join(dirpath, filename)
+            file = file.replace("./src/applications/", "")
+            headers.source.append(file)
 
     bld.ns3_python_bindings()

--- a/astra-sim/system/BaseStream.hh
+++ b/astra-sim/system/BaseStream.hh
@@ -18,13 +18,13 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/Callable.hh"
-#include "ns3/CollectivePhase.hh"
-#include "ns3/Common.hh"
-#include "ns3/DataSet.hh"
-#include "ns3/StreamStat.hh"
-#include "ns3/Sys.hh"
-#include "ns3/LogicalTopology.hh"
+#include "Callable.hh"
+#include "CollectivePhase.hh"
+#include "Common.hh"
+#include "DataSet.hh"
+#include "StreamStat.hh"
+#include "Sys.hh"
+#include "astra-sim/system/topology/LogicalTopology.hh"
 
 namespace AstraSim {
 class RecvPacketEventHadndlerData;

--- a/astra-sim/system/BasicEventHandlerData.hh
+++ b/astra-sim/system/BasicEventHandlerData.hh
@@ -18,8 +18,8 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/CallData.hh"
-#include "ns3/Common.hh"
+#include "CallData.hh"
+#include "Common.hh"
 
 namespace AstraSim {
 class Sys;

--- a/astra-sim/system/CollectivePhase.hh
+++ b/astra-sim/system/CollectivePhase.hh
@@ -18,7 +18,7 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/Common.hh"
+#include "Common.hh"
 
 namespace AstraSim {
 class Sys;

--- a/astra-sim/system/DMA_Request.hh
+++ b/astra-sim/system/DMA_Request.hh
@@ -18,8 +18,8 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/Callable.hh"
-#include "ns3/Common.hh"
+#include "Callable.hh"
+#include "Common.hh"
 
 namespace AstraSim {
 class DMA_Request {

--- a/astra-sim/system/DataSet.hh
+++ b/astra-sim/system/DataSet.hh
@@ -18,10 +18,10 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/CallData.hh"
-#include "ns3/Callable.hh"
-#include "ns3/Common.hh"
-#include "ns3/StreamStat.hh"
+#include "CallData.hh"
+#include "Callable.hh"
+#include "Common.hh"
+#include "StreamStat.hh"
 
 namespace AstraSim {
 class DataSet : public Callable, public StreamStat {

--- a/astra-sim/system/LogGP.hh
+++ b/astra-sim/system/LogGP.hh
@@ -18,10 +18,10 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/Callable.hh"
-#include "ns3/Common.hh"
-#include "ns3/MemBus.hh"
-#include "ns3/MemMovRequest.hh"
+#include "Callable.hh"
+#include "Common.hh"
+#include "MemBus.hh"
+#include "MemMovRequest.hh"
 
 namespace AstraSim {
 class Sys;

--- a/astra-sim/system/MemBus.hh
+++ b/astra-sim/system/MemBus.hh
@@ -18,8 +18,8 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/Callable.hh"
-#include "ns3/Common.hh"
+#include "Callable.hh"
+#include "Common.hh"
 
 namespace AstraSim {
 class Sys;

--- a/astra-sim/system/MemMovRequest.hh
+++ b/astra-sim/system/MemMovRequest.hh
@@ -18,9 +18,9 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/Callable.hh"
-#include "ns3/Common.hh"
-#include "ns3/SharedBusStat.hh"
+#include "Callable.hh"
+#include "Common.hh"
+#include "SharedBusStat.hh"
 
 namespace AstraSim {
 class Sys;

--- a/astra-sim/system/MyPacket.hh
+++ b/astra-sim/system/MyPacket.hh
@@ -18,8 +18,8 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/Callable.hh"
-#include "ns3/Common.hh"
+#include "Callable.hh"
+#include "Common.hh"
 
 namespace AstraSim {
 class MyPacket : public Callable {

--- a/astra-sim/system/NetworkStat.hh
+++ b/astra-sim/system/NetworkStat.hh
@@ -18,7 +18,7 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/Common.hh"
+#include "Common.hh"
 
 namespace AstraSim {
 class NetworkStat {

--- a/astra-sim/system/PacketBundle.hh
+++ b/astra-sim/system/PacketBundle.hh
@@ -18,11 +18,11 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/BaseStream.hh"
-#include "ns3/Callable.hh"
-#include "ns3/Common.hh"
-#include "ns3/MemBus.hh"
-#include "ns3/MyPacket.hh"
+#include "BaseStream.hh"
+#include "Callable.hh"
+#include "Common.hh"
+#include "MemBus.hh"
+#include "MyPacket.hh"
 
 namespace AstraSim {
 class Sys;

--- a/astra-sim/system/QueueLevelHandler.hh
+++ b/astra-sim/system/QueueLevelHandler.hh
@@ -18,8 +18,8 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/AstraNetworkAPI.hh"
-#include "ns3/RingTopology.hh"
+#include "AstraNetworkAPI.hh"
+#include "astra-sim/system/topology/RingTopology.hh"
 
 namespace AstraSim {
 class QueueLevelHandler {

--- a/astra-sim/system/QueueLevels.hh
+++ b/astra-sim/system/QueueLevels.hh
@@ -18,9 +18,9 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/AstraNetworkAPI.hh"
-#include "ns3/QueueLevelHandler.hh"
-#include "ns3/RingTopology.hh"
+#include "AstraNetworkAPI.hh"
+#include "QueueLevelHandler.hh"
+#include "astra-sim/system/topology/RingTopology.hh"
 
 namespace AstraSim {
 class QueueLevels {

--- a/astra-sim/system/RecvPacketEventHadndlerData.hh
+++ b/astra-sim/system/RecvPacketEventHadndlerData.hh
@@ -18,8 +18,8 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/BaseStream.hh"
-#include "ns3/BasicEventHandlerData.hh"
+#include "BaseStream.hh"
+#include "BasicEventHandlerData.hh"
 
 namespace AstraSim {
 class RecvPacketEventHadndlerData : public BasicEventHandlerData,

--- a/astra-sim/system/RendezvousRecvData.hh
+++ b/astra-sim/system/RendezvousRecvData.hh
@@ -18,9 +18,9 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/BasicEventHandlerData.hh"
-#include "ns3/Common.hh"
-#include "ns3/SimRecvCaller.hh"
+#include "BasicEventHandlerData.hh"
+#include "Common.hh"
+#include "SimRecvCaller.hh"
 
 namespace AstraSim {
 class Sys;

--- a/astra-sim/system/RendezvousSendData.hh
+++ b/astra-sim/system/RendezvousSendData.hh
@@ -18,9 +18,9 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/BasicEventHandlerData.hh"
-#include "ns3/Common.hh"
-#include "ns3/SimSendCaller.hh"
+#include "BasicEventHandlerData.hh"
+#include "Common.hh"
+#include "SimSendCaller.hh"
 
 namespace AstraSim {
 class Sys;

--- a/astra-sim/system/SendPacketEventHandlerData.hh
+++ b/astra-sim/system/SendPacketEventHandlerData.hh
@@ -20,10 +20,10 @@ class SendPacketEventHandlerData {};
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/BaseStream.hh"
-#include "ns3/BasicEventHandlerData.hh"
-#include "ns3/Common.hh"
-#include "ns3/Sys.hh"
+#include "BaseStream.hh"
+#include "BasicEventHandlerData.hh"
+#include "Common.hh"
+#include "Sys.hh"
 
 namespace AstraSim {
 class SendPacketEventHandlerData : public BasicEventHandlerData,

--- a/astra-sim/system/SharedBusStat.hh
+++ b/astra-sim/system/SharedBusStat.hh
@@ -18,7 +18,7 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/CallData.hh"
+#include "CallData.hh"
 
 namespace AstraSim {
 class SharedBusStat : public CallData {

--- a/astra-sim/system/SimRecvCaller.hh
+++ b/astra-sim/system/SimRecvCaller.hh
@@ -18,9 +18,9 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/CallData.hh"
-#include "ns3/Callable.hh"
-#include "ns3/Common.hh"
+#include "CallData.hh"
+#include "Callable.hh"
+#include "Common.hh"
 
 namespace AstraSim {
 class Sys;

--- a/astra-sim/system/SimSendCaller.hh
+++ b/astra-sim/system/SimSendCaller.hh
@@ -18,9 +18,9 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/CallData.hh"
-#include "ns3/Callable.hh"
-#include "ns3/Common.hh"
+#include "CallData.hh"
+#include "Callable.hh"
+#include "Common.hh"
 
 namespace AstraSim {
 class Sys;

--- a/astra-sim/system/StatData.hh
+++ b/astra-sim/system/StatData.hh
@@ -18,8 +18,8 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/CallData.hh"
-#include "ns3/Common.hh"
+#include "CallData.hh"
+#include "Common.hh"
 namespace AstraSim {
 class StatData : public CallData {
  public:

--- a/astra-sim/system/StreamBaseline.hh
+++ b/astra-sim/system/StreamBaseline.hh
@@ -18,10 +18,10 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/BaseStream.hh"
-#include "ns3/CollectivePhase.hh"
-#include "ns3/Common.hh"
-#include "ns3/RecvPacketEventHadndlerData.hh"
+#include "BaseStream.hh"
+#include "CollectivePhase.hh"
+#include "Common.hh"
+#include "RecvPacketEventHadndlerData.hh"
 
 namespace AstraSim {
 class Sys;

--- a/astra-sim/system/StreamStat.hh
+++ b/astra-sim/system/StreamStat.hh
@@ -18,9 +18,9 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/Common.hh"
-#include "ns3/NetworkStat.hh"
-#include "ns3/SharedBusStat.hh"
+#include "Common.hh"
+#include "NetworkStat.hh"
+#include "SharedBusStat.hh"
 
 namespace AstraSim {
 class StreamStat : public SharedBusStat, public NetworkStat {

--- a/astra-sim/system/Sys.hh
+++ b/astra-sim/system/Sys.hh
@@ -18,15 +18,15 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/AstraMemoryAPI.hh"
-#include "ns3/AstraNetworkAPI.hh"
-#include "ns3/Callable.hh"
-#include "ns3/CollectivePhase.hh"
-#include "ns3/Common.hh"
-#include "ns3/SendPacketEventHandlerData.hh"
-#include "ns3/UsageTracker.hh"
-#include "ns3/RingTopology.hh"
-#include "ns3/Workload.hh"
+#include "AstraMemoryAPI.hh"
+#include "AstraNetworkAPI.hh"
+#include "Callable.hh"
+#include "CollectivePhase.hh"
+#include "Common.hh"
+#include "SendPacketEventHandlerData.hh"
+#include "UsageTracker.hh"
+#include "astra-sim/system/topology/RingTopology.hh"
+#include "astra-sim/workload/Workload.hh"
 
 namespace AstraSim {
 class MemBus;

--- a/astra-sim/system/Usage.hh
+++ b/astra-sim/system/Usage.hh
@@ -18,7 +18,7 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/Common.hh"
+#include "Common.hh"
 
 namespace AstraSim {
 class Usage {

--- a/astra-sim/system/UsageTracker.hh
+++ b/astra-sim/system/UsageTracker.hh
@@ -18,10 +18,10 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/Callable.hh"
-#include "ns3/Common.hh"
-#include "ns3/Usage.hh"
-#include "ns3/CSVWriter.hh"
+#include "Callable.hh"
+#include "Common.hh"
+#include "Usage.hh"
+#include "astra-sim/workload/CSVWriter.hh"
 
 namespace AstraSim {
 class UsageTracker {

--- a/astra-sim/system/collective/Algorithm.hh
+++ b/astra-sim/system/collective/Algorithm.hh
@@ -18,11 +18,11 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/BaseStream.hh"
-#include "ns3/CallData.hh"
-#include "ns3/Callable.hh"
-#include "ns3/Common.hh"
-#include "ns3/LogicalTopology.hh"
+#include "astra-sim/system/BaseStream.hh"
+#include "astra-sim/system/CallData.hh"
+#include "astra-sim/system/Callable.hh"
+#include "astra-sim/system/Common.hh"
+#include "astra-sim/system/topology/LogicalTopology.hh"
 
 namespace AstraSim {
 class Algorithm : public Callable {

--- a/astra-sim/system/collective/AllToAll.hh
+++ b/astra-sim/system/collective/AllToAll.hh
@@ -18,10 +18,10 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/Ring.hh"
-#include "ns3/CallData.hh"
-#include "ns3/Common.hh"
-#include "ns3/RingTopology.hh"
+#include "Ring.hh"
+#include "astra-sim/system/CallData.hh"
+#include "astra-sim/system/Common.hh"
+#include "astra-sim/system/topology/RingTopology.hh"
 
 namespace AstraSim {
 class AllToAll : public Ring {

--- a/astra-sim/system/collective/DoubleBinaryTreeAllReduce.hh
+++ b/astra-sim/system/collective/DoubleBinaryTreeAllReduce.hh
@@ -19,10 +19,10 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/Algorithm.hh"
-#include "ns3/CallData.hh"
-#include "ns3/Common.hh"
-#include "ns3/BinaryTree.hh"
+#include "Algorithm.hh"
+#include "astra-sim/system/CallData.hh"
+#include "astra-sim/system/Common.hh"
+#include "astra-sim/system/topology/BinaryTree.hh"
 
 namespace AstraSim {
 class DoubleBinaryTreeAllReduce : public Algorithm {

--- a/astra-sim/system/collective/HalvingDoubling.hh
+++ b/astra-sim/system/collective/HalvingDoubling.hh
@@ -18,11 +18,11 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/Algorithm.hh"
-#include "ns3/Common.hh"
-#include "ns3/MemBus.hh"
-#include "ns3/MyPacket.hh"
-#include "ns3/RingTopology.hh"
+#include "Algorithm.hh"
+#include "astra-sim/system/Common.hh"
+#include "astra-sim/system/MemBus.hh"
+#include "astra-sim/system/MyPacket.hh"
+#include "astra-sim/system/topology/RingTopology.hh"
 
 namespace AstraSim {
 class HalvingDoubling : public Algorithm {

--- a/astra-sim/system/collective/Ring.hh
+++ b/astra-sim/system/collective/Ring.hh
@@ -18,11 +18,11 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/Algorithm.hh"
-#include "ns3/Common.hh"
-#include "ns3/MemBus.hh"
-#include "ns3/MyPacket.hh"
-#include "ns3/RingTopology.hh"
+#include "Algorithm.hh"
+#include "astra-sim/system/Common.hh"
+#include "astra-sim/system/MemBus.hh"
+#include "astra-sim/system/MyPacket.hh"
+#include "astra-sim/system/topology/RingTopology.hh"
 
 namespace AstraSim {
 class Ring : public Algorithm {

--- a/astra-sim/system/fast-backend/FastBackEnd.hh
+++ b/astra-sim/system/fast-backend/FastBackEnd.hh
@@ -6,7 +6,7 @@
 #include <map>
 #include <tuple>
 
-#include "ns3/AstraNetworkAPI.hh"
+#include "astra-sim/system/AstraNetworkAPI.hh"
 namespace AstraSim {
 class FastBackEnd;
 

--- a/astra-sim/system/memory/SimpleMemory.hh
+++ b/astra-sim/system/memory/SimpleMemory.hh
@@ -5,8 +5,8 @@ LICENSE file in the root directory of this source tree.
 
 #ifndef __SIMPLEMEMORY_HH__
 #define __SIMPLEMEMORY_HH__
-#include "ns3/AstraMemoryAPI.hh"
-#include "ns3/AstraNetworkAPI.hh"
+#include "astra-sim/system/AstraMemoryAPI.hh"
+#include "astra-sim/system/AstraNetworkAPI.hh"
 namespace AstraSim {
 class SimpleMemory : public AstraMemoryAPI {
  public:

--- a/astra-sim/system/scheduling/OfflineGreedy.hh
+++ b/astra-sim/system/scheduling/OfflineGreedy.hh
@@ -5,8 +5,8 @@ LICENSE file in the root directory of this source tree.
 
 #ifndef __OFFLINEGREEDY_HH__
 #define __OFFLINEGREEDY_HH__
-#include "ns3/Common.hh"
-#include "ns3/Sys.hh"
+#include "astra-sim/system/Common.hh"
+#include "astra-sim/system/Sys.hh"
 #include "vector"
 namespace AstraSim {
 class DimElapsedTime {

--- a/astra-sim/system/topology/BasicLogicalTopology.hh
+++ b/astra-sim/system/topology/BasicLogicalTopology.hh
@@ -18,8 +18,8 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/LogicalTopology.hh"
-#include "ns3/Common.hh"
+#include "LogicalTopology.hh"
+#include "astra-sim/system/Common.hh"
 
 namespace AstraSim {
 class BasicLogicalTopology : public LogicalTopology {

--- a/astra-sim/system/topology/BinaryTree.hh
+++ b/astra-sim/system/topology/BinaryTree.hh
@@ -18,9 +18,9 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/BasicLogicalTopology.hh"
-#include "ns3/Node.hh"
-#include "ns3/Common.hh"
+#include "BasicLogicalTopology.hh"
+#include "Node.hh"
+#include "astra-sim/system/Common.hh"
 
 namespace AstraSim {
 class BinaryTree : public BasicLogicalTopology {

--- a/astra-sim/system/topology/ComplexLogicalTopology.hh
+++ b/astra-sim/system/topology/ComplexLogicalTopology.hh
@@ -18,8 +18,8 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/LogicalTopology.hh"
-#include "ns3/Common.hh"
+#include "LogicalTopology.hh"
+#include "astra-sim/system/Common.hh"
 
 namespace AstraSim {
 class ComplexLogicalTopology : public LogicalTopology {

--- a/astra-sim/system/topology/DoubleBinaryTreeTopology.hh
+++ b/astra-sim/system/topology/DoubleBinaryTreeTopology.hh
@@ -18,9 +18,9 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/ComplexLogicalTopology.hh"
-#include "ns3/LocalRingGlobalBinaryTree.hh"
-#include "ns3/Common.hh"
+#include "ComplexLogicalTopology.hh"
+#include "LocalRingGlobalBinaryTree.hh"
+#include "astra-sim/system/Common.hh"
 namespace AstraSim {
 class DoubleBinaryTreeTopology : public ComplexLogicalTopology {
  public:

--- a/astra-sim/system/topology/GeneralComplexTopology.hh
+++ b/astra-sim/system/topology/GeneralComplexTopology.hh
@@ -18,8 +18,8 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/ComplexLogicalTopology.hh"
-#include "ns3/Common.hh"
+#include "ComplexLogicalTopology.hh"
+#include "astra-sim/system/Common.hh"
 
 namespace AstraSim {
 class GeneralComplexTopology : public ComplexLogicalTopology {

--- a/astra-sim/system/topology/LocalRingGlobalBinaryTree.hh
+++ b/astra-sim/system/topology/LocalRingGlobalBinaryTree.hh
@@ -18,10 +18,10 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/BinaryTree.hh"
-#include "ns3/ComplexLogicalTopology.hh"
-#include "ns3/RingTopology.hh"
-#include "ns3/Common.hh"
+#include "BinaryTree.hh"
+#include "ComplexLogicalTopology.hh"
+#include "RingTopology.hh"
+#include "astra-sim/system/Common.hh"
 
 namespace AstraSim {
 class LocalRingGlobalBinaryTree : public ComplexLogicalTopology {

--- a/astra-sim/system/topology/LocalRingNodeA2AGlobalDBT.hh
+++ b/astra-sim/system/topology/LocalRingNodeA2AGlobalDBT.hh
@@ -18,10 +18,10 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/ComplexLogicalTopology.hh"
-#include "ns3/DoubleBinaryTreeTopology.hh"
-#include "ns3/RingTopology.hh"
-#include "ns3/Common.hh"
+#include "ComplexLogicalTopology.hh"
+#include "DoubleBinaryTreeTopology.hh"
+#include "RingTopology.hh"
+#include "astra-sim/system/Common.hh"
 
 namespace AstraSim {
 class LocalRingNodeA2AGlobalDBT : public ComplexLogicalTopology {

--- a/astra-sim/system/topology/LogicalTopology.hh
+++ b/astra-sim/system/topology/LogicalTopology.hh
@@ -5,7 +5,7 @@ LICENSE file in the root directory of this source tree.
 
 #ifndef __LOGICALTOPOLOGY_HH__
 #define __LOGICALTOPOLOGY_HH__
-#include "ns3/Common.hh"
+#include "astra-sim/system/Common.hh"
 namespace AstraSim {
 class BasicLogicalTopology;
 class LogicalTopology {

--- a/astra-sim/system/topology/Node.hh
+++ b/astra-sim/system/topology/Node.hh
@@ -18,8 +18,8 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/ComputeNode.hh"
-#include "ns3/Common.hh"
+#include "ComputeNode.hh"
+#include "astra-sim/system/Common.hh"
 
 namespace AstraSim {
 class Node : public ComputeNode {

--- a/astra-sim/system/topology/RingTopology.hh
+++ b/astra-sim/system/topology/RingTopology.hh
@@ -18,8 +18,8 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/BasicLogicalTopology.hh"
-#include "ns3/Common.hh"
+#include "BasicLogicalTopology.hh"
+#include "astra-sim/system/Common.hh"
 
 namespace AstraSim {
 class RingTopology : public BasicLogicalTopology {

--- a/astra-sim/system/topology/Torus3D.hh
+++ b/astra-sim/system/topology/Torus3D.hh
@@ -18,9 +18,9 @@ LICENSE file in the root directory of this source tree.
 #include <sstream>
 #include <tuple>
 #include <vector>
-#include "ns3/ComplexLogicalTopology.hh"
-#include "ns3/RingTopology.hh"
-#include "ns3/Common.hh"
+#include "ComplexLogicalTopology.hh"
+#include "RingTopology.hh"
+#include "astra-sim/system/Common.hh"
 
 namespace AstraSim {
 class Torus3D : public ComplexLogicalTopology {

--- a/astra-sim/workload/Layer.hh
+++ b/astra-sim/workload/Layer.hh
@@ -17,10 +17,10 @@ LICENSE file in the root directory of this source tree.
 #include <iostream>
 #include <map>
 #include <tuple>
-#include "ns3/CSVWriter.hh"
-#include "ns3/Workload.hh"
-#include "ns3/StreamStat.hh"
-#include "ns3/Sys.hh"
+#include "CSVWriter.hh"
+#include "Workload.hh"
+#include "astra-sim/system/StreamStat.hh"
+#include "astra-sim/system/Sys.hh"
 
 namespace AstraSim {
 class DataSet;

--- a/astra-sim/workload/Workload.hh
+++ b/astra-sim/workload/Workload.hh
@@ -17,7 +17,7 @@ LICENSE file in the root directory of this source tree.
 #include <iostream>
 #include <map>
 #include <tuple>
-#include "ns3/Callable.hh"
+#include "astra-sim/system/Callable.hh"
 
 namespace AstraSim {
 class Workload;
@@ -27,8 +27,8 @@ class Layer;
 class CSVWriter;
 } // namespace AstraSim
 
-#include "ns3/AstraSimDataAPI.hh"
-#include "ns3/Sys.hh"
+#include "astra-sim/system/AstraSimDataAPI.hh"
+#include "astra-sim/system/Sys.hh"
 
 namespace AstraSim {
 enum class ParallelismPolicy {


### PR DESCRIPTION
Previously, we copied all header files into `ns3-interface/build/ns3`, requiring us to change the #include statements. 
With https://github.com/astra-sim/astra-network-ns3/pull/12 , we can now return the #include statements to what they were. 
This is an essential step to merge `ns3_interface_tmp2` into `ASTRA-sim1.0`