### PR TITLE
Take network_config filename with argument flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,9 +165,10 @@ $ ./build/astra_ns3/build.sh -r
 
 # Or, alternatively:
 $ cd ./extern/network_backend/ns3/simulation
-$ ./waf --run "scratch/AstraSimNetwork mix/config.txt \
+$ ./waf --run "scratch/AstraSimNetwork \
   --workload-configuration=../../../../extern/graph_frontend/chakra/et_generator/oneCommNodeAllReduce \
   --system-configuration=../../../../inputs/system/Switch.json \
+  --network-configuration=mix/config.txt \
   --remote-memory-configuration=../../../../inputs/remote_memory/analytical/no_memory_expansion.json \
   --logical-topology-configuration=../../../../inputs/network/ns3/sample_64nodes_1D.json \
   --comm-group-configuration=\"empty\""

--- a/astra-sim/network_frontend/ns3/AstraSimNetwork.cc
+++ b/astra-sim/network_frontend/ns3/AstraSimNetwork.cc
@@ -142,6 +142,7 @@ class ASTRASimNetwork : public AstraSim::AstraNetworkAPI {
 // Command line arguments and default values.
 string workload_configuration;
 string system_configuration;
+string network_configuration;
 string memory_configuration;
 string comm_group_configuration;
 string logical_topology_configuration;
@@ -196,6 +197,10 @@ void parse_args(int argc, char* argv[]) {
       "system-configuration",
       "System configuration file",
       system_configuration);
+  cmd.AddValue(
+      "network-configuration",
+      "Network configuration file",
+      network_configuration);
   cmd.AddValue(
       "remote-memory-configuration",
       "Memory configuration file",
@@ -256,7 +261,7 @@ int main(int argc, char* argv[]) {
   }
 
   // Initialize ns3 simulation.
-  setup_ns3_simulation(argc, argv);
+  setup_ns3_simulation(network_configuration);
 
   // Tell workload layer to schedule first events.
   for (int i = 0; i < num_npus; i++) {

--- a/astra-sim/network_frontend/ns3/entry.h
+++ b/astra-sim/network_frontend/ns3/entry.h
@@ -281,8 +281,8 @@ void qp_finish(FILE *fout, Ptr<RdmaQueuePair> q) {
   notify_receiver_receive_data(sid, did, q->m_size, tag);
 }
 
-int setup_ns3_simulation(int argc, char *argv[]) {
-  if (!ReadConf(argc, argv))
+int setup_ns3_simulation(string network_configuration) {
+  if (!ReadConf(network_configuration))
     return -1;
   SetConfig();
   SetupNetwork(qp_finish);

--- a/build/astra_ns3/build.sh
+++ b/build/astra_ns3/build.sh
@@ -35,9 +35,10 @@ function compile {
 
 function run {
     cd "${NS3_DIR}/simulation"
-    ./waf --run "scratch/AstraSimNetwork ${NETWORK} \
+    ./waf --run "scratch/AstraSimNetwork \
         --workload-configuration=${WORKLOAD} \
         --system-configuration=${SYSTEM} \
+        --network-configuration=${NETWORK} \
         --remote-memory-configuration=${MEMORY} \
         --logical-topology-configuration=${LOGICAL_TOPOLOGY} \
         --comm-group-configuration=\"empty\""


### PR DESCRIPTION
Previously, the network config filename was provided as a command line argument without a flag. 
(i.e. we would parse argv[1] instead of looking for `--network_configuration`)

Adjust this so that we use the `--network_configuration` flag, just like Analytical