### PR TITLE
overflow bugfix for large comms, clean codes, add -O3 -Wall

### DIFF
--- a/astra-sim/system/CSVWriter.cc
+++ b/astra-sim/system/CSVWriter.cc
@@ -112,16 +112,16 @@ void CSVWriter::finalize_csv(
   int dim_num = 1;
   myFile << " time (us) ";
   myFile << ",";
-  for (int i = 0; i < dims.size(); i++) {
+  for (uint64_t i = 0; i < dims.size(); i++) {
     myFile << "dim" + std::to_string(dim_num) + " util";
     myFile << ',';
     dim_num++;
   }
   myFile << '\n';
   while (true) {
-    int finished = 0;
+    uint64_t finished = 0;
     uint64_t compare;
-    for (int i = 0; i < dims_it.size(); i++) {
+    for (uint64_t i = 0; i < dims_it.size(); i++) {
       if (dims_it[i] != dims_it_end[i]) {
         if (i == 0) {
           myFile << std::to_string((*dims_it[i]).first / FREQ);

--- a/astra-sim/system/CommunicatorGroup.cc
+++ b/astra-sim/system/CommunicatorGroup.cc
@@ -42,7 +42,7 @@ CollectivePlan* CommunicatorGroup::get_collective_plan(ComType comm_type) {
   if (comm_plans.find(comm_type) != comm_plans.end())
     return comm_plans[comm_type];
 
-  if (generator->total_nodes == involved_NPUs.size()) {
+  if (static_cast<uint64_t>(generator->total_nodes) == involved_NPUs.size()) {
     LogicalTopology* logical_topology =
         generator->get_logical_topology(comm_type);
     std::vector<CollectiveImpl*> collective_implementation =
@@ -69,4 +69,6 @@ CollectivePlan* CommunicatorGroup::get_collective_plan(ComType comm_type) {
         should_be_removed);
     return comm_plans[comm_type];
   }
+  assert(false);
+  return nullptr;
 }

--- a/astra-sim/system/Sys.cc
+++ b/astra-sim/system/Sys.cc
@@ -127,7 +127,7 @@ void Sys::SchedulerUnit::notify_stream_removed(int vnet, Tick running_time) {
 vector<double> Sys::SchedulerUnit::get_average_latency_per_dimension() {
   vector<double> result;
   result.resize(latency_per_dimension.size(), -1);
-  for (int i = 0; i < result.size(); i++) {
+  for (uint64_t i = 0; i < result.size(); i++) {
     result[i] = latency_per_dimension[i] / total_chunks_per_dimension[i];
   }
   return result;
@@ -203,13 +203,12 @@ Sys::Sys(
   }
 
   // scheduler
-  int total_disabled = 0;
   this->physical_dims = physical_dims;
   this->queues_per_dim = queues_per_dim;
   int element = 0;
   this->total_nodes = 1;
   this->dim_to_break = -1;
-  for (int current_dim = 0; current_dim < queues_per_dim.size();
+  for (uint64_t current_dim = 0; current_dim < queues_per_dim.size();
        current_dim++) {
     if (physical_dims[current_dim] >= 1) {
       this->total_nodes *= physical_dims[current_dim];
@@ -493,7 +492,7 @@ CollectiveImpl* Sys::generate_collective_impl_from_input(
 Tick Sys::boostedTick() {
   Sys* ts = all_sys[0];
   if (ts == nullptr) {
-    for (int i = 1; i < all_sys.size(); i++) {
+    for (uint64_t i = 1; i < all_sys.size(); i++) {
       if (all_sys[i] != nullptr) {
         ts = all_sys[i];
         break;
@@ -1080,8 +1079,8 @@ int Sys::break_dimension(int model_parallel_npu_group) {
       int second_subdim = physical_dims[dimension_to_break] / first_subdim;
       std::vector<int> logical_dims;
 
-      for (int dim = 0; dim < physical_dims.size(); dim++) {
-        if (dim != dimension_to_break) {
+      for (uint64_t dim = 0; dim < physical_dims.size(); dim++) {
+        if (dim != static_cast<uint64_t>(dimension_to_break)) {
           logical_dims.push_back(physical_dims[dim]);
         } else {
           logical_dims.push_back(first_subdim);
@@ -1263,9 +1262,9 @@ void Sys::ask_for_schedule(int max) {
     return;
   }
   int top = ready_list.front()->stream_id;
-  int min = ready_list.size();
+  uint64_t min = ready_list.size();
   if (min > max) {
-    min = max;
+    min = static_cast<uint64_t>(max);
   }
   for (auto& sys : all_sys) {
     if (sys->ready_list.size() == 0 ||

--- a/astra-sim/system/scheduling/OfflineGreedy.cc
+++ b/astra-sim/system/scheduling/OfflineGreedy.cc
@@ -25,15 +25,15 @@ OfflineGreedy::OfflineGreedy(Sys* sys) {
   if (sys->dim_to_break == -1) {
     this->dim_size = sys->physical_dims;
     this->dim_BW.resize(this->dim_size.size());
-    for (int i = 0; i < this->dim_size.size(); i++) {
+    for (uint64_t i = 0; i < this->dim_size.size(); i++) {
       this->dim_BW[i] = sys->comm_NI->get_BW_at_dimension(i);
       this->dim_elapsed_time.push_back(DimElapsedTime(i));
     }
   } else {
     this->dim_size = sys->logical_broken_dims;
     this->dim_BW.resize(this->dim_size.size());
-    for (int i = 0; i < this->dim_size.size(); i++) {
-      if (i > sys->dim_to_break) {
+    for (uint64_t i = 0; i < this->dim_size.size(); i++) {
+      if (i > static_cast<uint64_t>(sys->dim_to_break)) {
         this->dim_BW[i] = sys->comm_NI->get_BW_at_dimension(i - 1);
       } else {
         this->dim_BW[i] = sys->comm_NI->get_BW_at_dimension(i);
@@ -45,12 +45,12 @@ OfflineGreedy::OfflineGreedy(Sys* sys) {
     std::cout << "Themis is configured with the following parameters: "
               << std::endl;
     std::cout << "Dim size: ";
-    for (int i = 0; i < this->dim_size.size(); i++) {
+    for (uint64_t i = 0; i < this->dim_size.size(); i++) {
       std::cout << this->dim_size[i] << ", ";
     }
     std::cout << std::endl;
     std::cout << "BW per dim: ";
-    for (int i = 0; i < this->dim_BW.size(); i++) {
+    for (uint64_t i = 0; i < this->dim_BW.size(); i++) {
       std::cout << this->dim_BW[i] << ", ";
     }
     std::cout << std::endl << std::endl;
@@ -90,7 +90,8 @@ std::vector<int> OfflineGreedy::get_chunk_scheduling(
     ComType comm_type) {
   if (chunk_schedule.find(chunk_id) != chunk_schedule.end()) {
     schedule_consumer[chunk_id]++;
-    if (schedule_consumer[chunk_id] == sys->all_sys.size()) {
+    if (schedule_consumer[chunk_id] ==
+        static_cast<int64_t>(sys->all_sys.size())) {
       std::vector<int> res = chunk_schedule[chunk_id];
       remaining_data_size -= global_chunk_size[chunk_id];
       chunk_schedule.erase(chunk_id);
@@ -172,10 +173,11 @@ std::vector<int> OfflineGreedy::get_chunk_scheduling(
           schedule_consumer[chunk_id] = 1;
           std::vector<DimElapsedTime> myReordered;
           myReordered.resize(dim_elapsed_time.size(), dim_elapsed_time[0]);
-          for (int myDim = 0; myDim < dim_elapsed_time.size(); myDim++) {
-            for (int searchDim = 0; searchDim < dim_elapsed_time.size();
+          for (uint64_t myDim = 0; myDim < dim_elapsed_time.size(); myDim++) {
+            for (uint64_t searchDim = 0; searchDim < dim_elapsed_time.size();
                  searchDim++) {
-              if (dim_elapsed_time[searchDim].dim_num == myDim) {
+              if (dim_elapsed_time[searchDim].dim_num ==
+                  static_cast<uint64_t>(myDim)) {
                 myReordered[myDim] = dim_elapsed_time[searchDim];
                 break;
               }
@@ -185,7 +187,7 @@ std::vector<int> OfflineGreedy::get_chunk_scheduling(
           if (comm_type == ComType::All_Gather) {
             std::reverse(dim_elapsed_time.begin(), dim_elapsed_time.end());
           }
-          for (int myDim = 0; myDim < dim_elapsed_time.size(); myDim++) {
+          for (uint64_t myDim = 0; myDim < dim_elapsed_time.size(); myDim++) {
             if (!dimensions_involved[myDim] || dim_size[myDim] == 1) {
               result.push_back(myDim);
               continue;
@@ -248,10 +250,11 @@ std::vector<int> OfflineGreedy::get_chunk_scheduling(
           schedule_consumer[chunk_id] = 1;
           std::vector<DimElapsedTime> myReordered;
           myReordered.resize(dim_elapsed_time.size(), dim_elapsed_time[0]);
-          for (int myDim = 0; myDim < dim_elapsed_time.size(); myDim++) {
-            for (int searchDim = 0; searchDim < dim_elapsed_time.size();
+          for (uint64_t myDim = 0; myDim < dim_elapsed_time.size(); myDim++) {
+            for (uint64_t searchDim = 0; searchDim < dim_elapsed_time.size();
                  searchDim++) {
-              if (dim_elapsed_time[searchDim].dim_num == myDim) {
+              if (dim_elapsed_time[searchDim].dim_num ==
+                  static_cast<uint64_t>(myDim)) {
                 myReordered[myDim] = dim_elapsed_time[searchDim];
                 break;
               }
@@ -261,7 +264,7 @@ std::vector<int> OfflineGreedy::get_chunk_scheduling(
           if (comm_type == ComType::All_Gather) {
             std::reverse(dim_elapsed_time.begin(), dim_elapsed_time.end());
           }
-          for (int myDim = 0; myDim < dim_elapsed_time.size(); myDim++) {
+          for (uint64_t myDim = 0; myDim < dim_elapsed_time.size(); myDim++) {
             if (!dimensions_involved[myDim] || dim_size[myDim] == 1) {
               // result.push_back(myDim);
               continue;

--- a/astra-sim/system/topology/GeneralComplexTopology.cc
+++ b/astra-sim/system/topology/GeneralComplexTopology.cc
@@ -19,9 +19,9 @@ GeneralComplexTopology::GeneralComplexTopology(
     std::vector<int> dimension_size,
     std::vector<CollectiveImpl*> collective_impl) {
   int offset = 1;
-  int last_dim = collective_impl.size() - 1;
+  uint64_t last_dim = collective_impl.size() - 1;
   assert(collective_impl.size() <= dimension_size.size());
-  for (int dim = 0; dim < collective_impl.size(); dim++) {
+  for (uint64_t dim = 0; dim < collective_impl.size(); dim++) {
     if (collective_impl[dim]->type == CollectiveImplType::Ring ||
         collective_impl[dim]->type == CollectiveImplType::Direct ||
         collective_impl[dim]->type == CollectiveImplType::HalvingDoubling) {
@@ -64,7 +64,7 @@ GeneralComplexTopology::GeneralComplexTopology(
 }
 
 GeneralComplexTopology::~GeneralComplexTopology() {
-  for (int i = 0; i < dimension_topology.size(); i++) {
+  for (uint64_t i = 0; i < dimension_topology.size(); i++) {
     delete dimension_topology[i];
   }
 }
@@ -74,12 +74,12 @@ int GeneralComplexTopology::get_num_of_dimensions() {
 }
 
 int GeneralComplexTopology::get_num_of_nodes_in_dimension(int dimension) {
-  if (dimension >= dimension_topology.size()) {
+  if (static_cast<uint64_t>(dimension) >= dimension_topology.size()) {
     std::cout << "dim: " << dimension
               << " requested! but max dim is: " << dimension_topology.size() - 1
               << std::endl;
   }
-  assert(dimension < dimension_topology.size());
+  assert(static_cast<uint64_t>(dimension) < dimension_topology.size());
   return dimension_topology[dimension]->get_num_of_nodes_in_dimension(0);
 }
 

--- a/astra-sim/workload/Workload.cc
+++ b/astra-sim/workload/Workload.cc
@@ -170,8 +170,6 @@ void Workload::issue_comp(shared_ptr<Chakra::ETFeederNode> node) {
 }
 
 void Workload::issue_comm(shared_ptr<Chakra::ETFeederNode> node) {
-  int src, dst;
-
   hw_resource->occupy(node);
 
   vector<bool> involved_dim;

--- a/build/astra_analytical/CMakeLists.txt
+++ b/build/astra_analytical/CMakeLists.txt
@@ -5,6 +5,8 @@ cmake_minimum_required(VERSION 3.15)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+set(CMAKE_CXX_FLAGS "-O3 -Wall")
+
 # Setup project
 project(AstraSim_Analytical)
 

--- a/run.sh
+++ b/run.sh
@@ -5,10 +5,10 @@ BINARY="${SCRIPT_DIR:?}"/build/astra_analytical/build/AnalyticalAstra/bin/Analyt
 WORKLOAD="${SCRIPT_DIR:?}"/extern/graph_frontend/chakra/et_generator/twoCompNodesDependent
 SYSTEM="${SCRIPT_DIR:?}"/inputs/system/sample_fully_connected_sys.txt
 NETWORK="${SCRIPT_DIR:?}"/inputs/network/analytical/fully_connected.json
-MEMORY="${SCRIPT_DIR:?}"/inputs/memory/analytical/no_memory_expansion.json
+MEMORY="${SCRIPT_DIR:?}"/inputs/remote_memory/analytical/no_memory_expansion.json
 
 "${BINARY}" \
   --workload-configuration="${WORKLOAD}" \
   --system-configuration="${SYSTEM}" \
   --network-configuration="${NETWORK}"\
-  --memory-configuration="${MEMORY}"
+  --remote-memory-configuration="${MEMORY}"


### PR DESCRIPTION
Fixed some overflow bug which might cause sim fail with large comm and mem nodes. 

Added -O3 -Wall flags in Cmakefile

Changed run.sh to adapt change from "memory" to "remote-memory"