### PR TITLE
Update Common.hh

### DIFF
--- a/astra-sim/system/Common.hh
+++ b/astra-sim/system/Common.hh
@@ -21,7 +21,7 @@ enum req_type_e { UINT8 = 0, BFLOAT16, FP32 };
 
 struct timespec_t {
   time_type_e time_res;
-  double time_val;
+  long double time_val;
 };
 
 struct sim_request {


### PR DESCRIPTION
The data type of "time_val" should be changed to the long double. The reason is that for very large collectives, the delta time required to transmit a message over the network (using analytical backend) can exceed the double range. So, it is better to be converted to long double.