### PR TITLE
AstraComputeAPI interface added to support developement of online and…

### DIFF
--- a/astra-sim/common/AstraComputeAPI.cc
+++ b/astra-sim/common/AstraComputeAPI.cc
@@ -1,0 +1,29 @@
+/******************************************************************************
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*******************************************************************************/
+
+#include "AstraComputeAPI.hh"
+
+using namespace AstraSim;
+
+ComputeKernel ComputeKernel::create_llm_rmsnorm(int batch, int seq_len, int n_embed, ComputeKernelPhase phase){
+  std::unordered_map<std::string, std::string> attr={{"batch", std::to_string(batch)}, {"seq_len", std::to_string(seq_len)},
+   {"n_embed", std::to_string(n_embed)}};
+  return ComputeKernel(ComputeKernelType::LLM_RMSNorm,phase,attr);
+};
+ComputeKernel ComputeKernel::create_llm_residual_addition(int batch, int seq_len, int n_embed, ComputeKernelPhase phase){
+  std::unordered_map<std::string, std::string> attr={{"batch", std::to_string(batch)}, {"seq_len", std::to_string(seq_len)},
+   {"n_embed", std::to_string(n_embed)}};
+  return ComputeKernel(ComputeKernelType::LLM_Residual_Addition,phase,attr);
+};
+ComputeKernel ComputeKernel::create_llama_attn(int batch, int seq_len, int max_seq_len, int n_embed, int num_heads, int tensor_parallelism, ComputeKernelPhase phase){
+  std::unordered_map<std::string, std::string> attr={{"batch", std::to_string(batch)}, {"seq_len", std::to_string(seq_len)}, {"max_seq_len", std::to_string(max_seq_len)},
+   {"n_embed", std::to_string(n_embed)}, {"num_heads", std::to_string(num_heads)}, {"tensor_parallelism", std::to_string(tensor_parallelism)}};
+  return ComputeKernel(ComputeKernelType::Llama_Attn,phase,attr);
+};
+ComputeKernel ComputeKernel::create_llama_mlp(int batch, int seq_len, int n_embed, int num_heads, int tensor_parallelism, ComputeKernelPhase phase){
+  std::unordered_map<std::string, std::string> attr={{"batch", std::to_string(batch)}, {"seq_len", std::to_string(seq_len)},
+   {"n_embed", std::to_string(n_embed)}, {"num_heads", std::to_string(num_heads)}, {"tensor_parallelism", std::to_string(tensor_parallelism)}};
+  return ComputeKernel(ComputeKernelType::Llama_MLP,phase,attr);
+};

--- a/astra-sim/common/AstraComputeAPI.hh
+++ b/astra-sim/common/AstraComputeAPI.hh
@@ -1,0 +1,60 @@
+/******************************************************************************
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*******************************************************************************/
+
+#ifndef __COMPUTE_HH__
+#define __COMPUTE_HH__
+#include <cassert>
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+#include "Common.hh"
+#include "AstraNetworkAPI.hh"
+
+namespace AstraSim {
+class Sys;
+enum class ComputeKernelType{GEMM, Batch_GEMM, Softmax, LLM_RMSNorm, LLM_Residual_Addition, Llama_Attn, Llama_MLP};
+enum class ComputeKernelPhase{FWD,BCKWD, INFERENCE_TOKENGEN, INFERENCE_PREFILL};
+
+class ComputeKernel{
+  public:
+    ComputeKernelType type;
+    ComputeKernelPhase phase;
+    std::unordered_map<std::string,std::string> attributes;
+    ComputeKernel(ComputeKernelType type,ComputeKernelPhase phase,std::unordered_map<std::string,std::string> attributes){
+      this->type=type;
+      this->phase=phase;
+      this->attributes=attributes;
+    }
+    ComputeKernel(){};
+    static ComputeKernel create_llm_rmsnorm(int batch, int seq_len, int n_embed, ComputeKernelPhase phase);
+    static ComputeKernel create_llama_attn(int batch, int seq_len, int max_seq_len, int n_embed, int num_heads, int tensor_parallelism, ComputeKernelPhase phase);
+    static ComputeKernel create_llm_residual_addition(int batch, int seq_len, int n_embed, ComputeKernelPhase phase);
+    static ComputeKernel create_llama_mlp(int batch, int seq_len, int n_embed, int num_heads, int tensor_parallelism, ComputeKernelPhase phase);
+};
+class ComputeKernelSimulationMetaData {
+ public:
+  timespec_t compute_delay; // delay in nanoseconds
+};
+class AstraComputeAPI {
+ public:
+  
+  // gets the runtime in a blocking manner
+  virtual timespec_t get_static_runtime(
+    ComputeKernel &kernel
+  ) {timespec_t t; return t;};
+
+  // simulates the runtime asynchronously and calls the system layer once it is done
+  virtual void simulate(
+      ComputeKernel &kernel,
+      Sys *sys,
+      void (*msg_handler)(void* fun_arg),
+      ComputeKernelSimulationMetaData* fun_arg) {return;};
+
+  //virtual ~AstraComputeAPI() = 0;
+};
+} // namespace AstraSim
+#endif

--- a/astra-sim/system/AstraComputeAPI.cc
+++ b/astra-sim/system/AstraComputeAPI.cc
@@ -1,0 +1,1 @@
+../common/AstraComputeAPI.cc

--- a/astra-sim/system/AstraComputeAPI.hh
+++ b/astra-sim/system/AstraComputeAPI.hh
@@ -1,0 +1,1 @@
+../common/AstraComputeAPI.hh


### PR DESCRIPTION
In this pull request, the **AstraComputeAPI** interface is introduced to support development of offline/online compute backends on  top that. 

**Offline Compute Backend:** These backends are used to get the runtime of compute kernels which is offline from the main simulation. Once these backends are called, we blocking wait for them to get the compute runtime before proceeding with the rest of simulation. For example, we can use these backend to obtain the runtime of all compute kernels at the beginning of simulation even before the simulation starts. The interface function for using these backends is **get_static_runtime()** in the interface.

**Online Compute Backend:** These backends are used to simulate the runtime of compute kernels in the **similar** way we simulate the communication operations. Hence, they simulate the runtime in an online manner with the main simulation. To do this, they need to interact with the system layer to put events in the main event queue of the simulator (which could possibly interfere with comm operations and hence, get more realistic runtimes).  The interface function for using these backends is **simulate()** in the interface. 