### PR TITLE
Change NetworkAPI's schedule to use relative time

### DIFF
--- a/astra-sim/network_frontend/analytical/congestion_aware/AstraCongestionApi.cc
+++ b/astra-sim/network_frontend/analytical/congestion_aware/AstraCongestionApi.cc
@@ -100,13 +100,6 @@ void AstraCongestionApi::sim_schedule(
   event_queue->schedule_event(event_time, fun_ptr, fun_arg);
 }
 
-void AstraCongestionApi::schedule(
-    AstraSim::timespec_t delta,
-    void (*fun_ptr)(void*),
-    void* fun_arg) {
-  event_queue->schedule_event(delta.time_val, fun_ptr, fun_arg);
-}
-
 int AstraCongestionApi::sim_send(
     void* buffer,
     uint64_t count,
@@ -172,7 +165,7 @@ int AstraCongestionApi::sim_recv(
       auto delta = AstraSim::timespec_t{AstraSim::NS, 0};
       // sim_schedule(delta, msg_handler, fun_arg);
       //  Divya: Changes to port congestion backend to Chakra
-      schedule(delta, msg_handler, fun_arg);
+      sim_schedule(delta, msg_handler, fun_arg);
     } else {
       // register recv callback
       entry.value()->register_recv_callback(msg_handler, fun_arg);

--- a/astra-sim/network_frontend/analytical/congestion_aware/AstraCongestionApi.hh
+++ b/astra-sim/network_frontend/analytical/congestion_aware/AstraCongestionApi.hh
@@ -49,11 +49,6 @@ class AstraCongestionApi : public AstraSim::AstraNetworkAPI {
       void (*fun_ptr)(void* fun_arg),
       void* fun_arg);
 
-  void schedule(
-      AstraSim::timespec_t delta,
-      void (*fun_ptr)(void* fun_arg),
-      void* fun_arg) override;
-
   int sim_send(
       void* buffer,
       uint64_t count,

--- a/astra-sim/network_frontend/analytical/congestion_unaware/AnalyticalNetwork.cc
+++ b/astra-sim/network_frontend/analytical/congestion_unaware/AnalyticalNetwork.cc
@@ -135,13 +135,6 @@ void AnalyticalNetwork::sim_schedule(
   event_queue->add_event(event_time, fun_ptr, fun_arg);
 }
 
-void AnalyticalNetwork::schedule(
-    AstraSim::timespec_t event_time,
-    void (*fun_ptr)(void*),
-    void* fun_arg) {
-  event_queue->add_event(event_time, fun_ptr, fun_arg);
-}
-
 AstraSim::timespec_t AnalyticalNetwork::sim_get_time() {
   return event_queue->get_current_time();
 }

--- a/astra-sim/network_frontend/analytical/congestion_unaware/AnalyticalNetwork.hh
+++ b/astra-sim/network_frontend/analytical/congestion_unaware/AnalyticalNetwork.hh
@@ -45,11 +45,6 @@ class AnalyticalNetwork : public AstraSim::AstraNetworkAPI {
       void (*fun_ptr)(void* fun_arg),
       void* fun_arg);
 
-  void schedule(
-      AstraSim::timespec_t event_time,
-      void (*fun_ptr)(void* fun_arg),
-      void* fun_arg) override;
-
   AstraSim::timespec_t sim_get_time() override;
 
   double get_BW_at_dimension(int dim) override;

--- a/astra-sim/network_frontend/ns3/AstraSimNetwork.cc
+++ b/astra-sim/network_frontend/ns3/AstraSimNetwork.cc
@@ -51,14 +51,14 @@ public:
 
   AstraSim::timespec_t sim_get_time() {
     AstraSim::timespec_t timeSpec;
+    timeSpec.time_res = AstraSim::NS;
     timeSpec.time_val = Simulator::Now().GetNanoSeconds();
     return timeSpec;
   }
 
-  virtual void schedule(AstraSim::timespec_t schTime,
+  virtual void sim_schedule(AstraSim::timespec_t delta,
                         void (*fun_ptr)(void *fun_arg), void *fun_arg) {
-    Simulator::Schedule(NanoSeconds(schTime.time_val) - Simulator::Now(),
-                        fun_ptr, fun_arg);
+    Simulator::Schedule(NanoSeconds(delta.time_val), fun_ptr, fun_arg);
     return;
   }
 

--- a/astra-sim/system/AstraNetworkAPI.hh
+++ b/astra-sim/system/AstraNetworkAPI.hh
@@ -37,7 +37,13 @@ class AstraNetworkAPI {
       void (*msg_handler)(void* fun_arg),
       void* fun_arg) = 0;
 
-  virtual void schedule(
+  /* 
+   * sim_schedule is used when ASTRA-sim wants to schedule an event on the network backend.
+   * delta: The relative time difference between the current time and the time when the event is triggered, as observed by the network simulator.
+   * fun_ptr: The event handler to be triggered at the scheduled time.
+   * fun_arg: Arguments to pass into fun_ptr.
+   */
+  virtual void sim_schedule(
       timespec_t delta,
       void (*fun_ptr)(void* fun_arg),
       void* fun_arg) = 0;

--- a/astra-sim/system/Sys.cc
+++ b/astra-sim/system/Sys.cc
@@ -534,32 +534,32 @@ void Sys::register_event(
     Callable* callable,
     EventType event,
     CallData* callData,
-    Tick cycles) {
-  try_register_event(callable, event, callData, cycles);
+    Tick delta_cycles) {
+  try_register_event(callable, event, callData, delta_cycles);
 }
 
 void Sys::try_register_event(
     Callable* callable,
     EventType event,
     CallData* callData,
-    Tick& cycles) {
+    Tick& delta_cycles) {
   bool should_schedule = false;
-  if (event_queue.find(Sys::boostedTick() + cycles) == event_queue.end()) {
+  if (event_queue.find(Sys::boostedTick() + delta_cycles) == event_queue.end()) {
     list<tuple<Callable*, EventType, CallData*>> tmp;
-    event_queue[Sys::boostedTick() + cycles] = tmp;
+    event_queue[Sys::boostedTick() + delta_cycles] = tmp;
     should_schedule = true;
   }
-  event_queue[Sys::boostedTick() + cycles].push_back(
+  event_queue[Sys::boostedTick() + delta_cycles].push_back(
       make_tuple(callable, event, callData));
   if (should_schedule) {
     timespec_t tmp;
-    tmp.time_val = Sys::boostedTick() + cycles;
+    tmp.time_val = delta_cycles;
     BasicEventHandlerData* data =
         new BasicEventHandlerData(id, EventType::CallEvents);
     data->sys_id = id;
-    comm_NI->schedule(tmp, &Sys::handleEvent, data);
+    comm_NI->sim_schedule(tmp, &Sys::handleEvent, data);
   }
-  cycles = 0;
+  delta_cycles = 0;
   pending_events++;
   return;
 }

--- a/astra-sim/system/Sys.cc
+++ b/astra-sim/system/Sys.cc
@@ -544,13 +544,13 @@ void Sys::try_register_event(
     CallData* callData,
     Tick& delta_cycles) {
   bool should_schedule = false;
-  if (event_queue.find(Sys::boostedTick() + delta_cycles) == event_queue.end()) {
+  auto event_time = Sys::boostedTick() + delta_cycles;
+  if (event_queue.find(event_time) == event_queue.end()) {
     list<tuple<Callable*, EventType, CallData*>> tmp;
-    event_queue[Sys::boostedTick() + delta_cycles] = tmp;
+    event_queue[event_time] = tmp;
     should_schedule = true;
   }
-  event_queue[Sys::boostedTick() + delta_cycles].push_back(
-      make_tuple(callable, event, callData));
+  event_queue[event_time].push_back(make_tuple(callable, event, callData));
   if (should_schedule) {
     timespec_t tmp;
     tmp.time_val = delta_cycles;

--- a/astra-sim/system/Sys.hh
+++ b/astra-sim/system/Sys.hh
@@ -97,12 +97,12 @@ class Sys : public Callable {
       Callable* callable,
       EventType event,
       CallData* callData,
-      Tick cycles);
+      Tick delta_cycles);
   void try_register_event(
       Callable* callable,
       EventType event,
       CallData* callData,
-      Tick& cycles);
+      Tick& delta_cycles);
   static void handleEvent(void* arg);
   //---------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR changes the semantics of the `schedule` function in the Network API to use _relative_ time instead of _absoulte_ time. The `timespec_t` parameter of this function will now accept delta time instead of absolute time. Network backend simulator prefers absolute time, this should be reflected in the backend specific Network API _implementation_

- Adjust comments, variables to clearly state this. 
- This PR also renames the schedule function from `schedule` to `sim_schedule`

This PR replaces PR #101's part on relative time v. absolute time. 