### PR TITLE
fixed roofline bug

### DIFF
--- a/astra-sim/system/PacketBundle.cc
+++ b/astra-sim/system/PacketBundle.cc
@@ -54,12 +54,14 @@ void PacketBundle::send_to_NPU() {
 void PacketBundle::call(EventType event, CallData* data) {
   if (needs_processing == true) {
     needs_processing = false;
-    this->delay = static_cast<uint64_t>(
-                      static_cast<double>(size) / sys->local_mem_bw) // write
+    // this->delay[ns], size[bytes] local_mem_bw[bytes/s]
+    this->delay =
+        static_cast<uint64_t>(
+            static_cast<double>(size) / sys->local_mem_bw * 1e9) // write
         + static_cast<uint64_t>(
-                      static_cast<double>(size) / sys->local_mem_bw) // read
+              static_cast<double>(size) / sys->local_mem_bw * 1e9) // read
         + static_cast<uint64_t>(
-                      static_cast<double>(size) / sys->local_mem_bw); // read
+              static_cast<double>(size) / sys->local_mem_bw * 1e9); // read
     sys->try_register_event(
         this, EventType::CommProcessingFinished, data, this->delay);
     return;

--- a/astra-sim/system/Sys.cc
+++ b/astra-sim/system/Sys.cc
@@ -436,7 +436,8 @@ bool Sys::initialize_sys(string name) {
     peak_perf = peak_perf * 1000000000000; // TFLOPS
   }
   if (j.contains("local-mem-bw")) {
-    local_mem_bw = j["local-mem-bw"]; // GB/sec
+    local_mem_bw = j["local-mem-bw"];
+    local_mem_bw = local_mem_bw * 1000000000; // GB/sec
   }
   if (j.contains("roofline-enabled")) {
     if (j["roofline-enabled"] != 0) {

--- a/astra-sim/workload/Workload.cc
+++ b/astra-sim/workload/Workload.cc
@@ -185,8 +185,8 @@ void Workload::issue_comp(shared_ptr<Chakra::ETFeederNode> node) {
     double operational_intensity = static_cast<double>(node->num_ops()) /
         static_cast<double>(node->tensor_size());
     double perf = sys->roofline->get_perf(operational_intensity);
-    double elapsed_time = static_cast<double>(node->num_ops()) / perf;
-    uint64_t runtime = static_cast<uint64_t>(elapsed_time);
+    double elapsed_time = static_cast<double>(node->num_ops()) / perf; // sec
+    uint64_t runtime = static_cast<uint64_t>(elapsed_time * 1e9); // sec -> ns
     sys->register_event(this, EventType::General, wlhd, runtime);
   } else {
     // advance this node forward the recorded "replayed" time specificed in the


### PR DESCRIPTION
## Summary
Originally for roofline model, the input of peak-perf(Tflops) will be timed by 1e12 but bandwidth(GB/s) do not times. 

When calling `get_perf`, the bandwidth is in unit of [GB/s], `operation_intensity` in unit of [Flops/B], thus the `bandwidth*operational_intensity` should be in unit of [GFlops/s], however, another item named `peak_perf` in min function has unit of [Flops], which is not matching. 

In this PR we fixed this problem. 

