### PR TITLE
Rendezvous Protocol Segfault Fix: The SimSendCaller and SimRecvCaller…

### DIFF
--- a/astra-sim/system/RendezvousRecvData.cc
+++ b/astra-sim/system/RendezvousRecvData.cc
@@ -19,6 +19,4 @@ RendezvousRecvData::RendezvousRecvData(
     void (*msg_handler)(void* fun_arg),
     void* fun_arg)
     : BasicEventHandlerData(sys_id, EventType::RendezvousRecv), recv(sys, buffer, count, type, src, tag, request, msg_handler, fun_arg, false) {
-  //this->recv = SimRecvCaller r(
-  //    sys, buffer, count, type, src, tag, request, msg_handler, fun_arg);
 }

--- a/astra-sim/system/RendezvousRecvData.cc
+++ b/astra-sim/system/RendezvousRecvData.cc
@@ -18,7 +18,7 @@ RendezvousRecvData::RendezvousRecvData(
     sim_request request,
     void (*msg_handler)(void* fun_arg),
     void* fun_arg)
-    : BasicEventHandlerData(sys_id, EventType::RendezvousRecv) {
-  this->recv = new SimRecvCaller(
-      sys, buffer, count, type, src, tag, request, msg_handler, fun_arg);
+    : BasicEventHandlerData(sys_id, EventType::RendezvousRecv), recv(sys, buffer, count, type, src, tag, request, msg_handler, fun_arg, false) {
+  //this->recv = SimRecvCaller r(
+  //    sys, buffer, count, type, src, tag, request, msg_handler, fun_arg);
 }

--- a/astra-sim/system/RendezvousRecvData.hh
+++ b/astra-sim/system/RendezvousRecvData.hh
@@ -26,7 +26,7 @@ class RendezvousRecvData : public BasicEventHandlerData, public MetaData {
       sim_request request,
       void (*msg_handler)(void* fun_arg),
       void* fun_arg);
-  SimRecvCaller* recv;
+  SimRecvCaller recv;
 };
 
 } // namespace AstraSim

--- a/astra-sim/system/RendezvousSendData.cc
+++ b/astra-sim/system/RendezvousSendData.cc
@@ -18,7 +18,7 @@ RendezvousSendData::RendezvousSendData(
     sim_request request,
     void (*msg_handler)(void* fun_arg),
     void* fun_arg)
-    : BasicEventHandlerData(sys_id, EventType::RendezvousSend) {
-  this->send = new SimSendCaller(
-      sys, buffer, count, type, dst, tag, request, msg_handler, fun_arg);
+    : BasicEventHandlerData(sys_id, EventType::RendezvousSend), send(sys, buffer, count, type, dst, tag, request, msg_handler, fun_arg, false) {
+  //this->send = new SimSendCaller(
+  //    sys, buffer, count, type, dst, tag, request, msg_handler, fun_arg);
 }

--- a/astra-sim/system/RendezvousSendData.cc
+++ b/astra-sim/system/RendezvousSendData.cc
@@ -19,6 +19,4 @@ RendezvousSendData::RendezvousSendData(
     void (*msg_handler)(void* fun_arg),
     void* fun_arg)
     : BasicEventHandlerData(sys_id, EventType::RendezvousSend), send(sys, buffer, count, type, dst, tag, request, msg_handler, fun_arg, false) {
-  //this->send = new SimSendCaller(
-  //    sys, buffer, count, type, dst, tag, request, msg_handler, fun_arg);
 }

--- a/astra-sim/system/RendezvousSendData.hh
+++ b/astra-sim/system/RendezvousSendData.hh
@@ -26,7 +26,7 @@ class RendezvousSendData : public BasicEventHandlerData, public MetaData {
       sim_request request,
       void (*msg_handler)(void* fun_arg),
       void* fun_arg);
-  SimSendCaller* send;
+  SimSendCaller send;
 };
 
 } // namespace AstraSim

--- a/astra-sim/system/SimRecvCaller.cc
+++ b/astra-sim/system/SimRecvCaller.cc
@@ -17,7 +17,8 @@ SimRecvCaller::SimRecvCaller(
     int tag,
     sim_request request,
     void (*msg_handler)(void* fun_arg),
-    void* fun_arg) {
+    void* fun_arg,
+    bool should_cleanup) {
   this->sys = sys;
   this->buffer = buffer;
   this->count = count;
@@ -27,6 +28,7 @@ SimRecvCaller::SimRecvCaller(
   this->request = request;
   this->msg_handler = msg_handler;
   this->fun_arg = fun_arg;
+  this->should_cleanup = should_cleanup;
 }
 
 void SimRecvCaller::call(EventType type, CallData* data) {
@@ -39,5 +41,6 @@ void SimRecvCaller::call(EventType type, CallData* data) {
       &this->request,
       this->msg_handler,
       this->fun_arg);
-  delete this;
+  if(should_cleanup)
+    delete this;
 }

--- a/astra-sim/system/SimRecvCaller.hh
+++ b/astra-sim/system/SimRecvCaller.hh
@@ -23,6 +23,7 @@ class SimRecvCaller : public Callable {
   sim_request request;
   void (*msg_handler)(void* fun_arg);
   void* fun_arg;
+  bool should_cleanup;
   void call(EventType type, CallData* data);
   Sys* sys;
   SimRecvCaller(
@@ -34,7 +35,8 @@ class SimRecvCaller : public Callable {
       int tag,
       sim_request request,
       void (*msg_handler)(void* fun_arg),
-      void* fun_arg);
+      void* fun_arg,
+      bool should_cleanup);
 };
 
 } // namespace AstraSim

--- a/astra-sim/system/SimSendCaller.cc
+++ b/astra-sim/system/SimSendCaller.cc
@@ -17,7 +17,8 @@ SimSendCaller::SimSendCaller(
     int tag,
     sim_request request,
     void (*msg_handler)(void* fun_arg),
-    void* fun_arg) {
+    void* fun_arg,
+    bool should_cleanup) {
   this->sys = sys;
   this->buffer = buffer;
   this->count = count;
@@ -27,9 +28,11 @@ SimSendCaller::SimSendCaller(
   this->request = request;
   this->msg_handler = msg_handler;
   this->fun_arg = fun_arg;
+  this->should_cleanup = should_cleanup;
 }
 
 void SimSendCaller::call(EventType type, CallData* data) {
+  //std::cout<<"sysid: "<<sys->id<<std::endl;
   sys->comm_NI->sim_send(
       this->buffer,
       this->count,
@@ -39,5 +42,6 @@ void SimSendCaller::call(EventType type, CallData* data) {
       &this->request,
       this->msg_handler,
       this->fun_arg);
-  delete this;
+  if(should_cleanup)
+    delete this;
 }

--- a/astra-sim/system/SimSendCaller.hh
+++ b/astra-sim/system/SimSendCaller.hh
@@ -22,6 +22,7 @@ class SimSendCaller : public Callable {
   sim_request request;
   void (*msg_handler)(void* fun_arg);
   void* fun_arg;
+  bool should_cleanup;
   void call(EventType type, CallData* data);
   Sys* sys;
   SimSendCaller(
@@ -33,7 +34,8 @@ class SimSendCaller : public Callable {
       int tag,
       sim_request request,
       void (*msg_handler)(void* fun_arg),
-      void* fun_arg);
+      void* fun_arg,
+      bool should_cleanup);
 };
 
 } // namespace AstraSim

--- a/astra-sim/system/Sys.cc
+++ b/astra-sim/system/Sys.cc
@@ -589,11 +589,11 @@ void Sys::handleEvent(void* arg) {
     all_sys[id]->call_events();
   } else if (event == EventType::RendezvousSend) {
     RendezvousSendData* rsd = (RendezvousSendData*)ehd;
-    rsd->send->call(EventType::General, nullptr);
+    rsd->send.call(EventType::General, nullptr);
     delete rsd;
   } else if (event == EventType::RendezvousRecv) {
     RendezvousRecvData* rrd = (RendezvousRecvData*)ehd;
-    rrd->recv->call(EventType::General, nullptr);
+    rrd->recv.call(EventType::General, nullptr);
     delete rrd;
   } else if (
       (event == EventType::CompFinished) ||
@@ -1540,7 +1540,8 @@ int Sys::sim_send(
             tag,
             *request,
             msg_handler,
-            fun_arg),
+            fun_arg,
+            true),
         EventType::General,
         nullptr,
         delay);
@@ -1572,7 +1573,8 @@ int Sys::sim_recv(
             tag,
             *request,
             msg_handler,
-            fun_arg),
+            fun_arg,
+            true),
         EventType::General,
         nullptr,
         delay);


### PR DESCRIPTION
Rendezvous Protocol Segfault Fix: The `SimSendCaller `and `SimRecvCaller `are changed from pointer to object inside `RendezvousRecvData `and `RendezvousSendData `classes, respectively. Storing them as pointer creates some memory corruption (segfault) when the network backend has significant traffic congestion.