### PR TITLE
Update CMakeLists.txt which fixes debug build undefined reference errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ endif ()
 project(AstraSim)
 
 # Find Protobuf
-find_package(Protobuf REQUIRED)
+find_package(Protobuf REQUIRED CONFIG)
 
 # Files to compile
 file(GLOB srcs
@@ -33,7 +33,7 @@ file(GLOB srcs
 add_library(AstraSim STATIC ${srcs})
 
 # Link libraries
-target_link_libraries(AstraSim PUBLIC ${Protobuf_LIBRARIES})
+target_link_libraries(AstraSim PUBLIC protobuf::libprotobuf)
 
 # Include Directories
 target_include_directories(AstraSim PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
Building with debug
```bash
./build/astra_analytical/build.sh -d
```

gives errors while linking:
```
ld: [100%] Linking CXX executable ../bin/AstraSim_Analytical_Congestion_Aware
../lib/libAstraSim.a(et_feeder.cpp.o): in function `std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >* absl::lts_20230802::log_internal::MakeCheckOpString<int const&, int const&>(int const&, int const&, char const*)':
env/include/absl/log/internal/check_op.h:292: undefined reference to `absl::lts_20230802::log_internal::CheckOpMessageBuilder::CheckOpMessageBuilder(char const*)'
env/bin/../lib/gcc/x86_64-conda-linux-gnu/11.4.0/../../../../x86_64-conda-linux-gnu/bin/ld: env/include/absl/log/internal/check_op.h:294: undefined reference to `absl::lts_20230802::log_internal::CheckOpMessageBuilder::ForVar2()'
env/bin/../lib/gcc/x86_64-conda-linux-gnu/11.4.0/../../../../x86_64-conda-linux-gnu/bin/ld: env/include/absl/log/internal/check_op.h:295: undefined reference to `absl::lts_20230802::log_internal::CheckOpMessageBuilder::NewString[abi:cxx11]()'

# skipped for brevity
```

Following https://github.com/protocolbuffers/protobuf/issues/12292 issue discussions:

> I believe the issue is that something like `find_package(protobuf REQUIRED)` uses the embedded `FindProtobuf` package from CMake:
> 
> https://cmake.org/cmake/help/latest/module/FindProtobuf.html
> 
> This package has not been updated to know about the `Abseil` dependency. One needs to use:
> 
> ```cmake
> find_package(protobuf REQUIRED CONFIG)
> ```

and https://github.com/protocolbuffers/protobuf/issues/4806:

> You should not need any of these variables. Just link against `protobuf::libprotobuf` target, it will also find the headers correctly!


This PR fixes the problem in my environment.