### PR TITLE
Collectiveapi

### DIFF
--- a/astra-sim/common/Common.hh
+++ b/astra-sim/common/Common.hh
@@ -7,6 +7,7 @@ LICENSE file in the root directory of this source tree.
 #define __COMMON_HH__
 
 #include <cstdint>
+#include <string>
 
 namespace AstraSim {
 
@@ -62,6 +63,7 @@ enum class CollectiveImplType {
   DoubleBinaryTree,
   HalvingDoubling,
   OneHalvingDoubling,
+  ChakraImpl,
 };
 
 enum class CollectiveBarrier { Blocking = 0, Non_Blocking };
@@ -133,6 +135,9 @@ class CloneInterface {
   virtual ~CloneInterface() = default;
 };
 
+/* 
+ * CollectiveImpl holds the user's description on how a collective algorithm is implemented, provided in the System layer input.
+ */
 class CollectiveImpl : public CloneInterface {
  public:
   CollectiveImpl(CollectiveImplType type) {
@@ -145,6 +150,10 @@ class CollectiveImpl : public CloneInterface {
   CollectiveImplType type;
 };
 
+/* 
+ * DirectCollectiveImpl contains user-specified information about Direct implementation of collective algorithms.
+ * We have a separte class for DirectCollectiveImpl, because of the collective window, which is also defined in the system layer input.
+ */
 class DirectCollectiveImpl : public CollectiveImpl {
  public:
   CloneInterface* clone() const {
@@ -158,6 +167,24 @@ class DirectCollectiveImpl : public CollectiveImpl {
   int direct_collective_window;
 };
 
+
+/* 
+ * ChakraCollectiveImpl contains information about a collective implementation represented using the Chakra ET format. 
+ * It containes the filename of the Chakra ET which holds the implementation, provided in the System layer input.
+ */
+ class ChakraCollectiveImpl : public CollectiveImpl {
+ public:
+  CloneInterface* clone() const {
+    return new ChakraCollectiveImpl(*this);
+  };
+  ChakraCollectiveImpl(CollectiveImplType type, std::string filename)
+      : CollectiveImpl(type) {
+    this->filename = filename;
+  }
+
+  /* The filename of the corresponding Chakra ET file */
+  std::string filename;
+};
 } // namespace AstraSim
 
 #endif /* __COMMON_HH__ */

--- a/astra-sim/system/RecvPacketEventHandlerData.cc
+++ b/astra-sim/system/RecvPacketEventHandlerData.cc
@@ -10,8 +10,10 @@ LICENSE file in the root directory of this source tree.
 using namespace AstraSim;
 
 RecvPacketEventHandlerData::RecvPacketEventHandlerData() {
+  this->workload = nullptr;
   this->wlhd = nullptr;
   this->owner = nullptr;
+  this->chakra = nullptr;
 }
 
 RecvPacketEventHandlerData::RecvPacketEventHandlerData(
@@ -24,6 +26,7 @@ RecvPacketEventHandlerData::RecvPacketEventHandlerData(
   this->workload = nullptr;
   this->wlhd = nullptr;
   this->owner = owner;
+  this->chakra = nullptr;
   this->vnet = vnet;
   this->stream_id = stream_id;
   this->message_end = true;

--- a/astra-sim/system/RecvPacketEventHandlerData.hh
+++ b/astra-sim/system/RecvPacketEventHandlerData.hh
@@ -27,11 +27,11 @@ class RecvPacketEventHandlerData : public BasicEventHandlerData {
   Workload* workload;
   WorkloadLayerHandlerData* wlhd;
   BaseStream* owner;
+  ChakraImpl* chakra;
   int vnet;
   int stream_id;
   bool message_end;
   Tick ready_time;
-  ChakraImpl* chakra;
 };
 
 } // namespace AstraSim

--- a/astra-sim/system/RecvPacketEventHandlerData.hh
+++ b/astra-sim/system/RecvPacketEventHandlerData.hh
@@ -8,6 +8,7 @@ LICENSE file in the root directory of this source tree.
 
 #include "astra-sim/system/BaseStream.hh"
 #include "astra-sim/system/BasicEventHandlerData.hh"
+#include "astra-sim/system/collective/ChakraImpl.hh"
 
 namespace AstraSim {
 
@@ -30,6 +31,7 @@ class RecvPacketEventHandlerData : public BasicEventHandlerData {
   int stream_id;
   bool message_end;
   Tick ready_time;
+  ChakraImpl* chakra;
 };
 
 } // namespace AstraSim

--- a/astra-sim/system/Sys.cc
+++ b/astra-sim/system/Sys.cc
@@ -26,6 +26,7 @@ LICENSE file in the root directory of this source tree.
 #include "astra-sim/system/collective/DoubleBinaryTreeAllReduce.hh"
 #include "astra-sim/system/collective/HalvingDoubling.hh"
 #include "astra-sim/system/collective/Ring.hh"
+#include "astra-sim/system/collective/ChakraImpl.hh"
 #include "astra-sim/system/scheduling/OfflineGreedy.hh"
 #include "astra-sim/system/topology/BasicLogicalTopology.hh"
 #include "astra-sim/system/topology/GeneralComplexTopology.hh"
@@ -386,6 +387,37 @@ bool Sys::initialize_sys(string name) {
       all_to_all_implementation_per_dimension.push_back(ci);
     }
   }
+  // TODO: Remove 'experimental'.
+  if (j.contains("all-to-all-implementation-chakra-experimental")) {
+    vector<string> chakra_filepath_str_vec = j["all-to-all-implementation-chakra-experimental"];
+    all_to_all_implementation_per_dimension.clear();
+    if(chakra_filepath_str_vec.size() != 1) {
+      throw logic_error("There should be 1 Chakra ET only. In multi-dim collectives, that 1 ET file covers all dimensions");
+    }
+    CollectiveImpl* ci =
+          generate_collective_impl_from_chakra(chakra_filepath_str_vec[0]);
+    all_to_all_implementation_per_dimension.push_back(ci);
+  }
+  if (j.contains("all-gather-implementation-chakra-experimental")) {
+    vector<string> chakra_filepath_str_vec = j["all-gather-implementation-chakra-experimental"];
+    all_gather_implementation_per_dimension.clear();
+    if(chakra_filepath_str_vec.size() != 1) {
+      throw logic_error("There should be 1 Chakra ET only. In multi-dim collectives, that 1 ET file covers all dimensions");
+    }
+    CollectiveImpl* ci =
+          generate_collective_impl_from_chakra(chakra_filepath_str_vec[0]);
+    all_gather_implementation_per_dimension.push_back(ci);
+  }
+  if (j.contains("all-reduce-implementation-chakra-experimental")) {
+    vector<string> chakra_filepath_str_vec = j["all-reduce-implementation-chakra-experimental"];
+    all_reduce_implementation_per_dimension.clear();
+    if(chakra_filepath_str_vec.size() != 1) {
+      throw logic_error("There should be 1 Chakra ET only. In multi-dim collectives, that 1 ET file covers all dimensions");
+    }
+    CollectiveImpl* ci =
+          generate_collective_impl_from_chakra(chakra_filepath_str_vec[0]);
+    all_reduce_implementation_per_dimension.push_back(ci);
+  }
   if (j.contains("collective-optimization")) {
     string inp_collective_optimization = j["collective-optimization"];
     if (inp_collective_optimization == "baseline") {
@@ -495,6 +527,11 @@ CollectiveImpl* Sys::generate_collective_impl_from_input(
         "input file");
     return new CollectiveImpl(CollectiveImplType::Ring);
   }
+}
+
+CollectiveImpl* Sys::generate_collective_impl_from_chakra(string chakra_filepath) {
+  string filename = chakra_filepath + "." + to_string(id) + ".et";
+  return new ChakraCollectiveImpl(CollectiveImplType::ChakraImpl, filename);
 }
 
 Tick Sys::boostedTick() {
@@ -612,6 +649,9 @@ void Sys::handleEvent(void* arg) {
     }
     if (rcehd->owner) {
       rcehd->owner->consume(rcehd);
+    }
+    if (rcehd->chakra) {
+      rcehd->chakra->call(event, rcehd->wlhd);
     }
     delete rcehd;
   } else if (event == EventType::PacketSent) {
@@ -1081,6 +1121,14 @@ CollectivePhase Sys::generate_collective_phase(
         new HalvingDoubling(
             collective_type, id, (RingTopology*)topology, data_size));
     return vn;
+  } else if (
+      collective_impl->type == CollectiveImplType::ChakraImpl) {
+    string filename = ((ChakraCollectiveImpl*)collective_impl)->filename;
+    CollectivePhase vn(
+        this,
+        queue_id,
+        new ChakraImpl(filename, id));
+      return vn;      
   } else {
     cerr << "Error: No known collective implementation for collective phase"
          << endl;

--- a/astra-sim/system/Sys.cc
+++ b/astra-sim/system/Sys.cc
@@ -387,9 +387,8 @@ bool Sys::initialize_sys(string name) {
       all_to_all_implementation_per_dimension.push_back(ci);
     }
   }
-  // TODO: Remove 'experimental'.
-  if (j.contains("all-to-all-implementation-chakra-experimental")) {
-    vector<string> chakra_filepath_str_vec = j["all-to-all-implementation-chakra-experimental"];
+  if (j.contains("all-to-all-implementation-chakra")) {
+    vector<string> chakra_filepath_str_vec = j["all-to-all-implementation-chakra"];
     all_to_all_implementation_per_dimension.clear();
     if(chakra_filepath_str_vec.size() != 1) {
       throw logic_error("There should be 1 Chakra ET only. In multi-dim collectives, that 1 ET file covers all dimensions");
@@ -398,8 +397,8 @@ bool Sys::initialize_sys(string name) {
           generate_collective_impl_from_chakra(chakra_filepath_str_vec[0]);
     all_to_all_implementation_per_dimension.push_back(ci);
   }
-  if (j.contains("all-gather-implementation-chakra-experimental")) {
-    vector<string> chakra_filepath_str_vec = j["all-gather-implementation-chakra-experimental"];
+  if (j.contains("all-gather-implementation-chakra")) {
+    vector<string> chakra_filepath_str_vec = j["all-gather-implementation-chakra"];
     all_gather_implementation_per_dimension.clear();
     if(chakra_filepath_str_vec.size() != 1) {
       throw logic_error("There should be 1 Chakra ET only. In multi-dim collectives, that 1 ET file covers all dimensions");
@@ -408,8 +407,8 @@ bool Sys::initialize_sys(string name) {
           generate_collective_impl_from_chakra(chakra_filepath_str_vec[0]);
     all_gather_implementation_per_dimension.push_back(ci);
   }
-  if (j.contains("all-reduce-implementation-chakra-experimental")) {
-    vector<string> chakra_filepath_str_vec = j["all-reduce-implementation-chakra-experimental"];
+  if (j.contains("all-reduce-implementation-chakra")) {
+    vector<string> chakra_filepath_str_vec = j["all-reduce-implementation-chakra"];
     all_reduce_implementation_per_dimension.clear();
     if(chakra_filepath_str_vec.size() != 1) {
       throw logic_error("There should be 1 Chakra ET only. In multi-dim collectives, that 1 ET file covers all dimensions");

--- a/astra-sim/system/Sys.hh
+++ b/astra-sim/system/Sys.hh
@@ -79,6 +79,8 @@ class Sys : public Callable {
   bool initialize_sys(std::string name);
   CollectiveImpl* generate_collective_impl_from_input(
       std::string collective_impl_str);
+  CollectiveImpl* generate_collective_impl_from_chakra(
+      std::string collective_impl_str);
   //---------------------------------------------------------------------------
 
   // Helper Functions ---------------------------------------------------------

--- a/astra-sim/system/collective/ChakraImpl.cc
+++ b/astra-sim/system/collective/ChakraImpl.cc
@@ -1,0 +1,185 @@
+/******************************************************************************
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*******************************************************************************/
+
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "astra-sim/system/collective/ChakraImpl.hh"
+#include "extern/graph_frontend/chakra/et_feeder/et_feeder.h"
+#include "astra-sim/system/RecvPacketEventHandlerData.hh"
+#include "astra-sim/system/SendPacketEventHandlerData.hh"
+
+using namespace std;
+using namespace AstraSim;
+using namespace Chakra;
+
+typedef ChakraProtoMsg::NodeType ChakraNodeType;
+
+HardwareResourceChakra::HardwareResourceChakra()
+    : num_in_flight_cpu_ops(0), num_in_flight_gpu_comm_ops(0), 
+    num_in_flight_gpu_comp_ops(0) {}
+
+void HardwareResourceChakra::occupy(const shared_ptr<Chakra::ETFeederNode> node) {
+  if (node->is_cpu_op()) {
+    //assert(num_in_flight_cpu_ops == 0);
+    ++num_in_flight_cpu_ops;
+  } else {
+    if (node->type() == ChakraNodeType::COMP_NODE){
+      //assert(num_in_flight_gpu_comp_ops == 0);
+      ++num_in_flight_gpu_comp_ops;
+    } else{
+      if (node->type() == ChakraNodeType::COMM_RECV_NODE) {
+        return; 
+      }
+      //assert(num_in_flight_gpu_comm_ops == 0);
+      ++num_in_flight_gpu_comm_ops;
+      }
+  }
+}
+
+void HardwareResourceChakra::release(const shared_ptr<Chakra::ETFeederNode> node) {
+  if (node->is_cpu_op()) {
+    --num_in_flight_cpu_ops;
+    //assert(num_in_flight_cpu_ops == 0);
+  } else {
+    if (node->type() == ChakraNodeType::COMP_NODE){
+      --num_in_flight_gpu_comp_ops;
+      //assert(num_in_flight_gpu_comp_ops == 0);
+    } else {
+      if (node->type() == ChakraNodeType::COMM_RECV_NODE) {
+        return;
+      }
+      --num_in_flight_gpu_comm_ops;
+      //assert(num_in_flight_gpu_comm_ops == 0);
+    }
+  }
+}
+
+bool HardwareResourceChakra::is_available(
+    const shared_ptr<Chakra::ETFeederNode> node) const {
+      return true;
+  if (node->is_cpu_op()) {
+      if (num_in_flight_cpu_ops == 0) {
+        return true;
+      } else {
+        return false;
+      }
+  } else {
+      if (node->type() == ChakraNodeType::COMP_NODE){
+        if (num_in_flight_gpu_comp_ops == 0) {
+          return true;
+        } else {
+          return false;
+        }
+      } else {
+        if (node->type() == ChakraNodeType::COMM_RECV_NODE){
+          return true;
+        }
+        if (num_in_flight_gpu_comm_ops == 0) {
+          return true;
+        } else {
+          return false;
+        }
+      }
+  }
+}
+
+
+ChakraImpl::ChakraImpl(
+    std::string et_filename,
+    int id)
+    : Algorithm() {
+  this->et_feeder = new Chakra::ETFeeder(et_filename);
+  this->id = id;
+  this->hw_resource = new HardwareResourceChakra();
+}
+
+void ChakraImpl::issue(shared_ptr<Chakra::ETFeederNode> node) {
+  ChakraNodeType type = node->type();
+  hw_resource->occupy(node);
+  if (type == ChakraNodeType::COMM_SEND_NODE) {
+    sim_request snd_req;
+    snd_req.srcRank = node->comm_src();
+    snd_req.dstRank = node->comm_dst();
+    snd_req.reqType = UINT8;
+    SendPacketEventHandlerData* sehd = new SendPacketEventHandlerData;
+    sehd->callable = this;
+    sehd->wlhd = new WorkloadLayerHandlerData;
+    sehd->wlhd->node_id = node->id();
+    sehd->event = EventType::PacketSent;
+    stream->owner->front_end_sim_send(
+        0,
+        Sys::dummy_data,
+        // Note that we're using the comm size as hardcoded in the Impl Chakra et, ed through the comm. api, 
+        // and ignore the comm.size fed in the workload chakra et. TODO: fix. 
+        node->comm_size(),
+        UINT8,
+        node->comm_dst(),
+        node->comm_tag(),
+        &snd_req,
+        &Sys::handleEvent,
+        sehd);
+  } else if (type == ChakraNodeType::COMM_RECV_NODE) {
+    //cout << "at gpu " << id << "issue recv node for node " << node->id() << endl;
+    sim_request rcv_req;
+    RecvPacketEventHandlerData* rcehd = new RecvPacketEventHandlerData;
+    rcehd->wlhd = new WorkloadLayerHandlerData;
+    rcehd->wlhd->node_id = node->id();
+    rcehd->chakra = this;
+    rcehd->event = EventType::PacketReceived;
+    stream->owner->front_end_sim_recv(
+        0,
+        Sys::dummy_data,
+        node->comm_size(),
+        UINT8,
+        node->comm_src(),
+        node->comm_tag(),
+        &rcv_req,
+        &Sys::handleEvent,
+        rcehd);
+  } else if (type == ChakraNodeType::COMP_NODE) {
+    // if (id == 0)
+    //   cout << "at gpu " << id << "issue comp node for node " << node->id() << endl;
+    WorkloadLayerHandlerData* wlhd = new WorkloadLayerHandlerData;
+    wlhd->node_id = node->id();
+    uint64_t runtime = 1ul;
+    if (node->runtime() != 0ul)
+      // chakra runtimes are in microseconds and we should convert it into
+      // nanoseconds
+      runtime = node->runtime() * 1000;
+    stream->owner->register_event(this, EventType::General, wlhd, runtime);
+  }
+}
+
+void ChakraImpl::issue_dep_free_nodes() {
+  shared_ptr<Chakra::ETFeederNode> node = et_feeder->getNextIssuableNode();
+  while (node != nullptr) {
+    issue(node);
+    node = et_feeder->getNextIssuableNode();
+  }
+}
+
+void ChakraImpl::call(EventType event, CallData* data) {
+  if (data == nullptr) {
+    issue_dep_free_nodes();
+  } else {
+    WorkloadLayerHandlerData* wlhd = (WorkloadLayerHandlerData*)data;
+    shared_ptr<Chakra::ETFeederNode> node =
+      et_feeder->lookupNode(wlhd->node_id);
+    hw_resource->release(node);
+    et_feeder->freeChildrenNodes(wlhd->node_id);
+    issue_dep_free_nodes();
+    et_feeder->removeNode(wlhd->node_id);
+    delete wlhd;
+  }
+  if (!et_feeder->hasNodesToIssue()) {
+    exit();
+  }
+}
+
+void ChakraImpl::run(EventType event, CallData* data) {
+  issue_dep_free_nodes();
+  // cout << "Hello for " << id <<  endl;
+}

--- a/astra-sim/system/collective/ChakraImpl.hh
+++ b/astra-sim/system/collective/ChakraImpl.hh
@@ -1,0 +1,73 @@
+/******************************************************************************
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*******************************************************************************/
+
+#ifndef __CHAKRAIMPL__HH
+#define __CHAKRAIMPL__HH
+
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "astra-sim/system/MemBus.hh"
+#include "astra-sim/system/MyPacket.hh"
+#include "astra-sim/system/collective/Algorithm.hh"
+#include "extern/graph_frontend/chakra/et_feeder/et_feeder.h"
+
+namespace AstraSim {
+
+class HardwareResourceChakra {
+ public:
+  HardwareResourceChakra();
+  void occupy(const std::shared_ptr<Chakra::ETFeederNode> node);
+  void release(const std::shared_ptr<Chakra::ETFeederNode> node);
+  bool is_available(const std::shared_ptr<Chakra::ETFeederNode> node) const;
+
+  uint32_t num_in_flight_cpu_ops;
+  uint32_t num_in_flight_gpu_comp_ops;
+  uint32_t num_in_flight_gpu_comm_ops;
+};
+
+/* 
+ * ChakraImpl contains the logic to parse and execute a Chakra ET representation of a collective implementation. 
+ * (instead of the typical way of implementing collectives within the system layer and executing the code.)
+ * 
+ * This Chakra trace consists of only COMM_SEND, COMM_RECV, COMP nodes to describe the messages that make up a Collective. (note: no verifier!) 
+ * This allows us to easily define different implementations of the same algorithm, or, even define our own custom algorithms using tools such as MSCCLang.
+ * To use this implementation, write the "ABSOLUTE" path to the Chakra trace file in the system layer input (instead of traditional `Ring`, etc.),
+ *  under `{all-reduce|all-to-all|all-gather}-implementation-chakra-experimental`.
+ * 
+ * For a detailed description on using a Chakra ET based representation, refer to the documentation.
+ * TODO: Add a verifier to verify correct communication behavior.
+ */
+class ChakraImpl : public Algorithm {
+ public:
+  ChakraImpl(
+      std::string et_filename,
+      int id);
+
+  // Runs the collective algorithm.
+  virtual void run(EventType event, CallData* data);
+  void call(EventType event, CallData* data);
+  
+  private:
+  /*
+   * The following functions move through the Chakra ET and issues nodes whose dependencies are resolved, 
+   * Similar to how the Workload layer moves through the workload Chakra ET.
+   * TODO: merge with impl in Workload layer.
+   */
+  void issue(std::shared_ptr<Chakra::ETFeederNode> node);
+  void issue_dep_free_nodes();
+
+  // Rank Id
+  int id;
+  // Absolute path to the Chakra file for this specific rank.
+  Chakra::ETFeeder* et_feeder;
+  // Tracks availability of hardware resources (e.g. prevent two send ET nodes at same time). 
+  // TODO: merge with impl in Workload layer.
+  HardwareResourceChakra* hw_resource;
+};
+
+} // namespace AstraSim
+
+#endif /* __CHAKRAIMPL__HH */

--- a/astra-sim/system/collective/ChakraImpl.hh
+++ b/astra-sim/system/collective/ChakraImpl.hh
@@ -46,7 +46,7 @@ class ChakraImpl : public Algorithm {
       std::string et_filename,
       int id);
 
-  // Runs the collective algorithm.
+  // Runs the collective algorithm. This function is only called once to start the algorithm.
   virtual void run(EventType event, CallData* data);
   void call(EventType event, CallData* data);
   
@@ -61,7 +61,7 @@ class ChakraImpl : public Algorithm {
 
   // Rank Id
   int id;
-  // Absolute path to the Chakra file for this specific rank.
+  // ET Feeder for the Chakra ET for this specific rank.
   Chakra::ETFeeder* et_feeder;
   // Tracks availability of hardware resources (e.g. prevent two send ET nodes at same time). 
   // TODO: merge with impl in Workload layer.

--- a/astra-sim/system/collective/ChakraImpl.hh
+++ b/astra-sim/system/collective/ChakraImpl.hh
@@ -35,7 +35,7 @@ class HardwareResourceChakra {
  * This Chakra trace consists of only COMM_SEND, COMM_RECV, COMP nodes to describe the messages that make up a Collective. (note: no verifier!) 
  * This allows us to easily define different implementations of the same algorithm, or, even define our own custom algorithms using tools such as MSCCLang.
  * To use this implementation, write the "ABSOLUTE" path to the Chakra trace file in the system layer input (instead of traditional `Ring`, etc.),
- *  under `{all-reduce|all-to-all|all-gather}-implementation-chakra-experimental`.
+ *  under `{all-reduce|all-to-all|all-gather}-implementation-chakra`.
  * 
  * For a detailed description on using a Chakra ET based representation, refer to the documentation.
  * TODO: Add a verifier to verify correct communication behavior.

--- a/astra-sim/system/topology/GeneralComplexTopology.cc
+++ b/astra-sim/system/topology/GeneralComplexTopology.cc
@@ -24,7 +24,13 @@ GeneralComplexTopology::GeneralComplexTopology(
   for (uint64_t dim = 0; dim < collective_impl.size(); dim++) {
     if (collective_impl[dim]->type == CollectiveImplType::Ring ||
         collective_impl[dim]->type == CollectiveImplType::Direct ||
-        collective_impl[dim]->type == CollectiveImplType::HalvingDoubling) {
+        collective_impl[dim]->type == CollectiveImplType::HalvingDoubling || 
+        // While executing a collective according a Chakra ET representation does not need information on the logical topology, 
+        // The system layer's logic of defining and invoking "collective phase" objects (which in turn executes the 
+        // individual collective algorithm implementation) does rely on the existence (not the values) of the logical topology. 
+        // (Refer to functions involving 'Sys.cc::generate_collective')
+        // Therefore, we fill in the logical topology with a dummy, default value.
+        collective_impl[dim]->type == CollectiveImplType::ChakraImpl) {
       RingTopology* ring = new RingTopology(
           RingTopology::Dimension::NA,
           id,

--- a/astra-sim/workload/HardwareResource.cc
+++ b/astra-sim/workload/HardwareResource.cc
@@ -26,9 +26,12 @@ void HardwareResource::occupy(const shared_ptr<Chakra::ETFeederNode> node) {
       assert(num_in_flight_gpu_comp_ops == 0);
       ++num_in_flight_gpu_comp_ops;
     } else{
+      if (node->type() == ChakraNodeType::COMM_RECV_NODE) {
+        return; 
+      }
       assert(num_in_flight_gpu_comm_ops == 0);
       ++num_in_flight_gpu_comm_ops;
-    }
+      }
   }
 }
 
@@ -41,6 +44,9 @@ void HardwareResource::release(const shared_ptr<Chakra::ETFeederNode> node) {
       --num_in_flight_gpu_comp_ops;
       assert(num_in_flight_gpu_comp_ops == 0);
     } else {
+      if (node->type() == ChakraNodeType::COMM_RECV_NODE) {
+        return;
+      }
       --num_in_flight_gpu_comm_ops;
       assert(num_in_flight_gpu_comm_ops == 0);
     }
@@ -63,6 +69,9 @@ bool HardwareResource::is_available(
           return false;
         }
       } else {
+        if (node->type() == ChakraNodeType::COMM_RECV_NODE){
+          return true;
+        }
         if (num_in_flight_gpu_comm_ops == 0) {
           return true;
         } else {

--- a/inputs/system/ChakraImpl.json
+++ b/inputs/system/ChakraImpl.json
@@ -1,0 +1,11 @@
+{
+    "scheduling-policy": "FIFO",
+    "endpoint-delay": 10,
+    "active-chunks-per-dimension": 1,
+    "preferred-dataset-splits": 1,
+    "all-reduce-implementation-chakra-experimental": ["/home/jinsun/jinsun-astra-sim/astra-sim/demo/allreduce"],
+    "collective-optimization": "localBWAware",
+    "local-mem-bw": 50,
+    "boost-mode": 0
+  }
+  

--- a/inputs/system/ChakraImpl.json
+++ b/inputs/system/ChakraImpl.json
@@ -1,11 +1,10 @@
 {
-    "scheduling-policy": "FIFO",
-    "endpoint-delay": 10,
-    "active-chunks-per-dimension": 1,
-    "preferred-dataset-splits": 1,
-    "all-reduce-implementation-chakra-experimental": ["/home/jinsun/jinsun-astra-sim/astra-sim/demo/allreduce"],
-    "collective-optimization": "localBWAware",
-    "local-mem-bw": 50,
-    "boost-mode": 0
-  }
-  
+  "scheduling-policy": "FIFO",
+  "endpoint-delay": 10,
+  "active-chunks-per-dimension": 1,
+  "preferred-dataset-splits": 1,
+  "all-reduce-implementation-chakra": ["/home/jinsun/jinsun-astra-sim/astra-sim/demo/allreduce"],
+  "collective-optimization": "localBWAware",
+  "local-mem-bw": 50,
+  "boost-mode": 0
+}


### PR DESCRIPTION
## Summary
This PR adds collectiveapi, which can choose to take collective algorithm from Chakra traces, instead of System layer's internal implementation. The key inspiration is to create an implementation of `CollectiveImpl`. When the workload layer issues a collective communication, the system layer looks up the `CollectiveImpl` object designated in the System layer input. Our implementation will traverse through the Chakra trace, instead of executing a FSM within the system layer.

## Test Plan
Refer to `demo.ipynb`

## Additional Notes
This code is still experimental and needs more work. For example, 
- We have a duplicate version of HardwareResources & Chakra trace walker here, and also in the Workload layer. We should find a clean way to combine the two different implementations. 
- Collective size is still hardcoded into the chakra implementation, and overrides the workload et's comm size
- Chunk_split is fixed to 1 (to be exact, hasn't been verified in >1)
