### PR TITLE
updates: More assertions to ensure valid inputs.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = git@github.com:astra-sim/astra-network-garnet.git
 [submodule "extern/graph_frontend/chakra"]
 	path = extern/graph_frontend/chakra
-	url = git@github.com:mlcommons/chakra.git
+	url = git@github.com:changhai0109/chakra.git
 [submodule "extern/memory_backend/analytical"]
 	path = extern/remote_memory_backend/analytical
 	url = git@github.com:astra-sim/astra-memory-analytical.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = git@github.com:astra-sim/astra-network-garnet.git
 [submodule "extern/graph_frontend/chakra"]
 	path = extern/graph_frontend/chakra
-	url = git@github.com:changhai0109/chakra.git
+	url = git@github.com:mlcommons/chakra.git
 [submodule "extern/memory_backend/analytical"]
 	path = extern/remote_memory_backend/analytical
 	url = git@github.com:astra-sim/astra-memory-analytical.git

--- a/astra-sim/workload/Workload.cc
+++ b/astra-sim/workload/Workload.cc
@@ -93,7 +93,74 @@ void Workload::issue_dep_free_nodes() {
   }
 }
 
+void Workload::check_node_valid(std::shared_ptr<Chakra::ETFeederNode> node) {
+  const auto& chakra_node = node->getChakraNode();
+  if ((chakra_node->node_type() == ChakraNodeType::MEM_LOAD_NODE) ||
+      (chakra_node->node_type() == ChakraNodeType::MEM_STORE_NODE)) {
+    if (!(chakra_node->tensor_loc() == ChakraMemoryType::REMOTE_MEMORY))
+      throw std::invalid_argument("invalid tensor location for memory node");
+    if (!(chakra_node->has_tensor_size()))
+      throw std::invalid_argument("empty tensor size for memory node");
+    return;
+  } else if (chakra_node->node_type() == ChakraNodeType::COMP_NODE) {
+    if (sys->roofline_enabled) {
+      if (!(chakra_node->has_num_ops()))
+        throw std::invalid_argument(
+            "empty num_ops, with roofline model, comp node should have num_ops");
+      if (!(chakra_node->has_tensor_size()))
+        throw std::invalid_argument(
+            "empty tensor_size, with roofline model, comp node should have tensor_size");
+    } else {
+      if (!(chakra_node->has_simulated_run_time()))
+        throw std::invalid_argument(
+            "empty simulated_run_time, with roofline model, comp node should have simulated_run_time");
+    }
+    return;
+  } else if (
+      (chakra_node->node_type() == ChakraNodeType::COMM_COLL_NODE) ||
+      (chakra_node->node_type() == ChakraNodeType::COMM_SEND_NODE) ||
+      (chakra_node->node_type() == ChakraNodeType::COMM_RECV_NODE)) {
+    if (!(chakra_node->has_comm_size()))
+      throw std::invalid_argument("empty comm_size for comm node");
+    if (chakra_node->node_type() == ChakraNodeType::COMM_COLL_NODE) {
+      switch (chakra_node->comm_type()) {
+        // for all implemented comm types, break: please make sure list here
+        // align to issue_comm implementation
+        case ChakraCollectiveCommType::ALL_REDUCE:
+        case ChakraCollectiveCommType::ALL_GATHER:
+        case ChakraCollectiveCommType::ALL_TO_ALL:
+        case ChakraCollectiveCommType::REDUCE_SCATTER:
+          break;
+        // for other comm types, shouldnt be here, trigger exception
+        default:
+          throw std::invalid_argument("invalid comm type for COMM_COLL_NODE");
+      }
+    }
+    return;
+  }
+
+  throw std::invalid_argument("invalid node type");
+}
+
 void Workload::issue(shared_ptr<Chakra::ETFeederNode> node) {
+  // In strict_mode, the node field check will be enforced, and the simulation
+  // will stop if field check fails. Otherwise, just skip these invalid nodes
+  // and continue run (default behavior)
+  const bool strict_mode = false;
+  try {
+    check_node_valid(node);
+  } catch (std::invalid_argument& e) {
+    // conditional catch when not strict_mode
+    if (!strict_mode) {
+      std::cerr << e.what() << std::endl;
+      skip_invalid(node);
+      return;
+    } else {
+      throw e;
+    }
+  }
+
+  // from here the node should be valid and following code should run well.
   if ((node->getChakraNode()->node_type() == ChakraNodeType::MEM_LOAD_NODE) ||
       (node->getChakraNode()->node_type() == ChakraNodeType::MEM_STORE_NODE)) {
     if (sys->trace_enabled) {
@@ -103,17 +170,12 @@ void Workload::issue(shared_ptr<Chakra::ETFeederNode> node) {
     }
     issue_remote_mem(node);
   } else if (node->getChakraNode()->node_type() == ChakraNodeType::COMP_NODE) {
-    if ((node->getChakraNode()->simulated_run_time() == 0) &&
-        (node->getChakraNode()->num_ops() == 0)) {
-      skip_invalid(node);
-    } else {
-      if (sys->trace_enabled) {
-        cout << "issue,sys->id=" << sys->id << ",tick=" << Sys::boostedTick()
-             << ",node->id=" << node->getChakraNode()->id()
-             << ",node->name=" << node->getChakraNode()->name() << endl;
-      }
-      issue_comp(node);
+    if (sys->trace_enabled) {
+      cout << "issue,sys->id=" << sys->id << ",tick=" << Sys::boostedTick()
+           << ",node->id=" << node->getChakraNode()->id()
+           << ",node->name=" << node->getChakraNode()->name() << endl;
     }
+    issue_comp(node);
   } else if (
       (node->getChakraNode()->node_type() == ChakraNodeType::COMM_COLL_NODE) ||
       (node->getChakraNode()->node_type() == ChakraNodeType::COMM_SEND_NODE) ||
@@ -124,9 +186,6 @@ void Workload::issue(shared_ptr<Chakra::ETFeederNode> node) {
            << ",node->name=" << node->getChakraNode()->name() << endl;
     }
     issue_comm(node);
-  } else if (
-      node->getChakraNode()->node_type() == ChakraNodeType::INVALID_NODE) {
-    skip_invalid(node);
   }
 }
 
@@ -141,7 +200,6 @@ void Workload::issue_remote_mem(shared_ptr<Chakra::ETFeederNode> node) {
 }
 
 void Workload::issue_comp(shared_ptr<Chakra::ETFeederNode> node) {
-  assert(node->getChakraNode()->node_type() == ChakraNodeType::COMP_NODE);
   hw_resource->occupy(node);
 
   if (sys->roofline_enabled) {
@@ -260,6 +318,8 @@ void Workload::issue_comm(shared_ptr<Chakra::ETFeederNode> node) {
         &rcv_req,
         &Sys::handleEvent,
         rcehd);
+  } else {
+    assert(false && "invalid comm_node");
   }
 }
 

--- a/astra-sim/workload/Workload.cc
+++ b/astra-sim/workload/Workload.cc
@@ -12,6 +12,7 @@ LICENSE file in the root directory of this source tree.
 #include "astra-sim/system/SendPacketEventHandlerData.hh"
 #include "astra-sim/system/WorkloadLayerHandlerData.hh"
 
+#include <fstream>
 #include <iostream>
 
 using namespace std;
@@ -23,9 +24,17 @@ typedef ChakraProtoMsg::NodeType ChakraNodeType;
 typedef ChakraProtoMsg::MemoryType ChakraMemoryType;
 typedef ChakraProtoMsg::CollectiveCommType ChakraCollectiveCommType;
 
+bool file_exists(const string& filename) {
+  std::ifstream file(filename.c_str());
+  bool file_good = file.good();
+  file.close();
+  return file_good;
+}
+
 Workload::Workload(Sys* sys, string eg_filename, string comm_group_filename) {
-  this->et_feeder =
-      new ETFeeder(eg_filename + "." + to_string(sys->id) + ".eg");
+  const string path_to_eg = eg_filename + "." + to_string(sys->id) + ".eg";
+  assert(file_exists(path_to_eg));
+  this->et_feeder = new ETFeeder(path_to_eg);
   this->comm_group = nullptr;
   // TODO: parametrize the number of available hardware resources
   this->hw_resource = new HardwareResource(1);

--- a/astra-sim/workload/Workload.hh
+++ b/astra-sim/workload/Workload.hh
@@ -35,6 +35,7 @@ class Workload : public Callable {
   void skip_invalid(std::shared_ptr<Chakra::ETFeederNode> node);
   void call(EventType event, CallData* data);
   void fire();
+  void check_node_valid(std::shared_ptr<Chakra::ETFeederNode> node);
 
   // stats
   void report();


### PR DESCRIPTION
1. Updated submodules of chakra from mlcommons to another source, which contains bugfixes and not (going to) merge to mlcommons repo until new schema.
2. Added validations before issuing nodes to ensure all nodes are valid. 
  There is one switch called `const bool strict_mode`  at Workload.cc:158. By default it is false, means when met invalid nodes, skip it and **issue all its children** (otherwise early-stop bug as before, finished simulation but no report). If it set to true, the check will be enforced, and the simulation will stop when there is invalid nodes.
3. Added empty eg check: When the there is no file at eg_path, it will throw exception (before it will continues run and complete with run cycle of 0)
4. Updated network submodule to latest one.