### PR TITLE
[Bugfix]: add checking/offsets to avoid comm tag collilsion

### DIFF
--- a/astra-sim/system/Sys.cc
+++ b/astra-sim/system/Sys.cc
@@ -830,10 +830,8 @@ DataSet* Sys::generate_collective(
              InterDimensionScheduling::OfflineGreedy &&
          inter_dimension_scheduling !=
              InterDimensionScheduling::OfflineGreedyFlex)) {
-      if (chunk_size > size)
-        size = 0;
-      else
-        size -= chunk_size;
+      if (chunk_size > size) size = 0;
+      else size -= chunk_size;
     }
     remain_size = chunk_size;
     list<CollectivePhase> vect;

--- a/astra-sim/system/Sys.cc
+++ b/astra-sim/system/Sys.cc
@@ -1483,6 +1483,11 @@ int Sys::rendezvous_sim_send(
     sim_request* request,
     void (*msg_handler)(void* fun_arg),
     void* fun_arg) {
+  if (tag >= this->RENDEZVOUS_COMM_TAG_OFFSET) {
+    sys_panic(
+        "tag is bigger than RENDEZVOUS_COMM_TAG_OFFSET, \
+        which means it might be mistakenly used as a rendezvous tag.");
+  }
   RendezvousSendData* rsd = new RendezvousSendData(
       id, this, buffer, count, type, dst, tag, *request, msg_handler, fun_arg);
   sim_request newReq = *request;
@@ -1490,7 +1495,7 @@ int Sys::rendezvous_sim_send(
   newReq.dstRank = request->srcRank;
   newReq.srcRank = request->dstRank;
   newReq.reqCount = rendevouz_size;
-  int newTag = tag + 500000000;
+  int newTag = tag + this->RENDEZVOUS_COMM_TAG_OFFSET;
   newReq.tag = newTag;
   sim_recv(
       delay,
@@ -1515,6 +1520,11 @@ int Sys::rendezvous_sim_recv(
     sim_request* request,
     void (*msg_handler)(void* fun_arg),
     void* fun_arg) {
+  if (tag >= this->RENDEZVOUS_COMM_TAG_OFFSET) {
+    sys_panic(
+        "tag is bigger than RENDEZVOUS_COMM_TAG_OFFSET, \
+        which means it might be mistakenly used as a rendezvous tag.");
+  }
   RendezvousRecvData* rrd = new RendezvousRecvData(
       id, this, buffer, count, type, src, tag, *request, msg_handler, fun_arg);
   sim_request newReq = *request;
@@ -1522,7 +1532,7 @@ int Sys::rendezvous_sim_recv(
   newReq.dstRank = request->srcRank;
   newReq.srcRank = request->dstRank;
   newReq.reqCount = rendevouz_size;
-  int newTag = tag + 500000000;
+  int newTag = tag + this->RENDEZVOUS_COMM_TAG_OFFSET;
   newReq.tag = newTag;
   sim_send(
       delay,

--- a/astra-sim/system/Sys.hh
+++ b/astra-sim/system/Sys.hh
@@ -312,6 +312,8 @@ class Sys : public Callable {
 
   // skip simulation for all nodes and use current duration
   bool replay_only;
+
+  const int32_t RENDEZVOUS_COMM_TAG_OFFSET = 1000000000;
 };
 
 } // namespace AstraSim

--- a/astra-sim/system/Sys.hh
+++ b/astra-sim/system/Sys.hh
@@ -152,7 +152,7 @@ class Sys : public Callable {
   //---------------------------------------------------------------------------
 
   // Middle-level Network Primitives ------------------------------------------
-  uint64_t determine_chunk_size(uint64_t& size, ComType type);
+  uint64_t determine_chunk_size(uint64_t &size, ComType type);
   int get_priority(int explicit_priority);
   void insert_into_ready_list(BaseStream* stream);
   void insert_stream(std::list<BaseStream*>* queue, BaseStream* baseStream);

--- a/astra-sim/system/Sys.hh
+++ b/astra-sim/system/Sys.hh
@@ -152,7 +152,7 @@ class Sys : public Callable {
   //---------------------------------------------------------------------------
 
   // Middle-level Network Primitives ------------------------------------------
-  uint64_t determine_chunk_size(uint64_t &size, ComType type);
+  uint64_t determine_chunk_size(uint64_t& size, ComType type);
   int get_priority(int explicit_priority);
   void insert_into_ready_list(BaseStream* stream);
   void insert_stream(std::list<BaseStream*>* queue, BaseStream* baseStream);
@@ -162,6 +162,19 @@ class Sys : public Callable {
   //---------------------------------------------------------------------------
 
   // Low-level Network Primitives ---------------------------------------------
+  enum FrontEndSendRecvType {
+    // NATIVE means send/recv is issued directly by workload input
+    // COLLECTIVE means send/recv is caused by a collective communication
+    // RENDEZVOUS means send/recv is a rendezvous shake hand
+    // The value here presents the offset of the tag. The tag range for
+    // different type is as follows
+    // NATIVE: [0, 500000000)
+    // COLLECTIVE: [500000000, 1000000000)
+    // RENDEZVOUS: [1000000000, 2000000000)
+    NATIVE = 0,
+    COLLECTIVE = 500000000,
+    RENDEZVOUS = 1000000000
+  };
   int front_end_sim_send(
       Tick delay,
       void* buffer,
@@ -170,6 +183,7 @@ class Sys : public Callable {
       int dst,
       int tag,
       sim_request* request,
+      FrontEndSendRecvType send_type,
       void (*msg_handler)(void* fun_arg),
       void* fun_arg);
 
@@ -181,6 +195,7 @@ class Sys : public Callable {
       int src,
       int tag,
       sim_request* request,
+      FrontEndSendRecvType recv_type,
       void (*msg_handler)(void* fun_arg),
       void* fun_arg);
 
@@ -312,8 +327,6 @@ class Sys : public Callable {
 
   // skip simulation for all nodes and use current duration
   bool replay_only;
-
-  const int32_t RENDEZVOUS_COMM_TAG_OFFSET = 1000000000;
 };
 
 } // namespace AstraSim

--- a/astra-sim/system/collective/Algorithm.hh
+++ b/astra-sim/system/collective/Algorithm.hh
@@ -32,6 +32,7 @@ class Algorithm : public Callable {
   uint64_t final_data_size;
   ComType comType;
   bool enabled;
+  static const int32_t TAG_OFFSET = 500000000;
 };
 
 } // namespace AstraSim

--- a/astra-sim/system/collective/Algorithm.hh
+++ b/astra-sim/system/collective/Algorithm.hh
@@ -32,7 +32,6 @@ class Algorithm : public Callable {
   uint64_t final_data_size;
   ComType comType;
   bool enabled;
-  static const int32_t TAG_OFFSET = 500000000;
 };
 
 } // namespace AstraSim

--- a/astra-sim/system/collective/DoubleBinaryTreeAllReduce.cc
+++ b/astra-sim/system/collective/DoubleBinaryTreeAllReduce.cc
@@ -48,7 +48,7 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
     sim_request snd_req;
     snd_req.srcRank = stream->owner->id;
     snd_req.dstRank = parent;
-    snd_req.tag = stream->stream_id;
+    snd_req.tag = stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET;
     snd_req.reqType = UINT8;
     snd_req.vnet = this->stream->current_queue_id;
     stream->owner->front_end_sim_send(
@@ -57,7 +57,7 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         data_size,
         UINT8,
         parent,
-        stream->stream_id,
+        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET,
         &snd_req,
         &Sys::handleEvent,
         nullptr);
@@ -69,14 +69,14 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         stream->owner->id,
         EventType::PacketReceived,
         stream->current_queue_id,
-        stream->stream_id);
+        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET);
     stream->owner->front_end_sim_recv(
         0,
         Sys::dummy_data,
         data_size,
         UINT8,
         parent,
-        stream->stream_id,
+        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET,
         &rcv_req,
         &Sys::handleEvent,
         ehd);
@@ -108,14 +108,14 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         stream->owner->id,
         EventType::PacketReceived,
         stream->current_queue_id,
-        stream->stream_id);
+        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET);
     stream->owner->front_end_sim_recv(
         0,
         Sys::dummy_data,
         data_size,
         UINT8,
         left_child,
-        stream->stream_id,
+        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET,
         &rcv_req,
         &Sys::handleEvent,
         ehd);
@@ -126,14 +126,14 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         stream->owner->id,
         EventType::PacketReceived,
         stream->current_queue_id,
-        stream->stream_id);
+        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET);
     stream->owner->front_end_sim_recv(
         0,
         Sys::dummy_data,
         data_size,
         UINT8,
         right_child,
-        stream->stream_id,
+        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET,
         &rcv_req2,
         &Sys::handleEvent,
         ehd2);
@@ -179,7 +179,7 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
     sim_request snd_req;
     snd_req.srcRank = stream->owner->id;
     snd_req.dstRank = parent;
-    snd_req.tag = stream->stream_id;
+    snd_req.tag = stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET;
     snd_req.reqType = UINT8;
     snd_req.vnet = this->stream->current_queue_id;
     stream->owner->front_end_sim_send(
@@ -188,7 +188,7 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         data_size,
         UINT8,
         parent,
-        stream->stream_id,
+        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET,
         &snd_req,
         &Sys::handleEvent,
         nullptr);
@@ -200,14 +200,14 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         stream->owner->id,
         EventType::PacketReceived,
         stream->current_queue_id,
-        stream->stream_id);
+        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET);
     stream->owner->front_end_sim_recv(
         0,
         Sys::dummy_data,
         data_size,
         UINT8,
         parent,
-        stream->stream_id,
+        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET,
         &rcv_req,
         &Sys::handleEvent,
         ehd);
@@ -233,7 +233,7 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
     sim_request snd_req;
     snd_req.srcRank = stream->owner->id;
     snd_req.dstRank = left_child;
-    snd_req.tag = stream->stream_id;
+    snd_req.tag = stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET;
     snd_req.reqType = UINT8;
     snd_req.vnet = this->stream->current_queue_id;
     stream->owner->front_end_sim_send(
@@ -242,14 +242,14 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         data_size,
         UINT8,
         left_child,
-        stream->stream_id,
+        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET,
         &snd_req,
         &Sys::handleEvent,
         nullptr);
     sim_request snd_req2;
     snd_req2.srcRank = stream->owner->id;
     snd_req2.dstRank = left_child;
-    snd_req2.tag = stream->stream_id;
+    snd_req2.tag = stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET;
     snd_req2.reqType = UINT8;
     snd_req2.vnet = this->stream->current_queue_id;
     stream->owner->front_end_sim_send(
@@ -258,7 +258,7 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         data_size,
         UINT8,
         right_child,
-        stream->stream_id,
+        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET,
         &snd_req2,
         &Sys::handleEvent,
         nullptr);
@@ -275,14 +275,14 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         stream->owner->id,
         EventType::PacketReceived,
         stream->current_queue_id,
-        stream->stream_id);
+        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET);
     stream->owner->front_end_sim_recv(
         0,
         Sys::dummy_data,
         data_size,
         UINT8,
         only_child_id,
-        stream->stream_id,
+        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET,
         &rcv_req,
         &Sys::handleEvent,
         ehd);
@@ -309,7 +309,7 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
     sim_request snd_req;
     snd_req.srcRank = stream->owner->id;
     snd_req.dstRank = only_child_id;
-    snd_req.tag = stream->stream_id;
+    snd_req.tag = stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET;
     snd_req.reqType = UINT8;
     snd_req.vnet = this->stream->current_queue_id;
     stream->owner->front_end_sim_send(
@@ -318,7 +318,7 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         data_size,
         UINT8,
         only_child_id,
-        stream->stream_id,
+        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET,
         &snd_req,
         &Sys::handleEvent,
         nullptr);

--- a/astra-sim/system/collective/DoubleBinaryTreeAllReduce.cc
+++ b/astra-sim/system/collective/DoubleBinaryTreeAllReduce.cc
@@ -48,7 +48,7 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
     sim_request snd_req;
     snd_req.srcRank = stream->owner->id;
     snd_req.dstRank = parent;
-    snd_req.tag = stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET;
+    snd_req.tag = stream->stream_id;
     snd_req.reqType = UINT8;
     snd_req.vnet = this->stream->current_queue_id;
     stream->owner->front_end_sim_send(
@@ -57,8 +57,9 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         data_size,
         UINT8,
         parent,
-        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET,
+        stream->stream_id,
         &snd_req,
+        Sys::FrontEndSendRecvType::COLLECTIVE,
         &Sys::handleEvent,
         nullptr);
     // receiving
@@ -69,15 +70,16 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         stream->owner->id,
         EventType::PacketReceived,
         stream->current_queue_id,
-        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET);
+        stream->stream_id);
     stream->owner->front_end_sim_recv(
         0,
         Sys::dummy_data,
         data_size,
         UINT8,
         parent,
-        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET,
+        stream->stream_id,
         &rcv_req,
+        Sys::FrontEndSendRecvType::COLLECTIVE,
         &Sys::handleEvent,
         ehd);
     state = State::WaitingDataFromParent;
@@ -108,15 +110,16 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         stream->owner->id,
         EventType::PacketReceived,
         stream->current_queue_id,
-        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET);
+        stream->stream_id);
     stream->owner->front_end_sim_recv(
         0,
         Sys::dummy_data,
         data_size,
         UINT8,
         left_child,
-        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET,
+        stream->stream_id,
         &rcv_req,
+        Sys::FrontEndSendRecvType::COLLECTIVE,
         &Sys::handleEvent,
         ehd);
     sim_request rcv_req2;
@@ -126,15 +129,16 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         stream->owner->id,
         EventType::PacketReceived,
         stream->current_queue_id,
-        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET);
+        stream->stream_id);
     stream->owner->front_end_sim_recv(
         0,
         Sys::dummy_data,
         data_size,
         UINT8,
         right_child,
-        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET,
+        stream->stream_id,
         &rcv_req2,
+        Sys::FrontEndSendRecvType::COLLECTIVE,
         &Sys::handleEvent,
         ehd2);
     state = State::WaitingForTwoChildData;
@@ -179,7 +183,7 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
     sim_request snd_req;
     snd_req.srcRank = stream->owner->id;
     snd_req.dstRank = parent;
-    snd_req.tag = stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET;
+    snd_req.tag = stream->stream_id;
     snd_req.reqType = UINT8;
     snd_req.vnet = this->stream->current_queue_id;
     stream->owner->front_end_sim_send(
@@ -188,8 +192,9 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         data_size,
         UINT8,
         parent,
-        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET,
+        stream->stream_id,
         &snd_req,
+        Sys::FrontEndSendRecvType::COLLECTIVE,
         &Sys::handleEvent,
         nullptr);
     // receiving
@@ -200,15 +205,16 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         stream->owner->id,
         EventType::PacketReceived,
         stream->current_queue_id,
-        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET);
+        stream->stream_id);
     stream->owner->front_end_sim_recv(
         0,
         Sys::dummy_data,
         data_size,
         UINT8,
         parent,
-        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET,
+        stream->stream_id,
         &rcv_req,
+        Sys::FrontEndSendRecvType::COLLECTIVE,
         &Sys::handleEvent,
         ehd);
     state = State::WaitingDataFromParent;
@@ -233,7 +239,7 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
     sim_request snd_req;
     snd_req.srcRank = stream->owner->id;
     snd_req.dstRank = left_child;
-    snd_req.tag = stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET;
+    snd_req.tag = stream->stream_id;
     snd_req.reqType = UINT8;
     snd_req.vnet = this->stream->current_queue_id;
     stream->owner->front_end_sim_send(
@@ -242,14 +248,15 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         data_size,
         UINT8,
         left_child,
-        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET,
+        stream->stream_id,
         &snd_req,
+        Sys::FrontEndSendRecvType::COLLECTIVE,
         &Sys::handleEvent,
         nullptr);
     sim_request snd_req2;
     snd_req2.srcRank = stream->owner->id;
     snd_req2.dstRank = left_child;
-    snd_req2.tag = stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET;
+    snd_req2.tag = stream->stream_id;
     snd_req2.reqType = UINT8;
     snd_req2.vnet = this->stream->current_queue_id;
     stream->owner->front_end_sim_send(
@@ -258,8 +265,9 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         data_size,
         UINT8,
         right_child,
-        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET,
+        stream->stream_id,
         &snd_req2,
+        Sys::FrontEndSendRecvType::COLLECTIVE,
         &Sys::handleEvent,
         nullptr);
     exit();
@@ -275,15 +283,16 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         stream->owner->id,
         EventType::PacketReceived,
         stream->current_queue_id,
-        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET);
+        stream->stream_id);
     stream->owner->front_end_sim_recv(
         0,
         Sys::dummy_data,
         data_size,
         UINT8,
         only_child_id,
-        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET,
+        stream->stream_id,
         &rcv_req,
+        Sys::FrontEndSendRecvType::COLLECTIVE,
         &Sys::handleEvent,
         ehd);
     state = State::WaitingForOneChildData;
@@ -309,7 +318,7 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
     sim_request snd_req;
     snd_req.srcRank = stream->owner->id;
     snd_req.dstRank = only_child_id;
-    snd_req.tag = stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET;
+    snd_req.tag = stream->stream_id;
     snd_req.reqType = UINT8;
     snd_req.vnet = this->stream->current_queue_id;
     stream->owner->front_end_sim_send(
@@ -318,8 +327,9 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         data_size,
         UINT8,
         only_child_id,
-        stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET,
+        stream->stream_id,
         &snd_req,
+        Sys::FrontEndSendRecvType::COLLECTIVE,
         &Sys::handleEvent,
         nullptr);
     exit();

--- a/astra-sim/system/collective/HalvingDoubling.cc
+++ b/astra-sim/system/collective/HalvingDoubling.cc
@@ -263,7 +263,7 @@ bool HalvingDoubling::ready() {
   sim_request snd_req;
   snd_req.srcRank = id;
   snd_req.dstRank = packet.preferred_dest;
-  snd_req.tag = stream->stream_id;
+  snd_req.tag = stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET;
   snd_req.reqType = UINT8;
   snd_req.vnet = this->stream->current_queue_id;
   stream->owner->front_end_sim_send(
@@ -272,7 +272,7 @@ bool HalvingDoubling::ready() {
       packet.msg_size,
       UINT8,
       packet.preferred_dest,
-      stream->stream_id,
+      stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET,
       &snd_req,
       &Sys::handleEvent,
       nullptr); // stream_id+(packet.preferred_dest*50)
@@ -283,14 +283,14 @@ bool HalvingDoubling::ready() {
       stream->owner->id,
       EventType::PacketReceived,
       packet.preferred_vnet,
-      packet.stream_id);
+      packet.stream_id % this->TAG_OFFSET + this->TAG_OFFSET);
   stream->owner->front_end_sim_recv(
       0,
       Sys::dummy_data,
       packet.msg_size,
       UINT8,
       packet.preferred_src,
-      stream->stream_id,
+      stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET,
       &rcv_req,
       &Sys::handleEvent,
       ehd); // stream_id+(owner->id*50)

--- a/astra-sim/system/collective/HalvingDoubling.cc
+++ b/astra-sim/system/collective/HalvingDoubling.cc
@@ -263,7 +263,7 @@ bool HalvingDoubling::ready() {
   sim_request snd_req;
   snd_req.srcRank = id;
   snd_req.dstRank = packet.preferred_dest;
-  snd_req.tag = stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET;
+  snd_req.tag = stream->stream_id;
   snd_req.reqType = UINT8;
   snd_req.vnet = this->stream->current_queue_id;
   stream->owner->front_end_sim_send(
@@ -272,8 +272,9 @@ bool HalvingDoubling::ready() {
       packet.msg_size,
       UINT8,
       packet.preferred_dest,
-      stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET,
+      stream->stream_id,
       &snd_req,
+      Sys::FrontEndSendRecvType::COLLECTIVE,
       &Sys::handleEvent,
       nullptr); // stream_id+(packet.preferred_dest*50)
   sim_request rcv_req;
@@ -283,15 +284,16 @@ bool HalvingDoubling::ready() {
       stream->owner->id,
       EventType::PacketReceived,
       packet.preferred_vnet,
-      packet.stream_id % this->TAG_OFFSET + this->TAG_OFFSET);
+      packet.stream_id);
   stream->owner->front_end_sim_recv(
       0,
       Sys::dummy_data,
       packet.msg_size,
       UINT8,
       packet.preferred_src,
-      stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET,
+      stream->stream_id,
       &rcv_req,
+      Sys::FrontEndSendRecvType::COLLECTIVE,
       &Sys::handleEvent,
       ehd); // stream_id+(owner->id*50)
   reduce();

--- a/astra-sim/system/collective/Ring.cc
+++ b/astra-sim/system/collective/Ring.cc
@@ -238,7 +238,7 @@ bool Ring::ready() {
   sim_request snd_req;
   snd_req.srcRank = id;
   snd_req.dstRank = packet.preferred_dest;
-  snd_req.tag = stream->stream_id;
+  snd_req.tag = stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET;
   snd_req.reqType = UINT8;
   snd_req.vnet = this->stream->current_queue_id;
   stream->owner->front_end_sim_send(
@@ -247,7 +247,7 @@ bool Ring::ready() {
       msg_size,
       UINT8,
       packet.preferred_dest,
-      stream->stream_id,
+      stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET,
       &snd_req,
       &Sys::handleEvent,
       nullptr); // stream_id+(packet.preferred_dest*50)
@@ -258,14 +258,14 @@ bool Ring::ready() {
       stream->owner->id,
       EventType::PacketReceived,
       packet.preferred_vnet,
-      packet.stream_id);
+      packet.stream_id % this->TAG_OFFSET + this->TAG_OFFSET);
   stream->owner->front_end_sim_recv(
       0,
       Sys::dummy_data,
       msg_size,
       UINT8,
       packet.preferred_src,
-      stream->stream_id,
+      stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET,
       &rcv_req,
       &Sys::handleEvent,
       ehd); // stream_id+(owner->id*50)

--- a/astra-sim/system/collective/Ring.cc
+++ b/astra-sim/system/collective/Ring.cc
@@ -238,7 +238,7 @@ bool Ring::ready() {
   sim_request snd_req;
   snd_req.srcRank = id;
   snd_req.dstRank = packet.preferred_dest;
-  snd_req.tag = stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET;
+  snd_req.tag = stream->stream_id;
   snd_req.reqType = UINT8;
   snd_req.vnet = this->stream->current_queue_id;
   stream->owner->front_end_sim_send(
@@ -247,8 +247,9 @@ bool Ring::ready() {
       msg_size,
       UINT8,
       packet.preferred_dest,
-      stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET,
+      stream->stream_id,
       &snd_req,
+      Sys::FrontEndSendRecvType::COLLECTIVE,
       &Sys::handleEvent,
       nullptr); // stream_id+(packet.preferred_dest*50)
   sim_request rcv_req;
@@ -258,15 +259,16 @@ bool Ring::ready() {
       stream->owner->id,
       EventType::PacketReceived,
       packet.preferred_vnet,
-      packet.stream_id % this->TAG_OFFSET + this->TAG_OFFSET);
+      packet.stream_id);
   stream->owner->front_end_sim_recv(
       0,
       Sys::dummy_data,
       msg_size,
       UINT8,
       packet.preferred_src,
-      stream->stream_id % this->TAG_OFFSET + this->TAG_OFFSET,
+      stream->stream_id,
       &rcv_req,
+      Sys::FrontEndSendRecvType::COLLECTIVE,
       &Sys::handleEvent,
       ehd); // stream_id+(owner->id*50)
   reduce();

--- a/astra-sim/workload/Workload.cc
+++ b/astra-sim/workload/Workload.cc
@@ -11,6 +11,7 @@ LICENSE file in the root directory of this source tree.
 #include "astra-sim/system/RecvPacketEventHandlerData.hh"
 #include "astra-sim/system/SendPacketEventHandlerData.hh"
 #include "astra-sim/system/WorkloadLayerHandlerData.hh"
+#include "astra-sim/system/collective/Algorithm.hh"
 
 #include <stdlib.h>
 #include <unistd.h>

--- a/astra-sim/workload/Workload.cc
+++ b/astra-sim/workload/Workload.cc
@@ -255,11 +255,6 @@ void Workload::issue_comm(shared_ptr<Chakra::ETFeederNode> node) {
       fp->set_notifier(this, EventType::CollectiveCommunicationFinished);
     }
   } else if (node->type() == ChakraNodeType::COMM_SEND_NODE) {
-    if (node->comm_tag() >= Algorithm::TAG_OFFSET) {
-      this->sys->sys_panic(
-          "comm_tag should be less than " +
-          std::to_string(Algorithm::TAG_OFFSET) + " for comm_send_node");
-    }
     sim_request snd_req;
     snd_req.srcRank = node->comm_src();
     snd_req.dstRank = node->comm_dst();
@@ -277,14 +272,10 @@ void Workload::issue_comm(shared_ptr<Chakra::ETFeederNode> node) {
         node->comm_dst(),
         node->comm_tag(),
         &snd_req,
+        Sys::FrontEndSendRecvType::NATIVE,
         &Sys::handleEvent,
         sehd);
   } else if (node->type() == ChakraNodeType::COMM_RECV_NODE) {
-    if (node->comm_tag() >= Algorithm::TAG_OFFSET) {
-      this->sys->sys_panic(
-          "comm_tag should be less than " +
-          std::to_string(Algorithm::TAG_OFFSET) + " for comm_recv_node");
-    }
     sim_request rcv_req;
     RecvPacketEventHandlerData* rcehd = new RecvPacketEventHandlerData;
     rcehd->wlhd = new WorkloadLayerHandlerData;
@@ -299,6 +290,7 @@ void Workload::issue_comm(shared_ptr<Chakra::ETFeederNode> node) {
         node->comm_src(),
         node->comm_tag(),
         &rcv_req,
+        Sys::FrontEndSendRecvType::NATIVE,
         &Sys::handleEvent,
         rcehd);
   } else {

--- a/astra-sim/workload/Workload.cc
+++ b/astra-sim/workload/Workload.cc
@@ -255,6 +255,11 @@ void Workload::issue_comm(shared_ptr<Chakra::ETFeederNode> node) {
       fp->set_notifier(this, EventType::CollectiveCommunicationFinished);
     }
   } else if (node->type() == ChakraNodeType::COMM_SEND_NODE) {
+    if (node->comm_tag() >= Algorithm::TAG_OFFSET) {
+      this->sys->sys_panic(
+          "comm_tag should be less than " +
+          std::to_string(Algorithm::TAG_OFFSET) + " for comm_send_node");
+    }
     sim_request snd_req;
     snd_req.srcRank = node->comm_src();
     snd_req.dstRank = node->comm_dst();
@@ -275,6 +280,11 @@ void Workload::issue_comm(shared_ptr<Chakra::ETFeederNode> node) {
         &Sys::handleEvent,
         sehd);
   } else if (node->type() == ChakraNodeType::COMM_RECV_NODE) {
+    if (node->comm_tag() >= Algorithm::TAG_OFFSET) {
+      this->sys->sys_panic(
+          "comm_tag should be less than " +
+          std::to_string(Algorithm::TAG_OFFSET) + " for comm_recv_node");
+    }
     sim_request rcv_req;
     RecvPacketEventHandlerData* rcehd = new RecvPacketEventHandlerData;
     rcehd->wlhd = new WorkloadLayerHandlerData;

--- a/astra-sim/workload/Workload.cc
+++ b/astra-sim/workload/Workload.cc
@@ -11,7 +11,6 @@ LICENSE file in the root directory of this source tree.
 #include "astra-sim/system/RecvPacketEventHandlerData.hh"
 #include "astra-sim/system/SendPacketEventHandlerData.hh"
 #include "astra-sim/system/WorkloadLayerHandlerData.hh"
-#include "astra-sim/system/collective/Algorithm.hh"
 
 #include <stdlib.h>
 #include <unistd.h>


### PR DESCRIPTION
## Summary
There are three sources of send/recv: 
1. The native one in chakra trace.
2. Caused from collective communication
3. Caused from rendezvous send/recv

In the past the source 2 and source 3 are separate by an offset, however, for source 1 the tag range might overlap with source 
Then it might leads to bug that, source 1 and source 2 issue two comms with same tag, and confuse each other.

In this PR it will target this problem by offsetting, as well as sanity checking, the tag range should be as follows:
Source | from            | end
native   | 0                 | 499999999
coll       | 400000000 | 999999999
rendezvous | 1000000000 | INT32_MAX

## Test Plan
```
runs/example/run.sh
```

