### PR TITLE
Fix underflow bug in generate_collective

### DIFF
--- a/astra-sim/system/Sys.cc
+++ b/astra-sim/system/Sys.cc
@@ -829,7 +829,8 @@ DataSet* Sys::generate_collective(
              InterDimensionScheduling::OfflineGreedy &&
          inter_dimension_scheduling !=
              InterDimensionScheduling::OfflineGreedyFlex)) {
-      size -= chunk_size;
+      if (chunk_size > size) size = 0;
+      else size -= chunk_size;
     }
     remain_size = chunk_size;
     list<CollectivePhase> vect;


### PR DESCRIPTION
## Summary
generate_collective in Sys.cc malfunctions when underflow occurs. For instance, it overestimates execution time or falls in infinite loop.
This PR is to fix the problem by preventing underflow of variable `size` which is defined as uint64_t.

## Test Plan
I found this bug when I ran megatron attached in this PR. 

**Command**
```
./build/astra_analytical/build/bin/AstraSim_Analytical_Congestion_Unaware --workload-configuration=/home/un-gpu/Project/jpark/astra-sim/megatron-tp8/megatron_chakra --system-configuration=./inputs/system/Ring.json --network-configuration=./inputs/network/analytical/Ring.yml --remote-memory-configuration=./input
/remote_memory/analytical/no_memory_expansion.json
```

**./inputs/network/analytical/Ring.yml**
```
# Ring Topology
topology: [ Ring ]  # Ring, Switch, FullyConnected

# 8 NPUs
npus_count: [ 8 ]  # number of NPUs

# Bandwidth per each link (per direction)
bandwidth: [ 50.0 ]  # GB/s

# Latency per each link

latency: [ 500.0 ]  # ns
```
[megatron-tp8.zip](https://github.com/astra-sim/astra-sim/files/14749529/megatron-tp8.zip)
