### PR TITLE
Changhai improve workload layer

### DIFF
--- a/astra-sim/workload/HardwareResource.cc
+++ b/astra-sim/workload/HardwareResource.cc
@@ -14,60 +14,127 @@ using namespace Chakra;
 typedef ChakraProtoMsg::NodeType ChakraNodeType;
 
 HardwareResource::HardwareResource(uint32_t num_npus)
-    : num_npus(num_npus), num_in_flight_cpu_ops(0), num_in_flight_gpu_comm_ops(0), 
-    num_in_flight_gpu_comp_ops(0) {}
+    : num_npus(num_npus), num_in_flight_cpu_comp_ops(0u), num_in_flight_gpu_comp_ops(0u), 
+    num_in_flight_comm_send_ops(0u), num_in_flight_comm_recv_ops(0u), num_in_flight_mem_load_ops(0u),
+    num_in_flight_mem_store_ops(0u) {}
 
 void HardwareResource::occupy(const shared_ptr<Chakra::ETFeederNode> node) {
-  if (node->is_cpu_op()) {
-    assert(num_in_flight_cpu_ops == 0);
-    ++num_in_flight_cpu_ops;
-  } else {
-    if (node->type() == ChakraNodeType::COMP_NODE){
-      assert(num_in_flight_gpu_comp_ops == 0);
-      ++num_in_flight_gpu_comp_ops;
-    } else{
-      assert(num_in_flight_gpu_comm_ops == 0);
-      ++num_in_flight_gpu_comm_ops;
+  if (
+    node->type() == ChakraNodeType::COMM_COLL_NODE ||
+    node->type() == ChakraNodeType::COMM_SEND_NODE
+  ) {
+    assert(num_in_flight_comm_send_ops == 0);
+    this->num_in_flight_comm_send_ops++;
+  }
+  else if (node->type() == ChakraNodeType::COMM_RECV_NODE) {
+    this->num_in_flight_comm_recv_ops++;
+  }
+  else if (node->type() == ChakraNodeType::COMP_NODE) {
+    if (node->is_cpu_op()) {
+      assert(num_in_flight_cpu_comp_ops == 0);
+      this->num_in_flight_cpu_comp_ops++;
     }
+    else {
+      assert(num_in_flight_gpu_comp_ops == 0);
+      this->num_in_flight_gpu_comp_ops++;
+    }
+  }
+  else if (node->type() == ChakraNodeType::MEM_LOAD_NODE) {
+    assert(num_in_flight_mem_load_ops == 0);
+    this->num_in_flight_mem_load_ops++;
+  }
+  else if (node->type() == ChakraNodeType::MEM_STORE_NODE) {
+    assert(num_in_flight_mem_store_ops == 0);
+    this->num_in_flight_mem_store_ops++;
+  }
+  else if (node->type() == ChakraNodeType::INVALID_NODE) {
+    // pass
+  }
+  else {
+    cerr << "invalid node type" << endl;
+    exit(-1);
   }
 }
 
 void HardwareResource::release(const shared_ptr<Chakra::ETFeederNode> node) {
-  if (node->is_cpu_op()) {
-    --num_in_flight_cpu_ops;
-    assert(num_in_flight_cpu_ops == 0);
-  } else {
-    if (node->type() == ChakraNodeType::COMP_NODE){
-      --num_in_flight_gpu_comp_ops;
-      assert(num_in_flight_gpu_comp_ops == 0);
-    } else {
-      --num_in_flight_gpu_comm_ops;
-      assert(num_in_flight_gpu_comm_ops == 0);
+  if (
+    node->type() == ChakraNodeType::COMM_COLL_NODE ||
+    node->type() == ChakraNodeType::COMM_SEND_NODE
+  ) {
+    this->num_in_flight_comm_send_ops--;
+  }
+  else if (node->type() == ChakraNodeType::COMM_RECV_NODE) {
+    this->num_in_flight_comm_recv_ops--;
+  }
+  else if (node->type() == ChakraNodeType::COMP_NODE) {
+    if (node->is_cpu_op()) {
+      this->num_in_flight_cpu_comp_ops--;
     }
+    else {
+      this->num_in_flight_gpu_comp_ops--;
+    }
+  }
+  else if (node->type() == ChakraNodeType::MEM_LOAD_NODE) {
+    this->num_in_flight_mem_load_ops--;
+  }
+  else if (node->type() == ChakraNodeType::MEM_STORE_NODE) {
+    this->num_in_flight_mem_store_ops--;
+  }
+  else if (node->type() == ChakraNodeType::INVALID_NODE) {
+    // pass
+  }
+  else {
+    cerr << "invalid node type" << endl;
+    exit(-1);
   }
 }
 
 bool HardwareResource::is_available(
     const shared_ptr<Chakra::ETFeederNode> node) const {
-  if (node->is_cpu_op()) {
-      if (num_in_flight_cpu_ops == 0) {
-        return true;
-      } else {
-        return false;
-      }
-  } else {
-      if (node->type() == ChakraNodeType::COMP_NODE){
-        if (num_in_flight_gpu_comp_ops == 0) {
-          return true;
-        } else {
-          return false;
-        }
-      } else {
-        if (num_in_flight_gpu_comm_ops == 0) {
-          return true;
-        } else {
-          return false;
-        }
-      }
+  if (
+    node->type() == ChakraNodeType::COMM_COLL_NODE ||
+    node->type() == ChakraNodeType::COMM_SEND_NODE
+  ) {
+    return this->num_in_flight_comm_send_ops < 1u;
   }
+  else if (node->type() == ChakraNodeType::COMM_RECV_NODE) {
+    return true;
+  }
+  else if (node->type() == ChakraNodeType::COMP_NODE) {
+    if (node->is_cpu_op()) {
+      return this->num_in_flight_cpu_comp_ops < 1u;
+    }
+    else {
+      return this->num_in_flight_gpu_comp_ops < 1u;
+    }
+  }
+  else if (node->type() == ChakraNodeType::MEM_LOAD_NODE) {
+    return this->num_in_flight_mem_load_ops < 1u;
+  }
+  else if (node->type() == ChakraNodeType::MEM_STORE_NODE) {
+    return this->num_in_flight_mem_store_ops < 1u;
+  }
+  else if (node->type() == ChakraNodeType::INVALID_NODE) {
+    return true;
+  }
+  else {
+    cerr << "invalid node type" << endl;
+    exit(-1);
+  }
+}
+
+bool HardwareResource::all_resources_released() const {
+  if (num_in_flight_cpu_comp_ops != 0)
+    return false;
+  if (num_in_flight_gpu_comp_ops != 0)
+    return false;
+  if (num_in_flight_comm_send_ops != 0)
+    return false;
+  if (num_in_flight_comm_recv_ops != 0)
+    return false;
+  if (num_in_flight_mem_load_ops != 0)
+    return false;
+  if (num_in_flight_mem_store_ops != 0)
+    return false;
+  return true;
 }

--- a/astra-sim/workload/HardwareResource.hh
+++ b/astra-sim/workload/HardwareResource.hh
@@ -20,11 +20,15 @@ class HardwareResource {
   void occupy(const std::shared_ptr<Chakra::ETFeederNode> node);
   void release(const std::shared_ptr<Chakra::ETFeederNode> node);
   bool is_available(const std::shared_ptr<Chakra::ETFeederNode> node) const;
+  bool all_resources_released() const;
 
   const uint32_t num_npus;
-  uint32_t num_in_flight_cpu_ops;
+  uint32_t num_in_flight_cpu_comp_ops;
   uint32_t num_in_flight_gpu_comp_ops;
-  uint32_t num_in_flight_gpu_comm_ops;
+  uint32_t num_in_flight_comm_send_ops;
+  uint32_t num_in_flight_comm_recv_ops;
+  uint32_t num_in_flight_mem_load_ops;
+  uint32_t num_in_flight_mem_store_ops;
 };
 
 } // namespace AstraSim

--- a/astra-sim/workload/Workload.hh
+++ b/astra-sim/workload/Workload.hh
@@ -33,7 +33,8 @@ class Workload : public Callable {
   void issue(std::shared_ptr<Chakra::ETFeederNode> node);
   void issue_replay(std::shared_ptr<Chakra::ETFeederNode> node);
   void issue_remote_mem(std::shared_ptr<Chakra::ETFeederNode> node);
-  void issue_comp(std::shared_ptr<Chakra::ETFeederNode> node);
+  void issue_comp_cpu(std::shared_ptr<Chakra::ETFeederNode> node);
+  void issue_comp_gpu(std::shared_ptr<Chakra::ETFeederNode> node);
   void issue_comm(std::shared_ptr<Chakra::ETFeederNode> node);
   void skip_invalid(std::shared_ptr<Chakra::ETFeederNode> node);
   void call(EventType event, CallData* data);

--- a/runs/example/workload/generate.sh
+++ b/runs/example/workload/generate.sh
@@ -4,9 +4,9 @@ SCRIPT_DIR=$(dirname "$(realpath $0)")
 CHAKRA_DIR=${SCRIPT_DIR}"/../../../extern/graph_frontend/chakra"
 ASTRASIM_DIR=${SCRIPT_DIR}"/../../.."
 
-cd ${CHAKRA_DIR}
-
 # if not install chakra package, uncomment following
+# cd ${CHAKRA_DIR}
 # python -m pip install . --user
 
-python -m et_converter.et_converter --input_type Text --input_filename ${ASTRASIM_DIR}/inputs/workload/ASTRA-sim-1.0/Resnet50_DataParallel.txt --output_filename ${ASTRASIM_DIR}/runs/example/workload/Resnet50_DataParallel --num_dims 1 --num_npus 64 --num_passes 1
+cd ${SCRIPT_DIR}
+python -m chakra.et_converter.et_converter --input_type Text --input_filename ${ASTRASIM_DIR}/inputs/workload/ASTRA-sim-1.0/Resnet50_DataParallel.txt --output_filename ${ASTRASIM_DIR}/runs/example/workload/Resnet50_DataParallel --num_dims 1 --num_npus 64 --num_passes 1


### PR DESCRIPTION
## Summary
~~This PR contains commits belong to #151. New commits start from 39c83b0. This PR is tested with chakra updated to https://github.com/mlcommons/chakra/pull/76. Not sure if original chakra works.~~

- ~~Added attr checking before issuing nodes~~ Do not supported because pending chakra PR for optional attrs not merged.
- Re-categorized node type to mem/comm/gpu_comp/cpu_comp, updated corresponding hw_resources types.
- ~~Fixed bug of queue_levels when queues.size()=1~~ Covered in other PR
- Updated workload generation script in example runs.

## Test Plan
Using runs/example, assuming workload generated with new chakra(with [#76,](https://github.com/mlcommons/chakra/pull/76) also after updated text converter in [#78](https://github.com/mlcommons/chakra/pull/78) to make sure the generated workloads is correct).

### Positive case:
```
cd runs/example
./run.sh
```
and has output
```
[2023-12-07 11:55:08.693] [topology::RingTopology] [info] ring of node 0, id: 0 dimension: local total nodes in ring: 64 index in ring: 0total nodes in ring: 1
[2023-12-07 11:55:08.693] [topology::RingTopology] [info] ring of node 0, id: 0 dimension: local total nodes in ring: 64 index in ring: 0total nodes in ring: 1
[2023-12-07 11:55:08.693] [topology::RingTopology] [info] ring of node 0, id: 0 dimension: local total nodes in ring: 64 index in ring: 0total nodes in ring: 1
[2023-12-07 11:55:08.693] [topology::RingTopology] [info] ring of node 0, id: 0 dimension: local total nodes in ring: 64 index in ring: 0total nodes in ring: 1
[2023-12-07 11:55:14.567] [workload] [info] sys[8] finished, 1082454160 cycles
[2023-12-07 11:55:14.567] [workload] [info] sys[9] finished, 1082454160 cycles
[2023-12-07 11:55:14.567] [workload] [info] sys[10] finished, 1082454160 cycles
[2023-12-07 11:55:14.567] [workload] [info] sys[11] finished, 1082454160 cycles
[2023-12-07 11:55:14.567] [workload] [info] sys[12] finished, 1082454160 cycles
[2023-12-07 11:55:14.567] [workload] [info] sys[13] finished, 1082454160 cycles
[2023-12-07 11:55:14.567] [workload] [info] sys[14] finished, 1082454160 cycles
[2023-12-07 11:55:14.567] [workload] [info] sys[15] finished, 1082454160 cycles
[2023-12-07 11:55:14.567] [workload] [info] sys[16] finished, 1082454160 cycles
[2023-12-07 11:55:14.568] [workload] [info] sys[17] finished, 1082454160 cycles
[2023-12-07 11:55:14.568] [workload] [info] sys[18] finished, 1082454160 cycles
[2023-12-07 11:55:14.568] [workload] [info] sys[19] finished, 1082454160 cycles
[2023-12-07 11:55:14.568] [workload] [info] sys[20] finished, 1082454160 cycles
[2023-12-07 11:55:14.568] [workload] [info] sys[21] finished, 1082454160 cycles
[2023-12-07 11:55:14.568] [workload] [info] sys[22] finished, 1082454160 cycles
[2023-12-07 11:55:14.568] [workload] [info] sys[23] finished, 1082454160 cycles
[2023-12-07 11:55:14.568] [workload] [info] sys[24] finished, 1082454160 cycles
[2023-12-07 11:55:14.568] [workload] [info] sys[25] finished, 1082454160 cycles
[2023-12-07 11:55:14.568] [workload] [info] sys[26] finished, 1082454160 cycles
[2023-12-07 11:55:14.568] [workload] [info] sys[27] finished, 1082454160 cycles
[2023-12-07 11:55:14.568] [workload] [info] sys[28] finished, 1082454160 cycles
[2023-12-07 11:55:14.568] [workload] [info] sys[29] finished, 1082454160 cycles
[2023-12-07 11:55:14.568] [workload] [info] sys[30] finished, 1082454160 cycles
[2023-12-07 11:55:14.568] [workload] [info] sys[31] finished, 1082454160 cycles
[2023-12-07 11:55:14.569] [workload] [info] sys[32] finished, 1082454160 cycles
[2023-12-07 11:55:14.569] [workload] [info] sys[33] finished, 1082454160 cycles
[2023-12-07 11:55:14.569] [workload] [info] sys[34] finished, 1082454160 cycles
[2023-12-07 11:55:14.569] [workload] [info] sys[35] finished, 1082454160 cycles
[2023-12-07 11:55:14.569] [workload] [info] sys[36] finished, 1082454160 cycles
[2023-12-07 11:55:14.569] [workload] [info] sys[37] finished, 1082454160 cycles
[2023-12-07 11:55:14.569] [workload] [info] sys[38] finished, 1082454160 cycles
[2023-12-07 11:55:14.569] [workload] [info] sys[39] finished, 1082454160 cycles
[2023-12-07 11:55:14.569] [workload] [info] sys[40] finished, 1082454160 cycles
[2023-12-07 11:55:14.569] [workload] [info] sys[41] finished, 1082454160 cycles
[2023-12-07 11:55:14.569] [workload] [info] sys[42] finished, 1082454160 cycles
[2023-12-07 11:55:14.569] [workload] [info] sys[43] finished, 1082454160 cycles
[2023-12-07 11:55:14.569] [workload] [info] sys[44] finished, 1082454160 cycles
[2023-12-07 11:55:14.569] [workload] [info] sys[45] finished, 1082454160 cycles
[2023-12-07 11:55:14.569] [workload] [info] sys[46] finished, 1082454160 cycles
[2023-12-07 11:55:14.569] [workload] [info] sys[47] finished, 1082454160 cycles
[2023-12-07 11:55:14.570] [workload] [info] sys[48] finished, 1082454160 cycles
[2023-12-07 11:55:14.570] [workload] [info] sys[49] finished, 1082454160 cycles
[2023-12-07 11:55:14.570] [workload] [info] sys[50] finished, 1082454160 cycles
[2023-12-07 11:55:14.570] [workload] [info] sys[51] finished, 1082454160 cycles
[2023-12-07 11:55:14.570] [workload] [info] sys[52] finished, 1082454160 cycles
[2023-12-07 11:55:14.570] [workload] [info] sys[53] finished, 1082454160 cycles
[2023-12-07 11:55:14.570] [workload] [info] sys[54] finished, 1082454160 cycles
[2023-12-07 11:55:14.570] [workload] [info] sys[55] finished, 1082454160 cycles
[2023-12-07 11:55:14.570] [workload] [info] sys[56] finished, 1082454160 cycles
[2023-12-07 11:55:14.570] [workload] [info] sys[57] finished, 1082454160 cycles
[2023-12-07 11:55:14.570] [workload] [info] sys[58] finished, 1082454160 cycles
[2023-12-07 11:55:14.570] [workload] [info] sys[59] finished, 1082454160 cycles
[2023-12-07 11:55:14.570] [workload] [info] sys[60] finished, 1082454160 cycles
[2023-12-07 11:55:14.570] [workload] [info] sys[61] finished, 1082454160 cycles
[2023-12-07 11:55:14.570] [workload] [info] sys[62] finished, 1082454160 cycles
[2023-12-07 11:55:14.571] [workload] [info] sys[63] finished, 1082454160 cycles
[2023-12-07 11:55:14.571] [workload] [info] sys[0] finished, 1082454160 cycles
[2023-12-07 11:55:14.571] [workload] [info] sys[1] finished, 1082454160 cycles
[2023-12-07 11:55:14.571] [workload] [info] sys[2] finished, 1082454160 cycles
[2023-12-07 11:55:14.571] [workload] [info] sys[3] finished, 1082454160 cycles
[2023-12-07 11:55:14.571] [workload] [info] sys[4] finished, 1082454160 cycles
[2023-12-07 11:55:14.571] [workload] [info] sys[5] finished, 1082454160 cycles
[2023-12-07 11:55:14.571] [workload] [info] sys[6] finished, 1082454160 cycles
[2023-12-07 11:55:14.571] [workload] [info] sys[7] finished, 1082454160 cycles
[2023-12-07 11:55:14.573] [System] [info] Exiting
```

### ~~negative case~~
Because there is not attr check thus no negative case for now.

## Additional Notes
~~Should be merged after PR #151 to fast-forward a clean history.~~
Fixed the bug: in previous example the communication will be routing to `skip_invalid` because `node->is_cpu_op()==True` and `node->runtime()==0`, according to `workload.cc:130` it will be invalid, which should not be correct.
