### PR TITLE
Allocate half of the queues per dimension to collective phase for an AllReduce collective

### DIFF
--- a/astra-sim/system/Sys.cc
+++ b/astra-sim/system/Sys.cc
@@ -908,7 +908,7 @@ DataSet* Sys::generate_collective(
           continue;
         }
         pair<int, RingTopology::Direction> queue =
-            vLevels->get_next_queue_at_level(dim_mapper[dim]);
+            vLevels->get_next_queue_at_level_first(dim_mapper[dim]);
         CollectivePhase phase = generate_collective_phase(
             ComType::Reduce_Scatter,
             topology->get_basic_topology_at_dimension(
@@ -929,7 +929,7 @@ DataSet* Sys::generate_collective(
       if (dimensions_involved[dim_mapper[dim]] &&
           topology->get_num_of_nodes_in_dimension(dim_mapper[dim]) > 1) {
         pair<int, RingTopology::Direction> queue =
-            vLevels->get_next_queue_at_level(dim_mapper[dim]);
+            vLevels->get_next_queue_at_level_first(dim_mapper[dim]);
         CollectivePhase phase = generate_collective_phase(
             ComType::All_Reduce,
             topology->get_basic_topology_at_dimension(
@@ -949,7 +949,7 @@ DataSet* Sys::generate_collective(
           continue;
         }
         pair<int, RingTopology::Direction> queue =
-            vLevels->get_next_queue_at_level(dim_mapper[dim]);
+            vLevels->get_next_queue_at_level_last(dim_mapper[dim]);
         CollectivePhase phase = generate_collective_phase(
             ComType::All_Gather,
             topology->get_basic_topology_at_dimension(

--- a/astra-sim/system/Sys.cc
+++ b/astra-sim/system/Sys.cc
@@ -854,13 +854,15 @@ DataSet* Sys::generate_collective(
             InterDimensionScheduling::OfflineGreedyFlex ||
         inter_dimension_scheduling == InterDimensionScheduling::OnlineGreedy) {
       int dim = 0;
+        
+      // Create collective phase for each dimension in ascending order.
       for (dim = 0; dim < topology->get_num_of_dimensions(); dim++) {
         if (topology->get_num_of_nodes_in_dimension(dim_mapper[dim]) == 1 ||
             !dimensions_involved[dim_mapper[dim]]) {
           continue;
         }
         pair<int, RingTopology::Direction> queue =
-            vLevels->get_next_queue_at_level(dim_mapper[dim]);
+            vLevels->get_next_queue_at_level_first(dim_mapper[dim]);
         CollectivePhase phase = generate_collective_phase(
             ComType::Reduce_Scatter,
             topology->get_basic_topology_at_dimension(
@@ -874,13 +876,15 @@ DataSet* Sys::generate_collective(
         remain_size = phase.final_data_size;
       }
       dim--;
+
+      // Create collective phases for each dimension in descending order.  
       for (; dim >= 0; dim--) {
         if (topology->get_num_of_nodes_in_dimension(dim_mapper[dim]) == 1 ||
             !dimensions_involved[dim_mapper[dim]]) {
           continue;
         }
         pair<int, RingTopology::Direction> queue =
-            vLevels->get_next_queue_at_level(dim_mapper[dim]);
+            vLevels->get_next_queue_at_level_last(dim_mapper[dim]);
         CollectivePhase phase = generate_collective_phase(
             ComType::All_Gather,
             topology->get_basic_topology_at_dimension(

--- a/astra-sim/system/Sys.cc
+++ b/astra-sim/system/Sys.cc
@@ -894,6 +894,15 @@ DataSet* Sys::generate_collective(
         remain_size = phase.final_data_size;
       }
     } else {
+      // In this branch, and the branch directly above, a collective visits each dimension (excluding the last dimension) twice.
+      // Specifically, for example, in 2D AllReduce, there would be 3 collective phases:
+      // Phase 0: Reduce Scatter in dim 0, Phase 1: All Gather in dim 1, Phase 2: All Reduce in dim 2
+      // Similarly, in 3D AllReduce, there would be 5 collective phases: RS in dim 0, RS in dim 1, AG in dim 2, AR in dim 3, AR in dim 4. 
+      // Currently, queues are allocated per dimension. If we allocate all queues in a dimension to both phases of a single dimension, a race / deadlock condition may occur. 
+      // Therefore, in these cases, we have to allocate half of the queues to the first phase, and the remaining half to the second phase.
+      // (For example, in the above 2D case, if we have 4 queues per dim, queues 0~1 are allocated to phase 0, queues 2~3 are allocated to phase 2.  
+      // For details, refer to https://github.com/astra-sim/astra-sim/issues/137 and the linked document. 
+        
       int dim = 0;
       int last_active_dim = 0;
       for (dim = 0; dim < topology->get_num_of_dimensions(); dim++) {
@@ -902,11 +911,14 @@ DataSet* Sys::generate_collective(
           last_active_dim = dim;
         }
       }
+        
+      // Create collective phase for each dimension, excluding the last dimension, in ascending order.
       for (dim = 0; dim < last_active_dim; dim++) {
         if (topology->get_num_of_nodes_in_dimension(dim_mapper[dim]) == 1 ||
             !dimensions_involved[dim_mapper[dim]]) {
           continue;
         }
+        // Allocate the first half of queues available to this dimension.
         pair<int, RingTopology::Direction> queue =
             vLevels->get_next_queue_at_level_first(dim_mapper[dim]);
         CollectivePhase phase = generate_collective_phase(
@@ -926,8 +938,13 @@ DataSet* Sys::generate_collective(
               topology->get_num_of_nodes_in_dimension(dim_mapper[dim]) == 1)) {
         dim--;
       }
+
+      // The last dimension is the 'turning point'. Only one collective phase is created.
       if (dimensions_involved[dim_mapper[dim]] &&
           topology->get_num_of_nodes_in_dimension(dim_mapper[dim]) > 1) {
+        // Despite only one collective phase being allocated to the last dimension, we only allocate half of the queues available to this dimension. 
+        // This is because we want to match the number of queues allocated to each collective phase.
+        // Processing phases for this dim in n parallel queues, and queueing the next phases in n/2 parallel queues could cause another deadlock. Refer to the PR #135 for more details.
         pair<int, RingTopology::Direction> queue =
             vLevels->get_next_queue_at_level_first(dim_mapper[dim]);
         CollectivePhase phase = generate_collective_phase(
@@ -943,11 +960,14 @@ DataSet* Sys::generate_collective(
         remain_size = phase.final_data_size;
       }
       dim--;
+
+      // Create collective phases for each dimension, excluding the last dimension, in descending order.  
       for (; dim >= 0; dim--) {
         if (topology->get_num_of_nodes_in_dimension(dim_mapper[dim]) == 1 ||
             !dimensions_involved[dim_mapper[dim]]) {
           continue;
         }
+        // Allocate the second half of queues available to this dimension.
         pair<int, RingTopology::Direction> queue =
             vLevels->get_next_queue_at_level_last(dim_mapper[dim]);
         CollectivePhase phase = generate_collective_phase(


### PR DESCRIPTION
Refer to #137  for a detailed description of the issue. 

### Description

This PR attempts to fix the above issue. 
Normally, when generating a collective phase, we assign a single queue_id where this phase will run in a round robin fashin among the queues allocated to this dimension (Defined by the `num_queues_per_dim` variable when constructing the `Sys` object)

In AllReduce collectives (and other miscellaneous cases affected by the issue above), we perform the round robin only on the first half of available queues for the ReduceScatter phase (first collective phase visiting this dimension). Similarly, we perform the round robin only on the second half of available queues for the AllReduce phase (second collective phase visiting this dimension)


**The key of this approach is to prevent the contention reported in the issue above by separating the queues between different the Reduce Scatter (phase 0) and All Reduce (phase 2) phases**.

### Example

For example, let's assume a 2D workload with 4 AllReduce streams and 2 queues per dimension. Because we have 2 dimensions, we have 4 queues in total. From node 0's `Sys` object's perspective (remember, each `Sys` object is tied to one node) the collective phases will be scheduled and executed in the following manner. 

Each number represents the id of the stream.

```
// phase 0 of each collective is all scheduled to queue 0.
// All phase 0 are scheduled in queue 0 - the first half of the 2 queues available to dim 0.
Queue 0(dim 0): [0, 1, 2, 3] 
Queue 1(dim 0): 
Queue 2(dim 1): 
Queue 3(dim 1)

// phase 0 for stream 0 finishes. phase 1 for stream 0 is scheduled in queue 2.
Queue 0(dim 0): [1, 2, 3] 
Queue 1(dim 0): 
Queue 2(dim 1): [0]
Queue 3(dim 1)

// phase 1 for stream 0 finishes. phase 2, which revisits dim 0, is scheduled in queue 1.
// All phase 2 are scheduled in queue 1 - the second half of the 2 queues available to dim 1.
// Similarly, phase 0 for stream 1 finishes, and is scheduled in queue 2. 
Queue 0(dim 0): [2, 3] 
Queue 1(dim 0): [0]
Queue 2(dim 1): [1]
Queue 3(dim 1)

// phase 2 for stream 0 finishes. Stream 0 is completely finished.
Queue 0(dim 0): [3] 
Queue 1(dim 0): [1]
Queue 2(dim 1): [2]
Queue 3(dim 1)
```

### Pitfalls
This PR is a temporary fix and has several caveats. I have listed the caveats below and added replies
1. When we add new collective implementations where collectives visit a dimension twice, the codewriter has to remember to allocate half of the queues available.  (use `get_next_queue_at_level_first` instead of `get_next_queue_at_level`)
2. A more fundamental fix would be for the system layer to look at the workload and automatically decide how many (and which) queues it wants to run the round-robin on. 
3. This fix still relies on users having to provide an even number value to  `num_queue_per_dim`. Ideally, we'd want the system layer to determine this on its own. 
4. The System layer used to have queues per phase, not queues per dim. Why not revert back to that implementation?
- The above fundamental solutions are all valid. I have tried to pursue that direction, but after spending a few days I realized this involves (practically) rewriting a significant chunk of the system layer. This PR is a quickfix and the fundamental work is left to the future.

5. The collective phase for the last dimension (AllGather) visits this dimension only once. Yet, only half of the queues available to this dimension is considered for round robin. (i.e. We use `get_next_queue_at_level_fist` at AllGather instead of `get_next_queue_at_level`)

- Consider the following scenario, of the queues of **multiple** nodes at **each given point** of time. 
- At timestamp 1, queue 1:
  - In node 0, phase 2 of stream **1** is at the head & waiting for node 1 to send message of stream 1. 
  - Similarly, in node 1, phase 2 of stream **2** is at the head & waiting for node 0 to send message of stream 2. 

In the end, the same deadlock happens. This is because phase 1 of dim 1 is queued on 2 queues in parallel, but the resulting phase 2 is queued in only one queue (queue 1). Therefore, we can only allocate 1 queue to phase 1 too.
```
// Timestamp 0
// Node 0
Queue 0(dim 0): [3] 
Queue 1(dim 0): [0]
Queue 2(dim 1): [1]
Queue 3(dim 1): [2]

// Node 1
Queue 0(dim 0): [3] 
Queue 1(dim 0): [0]
Queue 2(dim 1): [1]
Queue 3(dim 1): [2]
=======
// Timestamp 1
// Node 0
Queue 0(dim 0):  
Queue 1(dim 0): [1, 2]
Queue 2(dim 1): [3]
Queue 3(dim 1)

// Node 1
Queue 0(dim 0): 
Queue 1(dim 0): [2, 1]
Queue 2(dim 1): [3]
Queue 3(dim 1)
```

6. When there are streams of different collectives this solution still has the potential to fail. For example, lets assume a 2D workload with an AllReduce stream after an AllToAll stream, and 2 queues per dimension. The first phase of the AllReduce stream will only be allocated to queue 0. However, the first (and only) phase of the AllToAll stream can be allocated to either queue 0 or queue 1. 
- If this becomes an issue, we can resort to allocating half of available queues to the AllToAll streams too, like the solution above.