### PR TITLE
System statistics + Local memory tracker

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,9 @@
 [submodule "extern/network_backend/ns-3"]
 	path = extern/network_backend/ns-3
 	url = git@github.com:astra-sim/astra-network-ns3.git
+[submodule "extern/helper/fmt"]
+	path = extern/helper/fmt
+	url = git@github.com:fmtlib/fmt.git
+[submodule "extern/helper/spdlog"]
+	path = extern/helper/spdlog
+	url = git@github.com:gabime/spdlog.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,10 +4,6 @@
 [submodule "extern/network_backend/garnet/gem5_astra"]
 	path = extern/network_backend/garnet/gem5_astra
 	url = git@github.com:astra-sim/astra-network-garnet.git
-[submodule "extern/graph_frontend/param"]
-	path = extern/graph_frontend/param
-	url = git@github.com:facebookresearch/param.git
-	branch = main
 [submodule "extern/remote_memory_backend/analytical"]
 	path = extern/remote_memory_backend/analytical
 	url = git@github.com:astra-sim/astra-memory-analytical.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,10 @@ endif ()
 # Setup project
 project(AstraSim)
 
-# Find Protobuf
+# Add libraries.
+add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/extern/helper/fmt")
+option(SPDLOG_FMT_EXTERNAL ON)    # override default option for spdlog.
+add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/extern/helper/spdlog")
 find_package(Protobuf REQUIRED)
 
 # Files to compile
@@ -24,6 +27,7 @@ file(GLOB srcs
         "${CMAKE_CURRENT_SOURCE_DIR}/astra-sim/system/topology/*.cc"
         "${CMAKE_CURRENT_SOURCE_DIR}/astra-sim/system/memory/*.cc"
         "${CMAKE_CURRENT_SOURCE_DIR}/astra-sim/system/scheduling/*.cc"
+        "${CMAKE_CURRENT_SOURCE_DIR}/astra-sim/common/*.cc"
         "${CMAKE_CURRENT_SOURCE_DIR}/extern/graph_frontend/chakra/third_party/utils/*.cc"
         "${CMAKE_CURRENT_SOURCE_DIR}/extern/graph_frontend/chakra/et_def/*.cc"
         "${CMAKE_CURRENT_SOURCE_DIR}/extern/graph_frontend/chakra/et_feeder/*.cpp"
@@ -34,6 +38,8 @@ add_library(AstraSim STATIC ${srcs})
 
 # Link libraries
 target_link_libraries(AstraSim PUBLIC ${Protobuf_LIBRARIES})
+target_link_libraries(AstraSim PUBLIC fmt::fmt)
+target_link_libraries(AstraSim PUBLIC spdlog::spdlog)
 
 # Include Directories
 target_include_directories(AstraSim PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,9 @@ file(GLOB srcs
         "${CMAKE_CURRENT_SOURCE_DIR}/astra-sim/system/scheduling/*.cc"
         "${CMAKE_CURRENT_SOURCE_DIR}/astra-sim/common/*.cc"
         "${CMAKE_CURRENT_SOURCE_DIR}/extern/graph_frontend/chakra/third_party/utils/*.cc"
-        "${CMAKE_CURRENT_SOURCE_DIR}/extern/graph_frontend/chakra/et_def/*.cc"
-        "${CMAKE_CURRENT_SOURCE_DIR}/extern/graph_frontend/chakra/et_feeder/*.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/extern/graph_frontend/chakra/src/third_party/utils/*.cc"
+        "${CMAKE_CURRENT_SOURCE_DIR}/extern/graph_frontend/chakra/schema/protobuf/*.cc"
+        "${CMAKE_CURRENT_SOURCE_DIR}/extern/graph_frontend/chakra/src/feeder/*.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/extern/remote_memory_backend/analytical/*.cc")
 
 # Compile AstraSim Library
@@ -44,6 +45,8 @@ target_link_libraries(AstraSim PUBLIC spdlog::spdlog)
 # Include Directories
 target_include_directories(AstraSim PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(AstraSim PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/extern/graph_frontend/chakra/)
+target_include_directories(AstraSim PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/extern/graph_frontend/chakra/schema/protobuf)
+target_include_directories(AstraSim PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/extern/graph_frontend/chakra/src/third_party/utils)
 target_include_directories(AstraSim PUBLIC ${Protobuf_INCLUDE_DIRS})
 target_include_directories(AstraSim PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/extern/helper/)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ file(GLOB srcs
         "${CMAKE_CURRENT_SOURCE_DIR}/extern/graph_frontend/chakra/third_party/utils/*.cc"
         "${CMAKE_CURRENT_SOURCE_DIR}/extern/graph_frontend/chakra/src/third_party/utils/*.cc"
         "${CMAKE_CURRENT_SOURCE_DIR}/extern/graph_frontend/chakra/schema/protobuf/*.cc"
-        "${CMAKE_CURRENT_SOURCE_DIR}/extern/graph_frontend/chakra/src/feeder/*.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/extern/graph_frontend/chakra/src/feeder_v2/*.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/extern/remote_memory_backend/analytical/*.cc")
 
 # Compile AstraSim Library

--- a/astra-sim/common/AstraNetworkAPI.hh
+++ b/astra-sim/common/AstraNetworkAPI.hh
@@ -14,8 +14,8 @@ class AstraNetworkAPI {
  public:
   enum class BackendType { NotSpecified = 0, Garnet, NS3, Analytical };
 
-  AstraNetworkAPI(int rank) : rank(rank){};
-  virtual ~AstraNetworkAPI(){};
+  AstraNetworkAPI(int rank) : rank(rank) {};
+  virtual ~AstraNetworkAPI() {};
 
   virtual int sim_send(
       void* buffer,

--- a/astra-sim/common/Cache.cc
+++ b/astra-sim/common/Cache.cc
@@ -1,0 +1,72 @@
+#include "astra-sim/common/Cache.hh"
+
+#include <atomic>
+#include <list>
+#include <memory>
+#include <shared_mutex>
+#include <thread>
+#include <unordered_map>
+
+#include "extern/graph_frontend/chakra/src/feeder_v2/raw_et_operator.h"
+
+using namespace AstraSim::Utils;
+
+template <typename K, typename T>
+void Cache<K, T>::put(const K& key, const T& value) {
+  std::unique_lock<std::shared_mutex> lock(cache_mutex);
+  if (this->cache.find(key) != this->cache.end()) {
+    this->lru.erase(cache[key].second);
+    this->lru.push_back(key);
+    this->cache[key].second = --this->lru.end();
+    this->cache[key].first =
+        std::static_pointer_cast<const T>(std::make_shared<T>(value));
+  } else {
+    if (cache.size() >= capacity) {
+      auto lru_node = this->lru.front();
+      this->cache.erase(lru_node);
+      this->lru.pop_front();
+    }
+    this->lru.push_back(key);
+    this->cache[key] = {
+        std::static_pointer_cast<const T>(std::make_shared<T>(value)),
+        --this->lru.end()};
+  }
+}
+
+template <typename K, typename T>
+bool Cache<K, T>::has(const K& key) {
+  std::shared_lock<std::shared_mutex> lock(cache_mutex);
+  return this->cache.find(key) != this->cache.end();
+}
+
+template <typename K, typename T>
+const std::weak_ptr<const T> Cache<K, T>::get(const K& key) {
+  std::shared_lock<std::shared_mutex> lock(cache_mutex);
+  if (this->cache.find(key) == this->cache.end())
+    throw std::runtime_error("Node not found in cache");
+  const std::weak_ptr<const T> weak_ptr(this->cache.at(key).first);
+  return weak_ptr;
+}
+
+template <typename K, typename T>
+const std::shared_ptr<const T> Cache<K, T>::get_locked(const K& key) {
+  std::shared_lock<std::shared_mutex> lock(cache_mutex);
+  if (this->cache.find(key) == this->cache.end())
+    throw std::runtime_error("Node not found in cache");
+  return this->cache.at(key).first;
+}
+
+template <typename K, typename T>
+void Cache<K, T>::remove(const K& key) {
+  std::unique_lock<std::shared_mutex> lock(cache_mutex);
+  if (!this->has(key)) {
+    return;
+  }
+  this->lru.erase(cache[key].second);
+  this->cache.erase(key);
+}
+
+// specialization for chakra
+// TODO: for some reason, now we need to define specialization in astrasim then
+// chakra and find object to link, should have better solution
+template class Cache<NodeId, ChakraNode>;

--- a/astra-sim/common/Cache.hh
+++ b/astra-sim/common/Cache.hh
@@ -1,0 +1,44 @@
+#ifndef ASTRASIM_COMMON_CACHE_HH
+#define ASTRASIM_COMMON_CACHE_HH
+
+#include <atomic>
+#include <list>
+#include <memory>
+#include <shared_mutex>
+#include <unordered_map>
+
+namespace AstraSim {
+namespace Utils {
+template <typename K, typename T>
+class Cache {
+ public:
+  Cache(size_t capacity) : capacity(capacity) {}
+
+  void put(const K& key, const T& value);
+
+  bool has(const K& key);
+
+  const std::weak_ptr<const T> get(const K& key);
+
+  const std::shared_ptr<const T> get_locked(const K& key);
+
+  void remove(const K& key);
+
+  ~Cache() {
+    cache.clear();
+    lru.clear();
+  }
+
+ private:
+  size_t capacity;
+  std::unordered_map<
+      K,
+      std::pair<std::shared_ptr<const T>, typename std::list<K>::iterator>>
+      cache;
+  std::list<K> lru;
+  std::shared_mutex cache_mutex;
+};
+} // namespace Utils
+} // namespace AstraSim
+
+#endif /*ASTRASIM_COMMON_CACHE_HH*/

--- a/astra-sim/common/Common.hh
+++ b/astra-sim/common/Common.hh
@@ -7,6 +7,7 @@ LICENSE file in the root directory of this source tree.
 #define __COMMON_HH__
 
 #include <cstdint>
+#include <stdexcept>
 
 namespace AstraSim {
 
@@ -157,7 +158,6 @@ class DirectCollectiveImpl : public CollectiveImpl {
 
   int direct_collective_window;
 };
-
 } // namespace AstraSim
 
 #endif /* __COMMON_HH__ */

--- a/astra-sim/common/Logging.cc
+++ b/astra-sim/common/Logging.cc
@@ -1,0 +1,57 @@
+#include "astra-sim/common/Logging.hh"
+
+namespace AstraSim {
+
+std::unordered_set<spdlog::sink_ptr> LoggerFactory::default_sinks;
+
+std::shared_ptr<spdlog::logger> LoggerFactory::get_logger(
+    const std::string& logger_name) {
+  auto logger = spdlog::get(logger_name);
+  if (logger == nullptr) {
+    logger = spdlog::create_async<spdlog::sinks::null_sink_mt>(logger_name);
+    logger->set_level(spdlog::level::trace);
+    logger->flush_on(spdlog::level::info);
+    // spdlog::register_logger(logger);
+  }
+  auto& logger_sinks = logger->sinks();
+  for (auto sink : default_sinks)
+    if (std::find(logger_sinks.begin(), logger_sinks.end(), sink) ==
+        logger_sinks.end())
+      logger_sinks.push_back(sink);
+  return logger;
+}
+
+void LoggerFactory::init(const std::string& log_config_path) {
+  if (log_config_path != "empty") {
+    spdlog_setup::from_file(log_config_path);
+  }
+  init_default_components();
+}
+
+void LoggerFactory::shutdown(void) {
+  default_sinks.clear();
+  spdlog::drop_all();
+  spdlog::shutdown();
+}
+
+void LoggerFactory::init_default_components() {
+  auto sink_color_console =
+      std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+  sink_color_console->set_level(spdlog::level::info);
+  default_sinks.insert(sink_color_console);
+
+  auto sink_rotate_out = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
+      "log/log.log", 1024 * 1024 * 10, 10);
+  sink_rotate_out->set_level(spdlog::level::debug);
+  default_sinks.insert(sink_rotate_out);
+
+  auto sink_rotate_err = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
+      "log/err.log", 1024 * 1024 * 10, 10);
+  sink_rotate_err->set_level(spdlog::level::err);
+  default_sinks.insert(sink_rotate_err);
+
+  spdlog::init_thread_pool(8192, 1);
+  spdlog::set_pattern("[%Y-%m-%dT%T%z] [%L] <%n>: %v");
+}
+
+} // namespace AstraSim

--- a/astra-sim/common/Logging.cc
+++ b/astra-sim/common/Logging.cc
@@ -6,13 +6,15 @@ std::unordered_set<spdlog::sink_ptr> LoggerFactory::default_sinks;
 
 std::shared_ptr<spdlog::logger> LoggerFactory::get_logger(
     const std::string& logger_name) {
+  constexpr bool ENABLE_DEFAULT_SINK_FOR_OTHER_LOGGERS = true;
   auto logger = spdlog::get(logger_name);
   if (logger == nullptr) {
     logger = spdlog::create_async<spdlog::sinks::null_sink_mt>(logger_name);
     logger->set_level(spdlog::level::trace);
     logger->flush_on(spdlog::level::info);
-    // spdlog::register_logger(logger);
   }
+  if constexpr (!ENABLE_DEFAULT_SINK_FOR_OTHER_LOGGERS)
+    return logger;
   auto& logger_sinks = logger->sinks();
   for (auto sink : default_sinks)
     if (std::find(logger_sinks.begin(), logger_sinks.end(), sink) ==

--- a/astra-sim/common/Logging.hh
+++ b/astra-sim/common/Logging.hh
@@ -1,0 +1,29 @@
+#ifndef __COMMON_LOGGING_HH__
+#define __COMMON_LOGGING_HH__
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include "spdlog/sinks/stdout_color_sinks.h"
+#include "spdlog/spdlog.h"
+#include "spdlog_setup/conf.h"
+
+namespace AstraSim {
+
+class LoggerFactory {
+ public:
+  LoggerFactory() = delete;
+  static std::shared_ptr<spdlog::logger> get_logger(
+      const std::string& logger_name);
+  static void init(const std::string& log_conf_path = "empty");
+  static void shutdown(void);
+
+ private:
+  static void init_default_components();
+  static std::unordered_set<spdlog::sink_ptr> default_sinks;
+};
+
+} // namespace AstraSim
+
+#endif

--- a/astra-sim/common/ProtobufUtils.cc
+++ b/astra-sim/common/ProtobufUtils.cc
@@ -1,0 +1,91 @@
+#include "astra-sim/common/ProtobufUtils.hh"
+#include <iostream>
+#include <memory>
+
+#include "extern/graph_frontend/chakra/src/feeder_v2/raw_et_operator.h"
+
+using namespace AstraSim::Utils;
+
+bool ProtobufUtils::readVarint32(std::istream& f, uint32_t& value) {
+  uint8_t byte;
+  value = 0;
+  int8_t shift = 0;
+  while (f.read(reinterpret_cast<char*>(&byte), 1)) {
+    value |= (byte & 0x7f) << shift;
+    if (!(byte & 0x80))
+      return true;
+    shift += 7;
+    if (shift > 28)
+      return false;
+  }
+  return false;
+}
+
+bool ProtobufUtils::writeVarint32(std::ostream& f, uint32_t value) {
+  uint8_t byte;
+  while (value > 0x7f) {
+    byte = (value & 0x7f) | 0x80;
+    f.write(reinterpret_cast<char*>(&byte), 1);
+    value >>= 7;
+  }
+  byte = value;
+  f.write(reinterpret_cast<char*>(&byte), 1);
+  return true;
+}
+
+template <typename T>
+bool ProtobufUtils::readMessage(std::istream& f, T& msg) {
+  constexpr size_t DEFAULT_BUFFER_SIZE = 16384;
+  if (f.eof())
+    return false;
+  static char buffer[DEFAULT_BUFFER_SIZE];
+  uint32_t size;
+  if (!readVarint32(f, size))
+    return false;
+  char* buffer_use = buffer;
+  if (size > DEFAULT_BUFFER_SIZE - 1) {
+    // buffer is not large enough, use a dynamic buffer
+    buffer_use = new char[size + 1];
+  }
+  f.read(buffer_use, size);
+  buffer_use[size] = 0;
+  msg.ParseFromArray(buffer_use, size);
+  if (size > DEFAULT_BUFFER_SIZE - 1) {
+    delete[] buffer_use;
+  }
+  return true;
+}
+
+template <typename T>
+bool ProtobufUtils::writeMessage(std::ostream& f, const T& msg) {
+  constexpr size_t DEFAULT_BUFFER_SIZE = 16384;
+  static char buffer[DEFAULT_BUFFER_SIZE];
+  size_t size = msg.ByteSizeLong();
+  if (size > DEFAULT_BUFFER_SIZE - 1) {
+    // buffer is not large enough, use a dynamic buffer
+    char* buffer_use = new char[size];
+    msg.SerializeToArray(buffer_use, size);
+    writeVarint32(f, size);
+    f.write(buffer_use, size);
+    delete[] buffer_use;
+  } else {
+    msg.SerializeToArray(buffer, size);
+    writeVarint32(f, size);
+    f.write(buffer, size);
+  }
+  return true;
+}
+
+// specialization for chakra
+// TODO: for some reason, now we need to define specialization in astrasim then
+// chakra and find object to link, should have better solution
+template bool ProtobufUtils::readMessage(std::istream& f, ChakraNode& msg);
+template bool ProtobufUtils::readMessage(
+    std::istream& f,
+    ChakraProtoMsg::GlobalMetadata& msg);
+template bool ProtobufUtils::writeMessage(
+    std::ostream& f,
+    const ChakraNode& msg);
+template bool ProtobufUtils::writeMessage(
+    std::ostream& f,
+    const ChakraProtoMsg::GlobalMetadata& msg);

--- a/astra-sim/common/ProtobufUtils.hh
+++ b/astra-sim/common/ProtobufUtils.hh
@@ -1,0 +1,25 @@
+#ifndef ASTRASIM_COMMON_PROTOBUFUTILS_HH
+#define ASTRASIM_COMMON_PROTOBUFUTILS_HH
+
+#include <iostream>
+
+namespace AstraSim {
+namespace Utils {
+
+class ProtobufUtils {
+ public:
+  static bool readVarint32(std::istream& f, uint32_t& value);
+
+  template <typename T>
+  static bool readMessage(std::istream& f, T& msg);
+
+  static bool writeVarint32(std::ostream& f, uint32_t value);
+
+  template <typename T>
+  static bool writeMessage(std::ostream& f, const T& msg);
+};
+
+} // namespace Utils
+} // namespace AstraSim
+
+#endif /*ASTRASIM_COMMON_PROTOBUFUTILS_HH*/

--- a/astra-sim/network_frontend/analytical/common/CmdLineParser.cc
+++ b/astra-sim/network_frontend/analytical/common/CmdLineParser.cc
@@ -32,6 +32,9 @@ void CmdLineParser::define_options() noexcept {
       "network-configuration",
       "Network configuration file",
       cxxopts::value<std::string>())(
+      "logging-configuration",
+      "Logging configuration file",
+      cxxopts::value<std::string>()->default_value("empty"))(
       "num-queues-per-dim",
       "Number of queues per each dimension",
       cxxopts::value<int>()->default_value("1"))(

--- a/astra-sim/network_frontend/analytical/congestion_aware/main.cc
+++ b/astra-sim/network_frontend/analytical/congestion_aware/main.cc
@@ -9,6 +9,7 @@ LICENSE file in the root directory of this source tree.
 #include <remote_memory_backend/analytical/AnalyticalRemoteMemory.hh>
 #include "common/CmdLineParser.hh"
 #include "congestion_aware/CongestionAwareNetworkApi.hh"
+#include "astra-sim/common/Logging.hh"
 
 using namespace AstraSim;
 using namespace Analytical;
@@ -33,12 +34,16 @@ int main(int argc, char* argv[]) {
       cmd_line_parser.get<std::string>("remote-memory-configuration");
   const auto network_configuration =
       cmd_line_parser.get<std::string>("network-configuration");
+  const auto logging_configuration = 
+      cmd_line_parser.get<std::string>("logging-configuration");
   const auto num_queues_per_dim =
       cmd_line_parser.get<int>("num-queues-per-dim");
   const auto comm_scale = cmd_line_parser.get<double>("comm-scale");
   const auto injection_scale = cmd_line_parser.get<double>("injection-scale");
   const auto rendezvous_protocol =
       cmd_line_parser.get<bool>("rendezvous-protocol");
+
+  AstraSim::LoggerFactory::init(logging_configuration);
 
   // Instantiate event queue
   const auto event_queue = std::make_shared<EventQueue>();
@@ -100,5 +105,6 @@ int main(int argc, char* argv[]) {
   }
 
   // terminate simulation
+  AstraSim::LoggerFactory::shutdown();
   return 0;
 }

--- a/astra-sim/network_frontend/analytical/congestion_aware/main.cc
+++ b/astra-sim/network_frontend/analytical/congestion_aware/main.cc
@@ -7,9 +7,9 @@ LICENSE file in the root directory of this source tree.
 #include <astra-network-analytical/common/NetworkParser.hh>
 #include <astra-network-analytical/congestion_aware/Helper.hh>
 #include <remote_memory_backend/analytical/AnalyticalRemoteMemory.hh>
+#include "astra-sim/common/Logging.hh"
 #include "common/CmdLineParser.hh"
 #include "congestion_aware/CongestionAwareNetworkApi.hh"
-#include "astra-sim/common/Logging.hh"
 
 using namespace AstraSim;
 using namespace Analytical;
@@ -34,7 +34,7 @@ int main(int argc, char* argv[]) {
       cmd_line_parser.get<std::string>("remote-memory-configuration");
   const auto network_configuration =
       cmd_line_parser.get<std::string>("network-configuration");
-  const auto logging_configuration = 
+  const auto logging_configuration =
       cmd_line_parser.get<std::string>("logging-configuration");
   const auto num_queues_per_dim =
       cmd_line_parser.get<int>("num-queues-per-dim");
@@ -105,6 +105,11 @@ int main(int argc, char* argv[]) {
   }
 
   // terminate simulation
+  for (int i = 0; i < npus_count; i++) {
+    delete systems[i];
+  }
+  network_apis.clear();
+  systems.clear();
   AstraSim::LoggerFactory::shutdown();
   return 0;
 }

--- a/astra-sim/network_frontend/analytical/congestion_unaware/main.cc
+++ b/astra-sim/network_frontend/analytical/congestion_unaware/main.cc
@@ -9,6 +9,7 @@ LICENSE file in the root directory of this source tree.
 #include <remote_memory_backend/analytical/AnalyticalRemoteMemory.hh>
 #include "common/CmdLineParser.hh"
 #include "congestion_unaware/CongestionUnawareNetworkApi.hh"
+#include "astra-sim/common/Logging.hh"
 
 using namespace AstraSim;
 using namespace Analytical;
@@ -33,12 +34,16 @@ int main(int argc, char* argv[]) {
       cmd_line_parser.get<std::string>("remote-memory-configuration");
   const auto network_configuration =
       cmd_line_parser.get<std::string>("network-configuration");
+  const auto logging_configuration = 
+      cmd_line_parser.get<std::string>("logging-configuration");
   const auto num_queues_per_dim =
       cmd_line_parser.get<int>("num-queues-per-dim");
   const auto comm_scale = cmd_line_parser.get<double>("comm-scale");
   const auto injection_scale = cmd_line_parser.get<double>("injection-scale");
   const auto rendezvous_protocol =
       cmd_line_parser.get<bool>("rendezvous-protocol");
+
+  AstraSim::LoggerFactory::init(logging_configuration);
 
   // Instantiate event queue
   const auto event_queue = std::make_shared<EventQueue>();
@@ -100,5 +105,6 @@ int main(int argc, char* argv[]) {
   }
 
   // terminate simulation
+  AstraSim::LoggerFactory::shutdown();
   return 0;
 }

--- a/astra-sim/network_frontend/analytical/congestion_unaware/main.cc
+++ b/astra-sim/network_frontend/analytical/congestion_unaware/main.cc
@@ -7,9 +7,9 @@ LICENSE file in the root directory of this source tree.
 #include <astra-network-analytical/common/NetworkParser.hh>
 #include <astra-network-analytical/congestion_unaware/Helper.hh>
 #include <remote_memory_backend/analytical/AnalyticalRemoteMemory.hh>
+#include "astra-sim/common/Logging.hh"
 #include "common/CmdLineParser.hh"
 #include "congestion_unaware/CongestionUnawareNetworkApi.hh"
-#include "astra-sim/common/Logging.hh"
 
 using namespace AstraSim;
 using namespace Analytical;
@@ -34,7 +34,7 @@ int main(int argc, char* argv[]) {
       cmd_line_parser.get<std::string>("remote-memory-configuration");
   const auto network_configuration =
       cmd_line_parser.get<std::string>("network-configuration");
-  const auto logging_configuration = 
+  const auto logging_configuration =
       cmd_line_parser.get<std::string>("logging-configuration");
   const auto num_queues_per_dim =
       cmd_line_parser.get<int>("num-queues-per-dim");
@@ -105,6 +105,12 @@ int main(int argc, char* argv[]) {
   }
 
   // terminate simulation
+  for (int i = 0; i < npus_count; i++) {
+    delete systems[i];
+  }
+  network_apis.clear();
+  systems.clear();
+
   AstraSim::LoggerFactory::shutdown();
   return 0;
 }

--- a/astra-sim/system/BaseStream.cc
+++ b/astra-sim/system/BaseStream.cc
@@ -28,7 +28,6 @@ BaseStream::BaseStream(
   if (synchronizer.find(stream_id) != synchronizer.end()) {
     synchronizer[stream_id]++;
   } else {
-    // std::cout<<"synchronizer set!"<<std::endl;
     synchronizer[stream_id] = 1;
     ready_counter[stream_id] = 0;
   }

--- a/astra-sim/system/CSVWriter.cc
+++ b/astra-sim/system/CSVWriter.cc
@@ -5,6 +5,7 @@ LICENSE file in the root directory of this source tree.
 
 #include "astra-sim/system/CSVWriter.hh"
 
+#include "astra-sim/common/Logging.hh"
 #include "astra-sim/system/Common.hh"
 
 #include <fcntl.h>
@@ -24,17 +25,17 @@ CSVWriter::CSVWriter(std::string path, std::string name) {
 }
 
 void CSVWriter::initialize_csv(int rows, int cols) {
-  std::cout << "CSV path and filename: " << path + name << std::endl;
+  auto logger = LoggerFactory::get_logger("system::CSVWriter");
+  logger->info("CSV path and filename: {}{}", path, name);
   int trial = 10000;
   do {
     myFile.open(path + name, std::fstream::out);
     trial--;
   } while (!myFile.is_open() && trial > 0);
   if (trial == 0) {
-    std::cerr << "Unable to create file: " << path << std::endl;
-    std::cerr
-        << "This error is fatal. Please make sure the CSV write path exists."
-        << std::endl;
+    logger->critical("Unable to create file: {}", path);
+    logger->critical(
+        "This error is fatal. Please make sure the CSV write path exists.");
     exit(1);
   }
   do {
@@ -46,14 +47,12 @@ void CSVWriter::initialize_csv(int rows, int cols) {
   } while (!myFile.is_open());
 
   if (!myFile) {
-    std::cerr << "Unable to open file: " << path << std::endl;
-    std::cerr
-        << "This error is fatal. Please make sure the CSV write path exists."
-        << std::endl;
+    logger->critical("Unable to create file: {}", path);
+    logger->critical(
+        "This error is fatal. Please make sure the CSV write path exists.");
     exit(1);
   } else {
-    std::cout << "Success in opening CSV file for writing the report."
-              << std::endl;
+    logger->info("Success in opening CSV file for writing the report.");
   }
 
   myFile.seekp(0, std::ios_base::beg);
@@ -71,17 +70,17 @@ void CSVWriter::initialize_csv(int rows, int cols) {
 
 void CSVWriter::finalize_csv(
     std::list<std::list<std::pair<uint64_t, double>>> dims) {
-  std::cout << "path to create csvs is: " << path << std::endl;
+  auto logger = LoggerFactory::get_logger("system::CSVWriter");
+  logger->info("path to create csvs is: {}", path);
   int trial = 10000;
   do {
     myFile.open(path + name, std::fstream::out);
     trial--;
   } while (!myFile.is_open() && trial > 0);
   if (trial == 0) {
-    std::cerr << "Unable to create file: " << path + name << std::endl;
-    std::cerr
-        << "This error is fatal. Please make sure the CSV write path exists."
-        << std::endl;
+    logger->critical("Unable to create file: {}{}", path, name);
+    logger->critical(
+        "This error is fatal. Please make sure the CSV write path exists.");
     exit(1);
   }
   do {
@@ -93,13 +92,12 @@ void CSVWriter::finalize_csv(
   } while (!myFile.is_open());
 
   if (!myFile) {
-    std::cerr << "Unable to open file: " << path + name << std::endl;
-    std::cerr
-        << "This error is fatal. Please make sure the CSV write path exists."
-        << std::endl;
+    logger->critical("Unable to create file: {}{}", path, name);
+    logger->critical(
+        "This error is fatal. Please make sure the CSV write path exists.");
     exit(1);
   } else {
-    std::cout << "success in openning file" << std::endl;
+    logger->info("success in openning file");
   }
   myFile.seekp(0, std::ios_base::beg);
   myFile.seekg(0, std::ios_base::beg);
@@ -177,7 +175,8 @@ void CSVWriter::write_cell(int row, int column, std::string data) {
       column--;
     }
     if (*buf == '\n') {
-      std::cerr << "fatal error in inserting cewll!" << std::endl;
+      LoggerFactory::get_logger("system::CSVWriter")
+          ->critical("fatal error in inserting cewll!");
       exit(1);
     }
   }

--- a/astra-sim/system/SimSendCaller.cc
+++ b/astra-sim/system/SimSendCaller.cc
@@ -32,7 +32,6 @@ SimSendCaller::SimSendCaller(
 }
 
 void SimSendCaller::call(EventType type, CallData* data) {
-  //std::cout<<"sysid: "<<sys->id<<std::endl;
   sys->comm_NI->sim_send(
       this->buffer,
       this->count,

--- a/astra-sim/system/Sys.cc
+++ b/astra-sim/system/Sys.cc
@@ -9,6 +9,7 @@ LICENSE file in the root directory of this source tree.
 #include <iostream>
 
 #include <json/json.hpp>
+#include "astra-sim/common/Logging.hh"
 #include "astra-sim/system/BaseStream.hh"
 #include "astra-sim/system/CollectivePlan.hh"
 #include "astra-sim/system/DataSet.hh"
@@ -335,7 +336,8 @@ bool Sys::initialize_sys(string name) {
   inFile.open(name);
   if (!inFile) {
     if (id == 0) {
-      cerr << "Unable to open file: " << name << endl;
+      LoggerFactory::get_logger("system")->critical(
+          "Unable to open file: {}", name);
     }
     exit(1);
   }
@@ -513,12 +515,14 @@ Tick Sys::boostedTick() {
 }
 
 void Sys::sys_panic(string msg) {
-  cerr << msg << endl;
+  auto logger = LoggerFactory::get_logger("system");
+  logger->critical(msg);
   exit(1);
 }
 
 void Sys::exit_sim_loop(string msg) {
-  cout << msg << endl;
+  auto logger = LoggerFactory::get_logger("system");
+  logger->warn(msg);
 }
 
 void Sys::call(EventType type, CallData* data) {}
@@ -529,8 +533,9 @@ void Sys::call_events() {
       pending_events--;
       (get<0>(callable))->call(get<1>(callable), get<2>(callable));
     } catch (const std::exception& e) {
-      cerr << "warning! a callable is removed before call" << endl;
-      cerr << e.what() << endl;
+      auto logger = LoggerFactory::get_logger("system");
+      logger->critical(
+          "warning! a callable is removed before call {}", e.what());
     }
   }
   if (event_queue[Sys::boostedTick()].size() > 0) {
@@ -1082,8 +1087,8 @@ CollectivePhase Sys::generate_collective_phase(
             collective_type, id, (RingTopology*)topology, data_size));
     return vn;
   } else {
-    cerr << "Error: No known collective implementation for collective phase"
-         << endl;
+    LoggerFactory::get_logger("system")->critical(
+        "Error: No known collective implementation for collective phase");
     exit(1);
   }
 }

--- a/astra-sim/system/Sys.cc
+++ b/astra-sim/system/Sys.cc
@@ -1448,8 +1448,21 @@ int Sys::front_end_sim_send(
     int dst,
     int tag,
     sim_request* request,
+    Sys::FrontEndSendRecvType send_type,
     void (*msg_handler)(void* fun_arg),
     void* fun_arg) {
+  if (send_type == Sys::FrontEndSendRecvType::NATIVE)
+    tag = tag %
+            (Sys::FrontEndSendRecvType::COLLECTIVE -
+             Sys::FrontEndSendRecvType::NATIVE) +
+        Sys::FrontEndSendRecvType::NATIVE;
+  else if (send_type == Sys::FrontEndSendRecvType::COLLECTIVE)
+    tag = tag %
+            (Sys::FrontEndSendRecvType::RENDEZVOUS -
+             Sys::FrontEndSendRecvType::COLLECTIVE) +
+        Sys::FrontEndSendRecvType::COLLECTIVE;
+  else
+    sys_panic("A type of RENDZVOUS should never issued in frontend");
   if (rendezvous_enabled) {
     return rendezvous_sim_send(
         delay, buffer, count, type, dst, tag, request, msg_handler, fun_arg);
@@ -1467,8 +1480,21 @@ int Sys::front_end_sim_recv(
     int src,
     int tag,
     sim_request* request,
+    Sys::FrontEndSendRecvType recv_type,
     void (*msg_handler)(void* fun_arg),
     void* fun_arg) {
+  if (recv_type == Sys::FrontEndSendRecvType::NATIVE)
+    tag = tag %
+            (Sys::FrontEndSendRecvType::COLLECTIVE -
+             Sys::FrontEndSendRecvType::NATIVE) +
+        Sys::FrontEndSendRecvType::NATIVE;
+  else if (recv_type == Sys::FrontEndSendRecvType::COLLECTIVE)
+    tag = tag %
+            (Sys::FrontEndSendRecvType::RENDEZVOUS -
+             Sys::FrontEndSendRecvType::COLLECTIVE) +
+        Sys::FrontEndSendRecvType::COLLECTIVE;
+  else
+    sys_panic("A type of RENDZVOUS should never issued in frontend");
   if (rendezvous_enabled) {
     return rendezvous_sim_recv(
         delay, buffer, count, type, src, tag, request, msg_handler, fun_arg);
@@ -1488,6 +1514,11 @@ int Sys::rendezvous_sim_send(
     sim_request* request,
     void (*msg_handler)(void* fun_arg),
     void* fun_arg) {
+  if (tag >= Sys::FrontEndSendRecvType::RENDEZVOUS) {
+    sys_panic(
+        "tag is bigger than RENDEZVOUS_COMM_TAG_OFFSET, \
+        which means it might be mistakenly used as a rendezvous tag.");
+  }
   RendezvousSendData* rsd = new RendezvousSendData(
       id, this, buffer, count, type, dst, tag, *request, msg_handler, fun_arg);
   sim_request newReq = *request;
@@ -1495,7 +1526,7 @@ int Sys::rendezvous_sim_send(
   newReq.dstRank = request->srcRank;
   newReq.srcRank = request->dstRank;
   newReq.reqCount = rendevouz_size;
-  int newTag = tag + 500000000;
+  int newTag = tag + Sys::FrontEndSendRecvType::RENDEZVOUS;
   newReq.tag = newTag;
   sim_recv(
       delay,
@@ -1520,6 +1551,11 @@ int Sys::rendezvous_sim_recv(
     sim_request* request,
     void (*msg_handler)(void* fun_arg),
     void* fun_arg) {
+  if (tag >= Sys::FrontEndSendRecvType::RENDEZVOUS) {
+    sys_panic(
+        "tag is bigger than RENDEZVOUS_COMM_TAG_OFFSET, \
+        which means it might be mistakenly used as a rendezvous tag.");
+  }
   RendezvousRecvData* rrd = new RendezvousRecvData(
       id, this, buffer, count, type, src, tag, *request, msg_handler, fun_arg);
   sim_request newReq = *request;
@@ -1527,7 +1563,7 @@ int Sys::rendezvous_sim_recv(
   newReq.dstRank = request->srcRank;
   newReq.srcRank = request->dstRank;
   newReq.reqCount = rendevouz_size;
-  int newTag = tag + 500000000;
+  int newTag = tag + Sys::FrontEndSendRecvType::RENDEZVOUS;
   newReq.tag = newTag;
   sim_send(
       delay,

--- a/astra-sim/system/Sys.cc
+++ b/astra-sim/system/Sys.cc
@@ -536,7 +536,7 @@ void Sys::call_events() {
     } catch (const std::exception& e) {
       auto logger = LoggerFactory::get_logger("system");
       logger->critical(
-          "warning! a callable is removed before call {}", e.what());
+          "warning! a callable is removed before call. Exception={}", e.what());
     }
   }
   if (event_queue[Sys::boostedTick()].size() > 0) {

--- a/astra-sim/system/Sys.cc
+++ b/astra-sim/system/Sys.cc
@@ -438,7 +438,8 @@ bool Sys::initialize_sys(string name) {
     peak_perf = peak_perf * 1000000000000; // TFLOPS
   }
   if (j.contains("local-mem-bw")) {
-    local_mem_bw = j["local-mem-bw"]; // GB/sec
+    local_mem_bw = j["local-mem-bw"];
+    local_mem_bw = local_mem_bw * 1000000000; // GB/sec
   }
   if (j.contains("roofline-enabled")) {
     if (j["roofline-enabled"] != 0) {

--- a/astra-sim/system/Sys.hh
+++ b/astra-sim/system/Sys.hh
@@ -162,6 +162,19 @@ class Sys : public Callable {
   //---------------------------------------------------------------------------
 
   // Low-level Network Primitives ---------------------------------------------
+  enum FrontEndSendRecvType {
+    // NATIVE means send/recv is issued directly by workload input
+    // COLLECTIVE means send/recv is caused by a collective communication
+    // RENDEZVOUS means send/recv is a rendezvous shake hand
+    // The value here presents the offset of the tag. The tag range for
+    // different type is as follows
+    // NATIVE: [0, 500000000)
+    // COLLECTIVE: [500000000, 1000000000)
+    // RENDEZVOUS: [1000000000, 2000000000)
+    NATIVE = 0,
+    COLLECTIVE = 500000000,
+    RENDEZVOUS = 1000000000
+  };
   int front_end_sim_send(
       Tick delay,
       void* buffer,
@@ -170,6 +183,7 @@ class Sys : public Callable {
       int dst,
       int tag,
       sim_request* request,
+      FrontEndSendRecvType send_type,
       void (*msg_handler)(void* fun_arg),
       void* fun_arg);
 
@@ -181,6 +195,7 @@ class Sys : public Callable {
       int src,
       int tag,
       sim_request* request,
+      FrontEndSendRecvType recv_type,
       void (*msg_handler)(void* fun_arg),
       void* fun_arg);
 

--- a/astra-sim/system/collective/DoubleBinaryTreeAllReduce.cc
+++ b/astra-sim/system/collective/DoubleBinaryTreeAllReduce.cc
@@ -59,6 +59,7 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         parent,
         stream->stream_id,
         &snd_req,
+        Sys::FrontEndSendRecvType::COLLECTIVE,
         &Sys::handleEvent,
         nullptr);
     // receiving
@@ -78,6 +79,7 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         parent,
         stream->stream_id,
         &rcv_req,
+        Sys::FrontEndSendRecvType::COLLECTIVE,
         &Sys::handleEvent,
         ehd);
     state = State::WaitingDataFromParent;
@@ -117,6 +119,7 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         left_child,
         stream->stream_id,
         &rcv_req,
+        Sys::FrontEndSendRecvType::COLLECTIVE,
         &Sys::handleEvent,
         ehd);
     sim_request rcv_req2;
@@ -135,6 +138,7 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         right_child,
         stream->stream_id,
         &rcv_req2,
+        Sys::FrontEndSendRecvType::COLLECTIVE,
         &Sys::handleEvent,
         ehd2);
     state = State::WaitingForTwoChildData;
@@ -190,6 +194,7 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         parent,
         stream->stream_id,
         &snd_req,
+        Sys::FrontEndSendRecvType::COLLECTIVE,
         &Sys::handleEvent,
         nullptr);
     // receiving
@@ -209,6 +214,7 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         parent,
         stream->stream_id,
         &rcv_req,
+        Sys::FrontEndSendRecvType::COLLECTIVE,
         &Sys::handleEvent,
         ehd);
     state = State::WaitingDataFromParent;
@@ -244,6 +250,7 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         left_child,
         stream->stream_id,
         &snd_req,
+        Sys::FrontEndSendRecvType::COLLECTIVE,
         &Sys::handleEvent,
         nullptr);
     sim_request snd_req2;
@@ -260,6 +267,7 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         right_child,
         stream->stream_id,
         &snd_req2,
+        Sys::FrontEndSendRecvType::COLLECTIVE,
         &Sys::handleEvent,
         nullptr);
     exit();
@@ -284,6 +292,7 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         only_child_id,
         stream->stream_id,
         &rcv_req,
+        Sys::FrontEndSendRecvType::COLLECTIVE,
         &Sys::handleEvent,
         ehd);
     state = State::WaitingForOneChildData;
@@ -320,6 +329,7 @@ void DoubleBinaryTreeAllReduce::run(EventType event, CallData* data) {
         only_child_id,
         stream->stream_id,
         &snd_req,
+        Sys::FrontEndSendRecvType::COLLECTIVE,
         &Sys::handleEvent,
         nullptr);
     exit();

--- a/astra-sim/system/collective/HalvingDoubling.cc
+++ b/astra-sim/system/collective/HalvingDoubling.cc
@@ -8,6 +8,7 @@ LICENSE file in the root directory of this source tree.
 #include <cmath>
 #include <iostream>
 
+#include "astra-sim/common/Logging.hh"
 #include "astra-sim/system/PacketBundle.hh"
 #include "astra-sim/system/RecvPacketEventHandlerData.hh"
 
@@ -71,9 +72,9 @@ HalvingDoubling::HalvingDoubling(
       this->offset_multiplier = 2;
       break;
     default:
-      std::cerr
-          << "######### Exiting because of unknown communication type for HalvingDoubling collective algorithm #########"
-          << std::endl;
+      LoggerFactory::get_logger("system::collective::HalvingDoubling")
+          ->critical(
+              "######### Exiting because of unknown communication type for HalvingDoubling collective algorithm #########");
       std::exit(1);
   }
   RingTopology::Direction direction = specify_direction();

--- a/astra-sim/system/collective/HalvingDoubling.cc
+++ b/astra-sim/system/collective/HalvingDoubling.cc
@@ -275,6 +275,7 @@ bool HalvingDoubling::ready() {
       packet.preferred_dest,
       stream->stream_id,
       &snd_req,
+      Sys::FrontEndSendRecvType::COLLECTIVE,
       &Sys::handleEvent,
       nullptr); // stream_id+(packet.preferred_dest*50)
   sim_request rcv_req;
@@ -293,6 +294,7 @@ bool HalvingDoubling::ready() {
       packet.preferred_src,
       stream->stream_id,
       &rcv_req,
+      Sys::FrontEndSendRecvType::COLLECTIVE,
       &Sys::handleEvent,
       ehd); // stream_id+(owner->id*50)
   reduce();

--- a/astra-sim/system/collective/Ring.cc
+++ b/astra-sim/system/collective/Ring.cc
@@ -249,6 +249,7 @@ bool Ring::ready() {
       packet.preferred_dest,
       stream->stream_id,
       &snd_req,
+      Sys::FrontEndSendRecvType::COLLECTIVE,
       &Sys::handleEvent,
       nullptr); // stream_id+(packet.preferred_dest*50)
   sim_request rcv_req;
@@ -267,6 +268,7 @@ bool Ring::ready() {
       packet.preferred_src,
       stream->stream_id,
       &rcv_req,
+      Sys::FrontEndSendRecvType::COLLECTIVE,
       &Sys::handleEvent,
       ehd); // stream_id+(owner->id*50)
   reduce();

--- a/astra-sim/system/scheduling/OfflineGreedy.cc
+++ b/astra-sim/system/scheduling/OfflineGreedy.cc
@@ -4,11 +4,13 @@ LICENSE file in the root directory of this source tree.
 *******************************************************************************/
 
 #include "astra-sim/system/scheduling/OfflineGreedy.hh"
+#include "astra-sim/common/Logging.hh"
 
 #include <algorithm>
 #include <cmath>
 #include <iostream>
 #include <numeric>
+#include <sstream>
 
 using namespace AstraSim;
 
@@ -42,18 +44,20 @@ OfflineGreedy::OfflineGreedy(Sys* sys) {
     }
   }
   if (sys->id == 0) {
-    std::cout << "Themis is configured with the following parameters: "
-              << std::endl;
-    std::cout << "Dim size: ";
+    auto logger = LoggerFactory::get_logger("themis");
+    logger->info("Themis is configured with the following parameters:");
+    std::stringstream buffer;
+    buffer << "Dim size: ";
     for (uint64_t i = 0; i < this->dim_size.size(); i++) {
-      std::cout << this->dim_size[i] << ", ";
+      buffer << this->dim_size[i] << ", ";
     }
-    std::cout << std::endl;
-    std::cout << "BW per dim: ";
+    logger->info(buffer.str());
+    buffer.str("");
+    buffer << "BW per dim: ";
     for (uint64_t i = 0; i < this->dim_BW.size(); i++) {
-      std::cout << this->dim_BW[i] << ", ";
+      buffer << this->dim_BW[i] << ", ";
     }
-    std::cout << std::endl << std::endl;
+    logger->info(buffer.str());
   }
 }
 uint64_t OfflineGreedy::get_chunk_size_from_elapsed_time(

--- a/astra-sim/system/topology/BinaryTree.cc
+++ b/astra-sim/system/topology/BinaryTree.cc
@@ -4,6 +4,7 @@ LICENSE file in the root directory of this source tree.
 *******************************************************************************/
 
 #include "astra-sim/system/topology/BinaryTree.hh"
+#include "astra-sim/common/Logging.hh"
 
 #include <iostream>
 
@@ -100,25 +101,25 @@ BinaryTree::Type BinaryTree::get_node_type(int id) {
 }
 
 void BinaryTree::print(Node* node) {
-  cout << "I am node: " << node->id;
+  auto logger = LoggerFactory::get_logger("system::topology::BinaryTree");
+  logger->debug("I am node: {}", node->id);
   if (node->left_child != nullptr) {
-    cout << " and my left child is: " << node->left_child->id;
+    logger->debug("and my left child is {}", node->left_child->id);
   }
   if (node->right_child != nullptr) {
-    cout << " and my right child is: " << node->right_child->id;
+    logger->debug("and my right child is {}", node->right_child->id);
   }
   if (node->parent != nullptr) {
-    cout << " and my parent is: " << node->parent->id;
+    logger->debug("and my parent is {}", node->parent->id);
   }
   BinaryTree::Type typ = get_node_type(node->id);
   if (typ == BinaryTree::Type::Root) {
-    cout << " and I am Root ";
+    logger->debug("and I am Root");
   } else if (typ == BinaryTree::Type::Intermediate) {
-    cout << " and I am Intermediate ";
+    logger->debug("and I am Intermediate");
   } else if (typ == BinaryTree::Type::Leaf) {
-    cout << " and I am Leaf ";
+    logger->debug("and I am Leaf");
   }
-  cout << endl;
   if (node->left_child != nullptr) {
     print(node->left_child);
   }

--- a/astra-sim/system/topology/GeneralComplexTopology.cc
+++ b/astra-sim/system/topology/GeneralComplexTopology.cc
@@ -8,6 +8,7 @@ LICENSE file in the root directory of this source tree.
 #include <cassert>
 #include <iostream>
 
+#include "astra-sim/common/Logging.hh"
 #include "astra-sim/system/topology/DoubleBinaryTreeTopology.hh"
 #include "astra-sim/system/topology/RingTopology.hh"
 
@@ -75,9 +76,11 @@ int GeneralComplexTopology::get_num_of_dimensions() {
 
 int GeneralComplexTopology::get_num_of_nodes_in_dimension(int dimension) {
   if (static_cast<uint64_t>(dimension) >= dimension_topology.size()) {
-    std::cout << "dim: " << dimension
-              << " requested! but max dim is: " << dimension_topology.size() - 1
-              << std::endl;
+    LoggerFactory::get_logger("system::topology::GeneralComplexTopology")
+        ->critical(
+            "dim: {} requested! but max dim is {}",
+            dimension,
+            dimension_topology.size() - 1);
   }
   assert(static_cast<uint64_t>(dimension) < dimension_topology.size());
   return dimension_topology[dimension]->get_num_of_nodes_in_dimension(0);

--- a/astra-sim/system/topology/RingTopology.cc
+++ b/astra-sim/system/topology/RingTopology.cc
@@ -4,6 +4,7 @@ LICENSE file in the root directory of this source tree.
 *******************************************************************************/
 
 #include "astra-sim/system/topology/RingTopology.hh"
+#include "astra-sim/common/Logging.hh"
 
 #include <cassert>
 #include <iostream>
@@ -32,11 +33,14 @@ RingTopology::RingTopology(Dimension dimension, int id, std::vector<int> NPUs)
     }
   }
 
-  cout << "custom ring, "
-       << "id: " << id << " dimension: " << name
-       << " total nodes in ring: " << total_nodes_in_ring
-       << " index in ring: " << index_in_ring
-       << "total nodes in ring: " << total_nodes_in_ring << endl;
+  LoggerFactory::get_logger("system::topology::RingTopology")
+      ->info(
+          "custom ring, id: {}, dimension: {} total nodes in ring: {} index in ring: {} total nodes in ring {}",
+          id,
+          name,
+          total_nodes_in_ring,
+          index_in_ring,
+          total_nodes_in_ring);
 
   assert(index_in_ring >= 0);
 }
@@ -54,11 +58,15 @@ RingTopology::RingTopology(
     name = "horizontal";
   }
   if (id == 0) {
-    cout << "ring of node 0, "
-         << "id: " << id << " dimension: " << name
-         << " total nodes in ring: " << total_nodes_in_ring
-         << " index in ring: " << index_in_ring << " offset: " << offset
-         << "total nodes in ring: " << total_nodes_in_ring << endl;
+    LoggerFactory::get_logger("system::topology::RingTopology")
+        ->info(
+            "ring of node 0, id: {} dimension: {} total nodes in ring: {} index in ring: {} offset: {} total nodes in ring: {}",
+            id,
+            name,
+            total_nodes_in_ring,
+            index_in_ring,
+            offset,
+            total_nodes_in_ring);
   }
   this->id = id;
   this->total_nodes_in_ring = total_nodes_in_ring;
@@ -90,10 +98,17 @@ int RingTopology::get_receiver_homogeneous(
       index++;
     }
     if (receiver < 0) {
-      cout << "at dim: " << name << "at id: " << id << "dimension: " << name
-           << " index: " << index << " ,node id: " << node_id
-           << " ,offset: " << offset << " ,index_in_ring: " << index_in_ring
-           << " receiver: " << receiver << endl;
+      LoggerFactory::get_logger("system::topology::RingTopology")
+          ->critical(
+              "at dim: {} at id: {} dimension: {} index: {}, node id: {}, offset: {}, index_in_ring {} receiver {}",
+              name,
+              id,
+              name,
+              index,
+              node_id,
+              offset,
+              index_in_ring,
+              receiver);
     }
     assert(receiver >= 0);
     id_to_index[receiver] = index;
@@ -108,10 +123,17 @@ int RingTopology::get_receiver_homogeneous(
       index--;
     }
     if (receiver < 0) {
-      cout << "at dim: " << name << "at id: " << id << "dimension: " << name
-           << " index: " << index << " ,node id: " << node_id
-           << " ,offset: " << offset << " ,index_in_ring: " << index_in_ring
-           << " receiver: " << receiver << endl;
+      LoggerFactory::get_logger("system::topology::RingTopology")
+          ->critical(
+              "at dim: {} at id: {} dimension: {} index: {}, node id: {}, offset: {}, index_in_ring {} receiver {}",
+              name,
+              id,
+              name,
+              index,
+              node_id,
+              offset,
+              index_in_ring,
+              receiver);
     }
     assert(receiver >= 0);
     id_to_index[receiver] = index;

--- a/astra-sim/workload/HardwareResource.cc
+++ b/astra-sim/workload/HardwareResource.cc
@@ -14,18 +14,20 @@ using namespace Chakra;
 typedef ChakraProtoMsg::NodeType ChakraNodeType;
 
 HardwareResource::HardwareResource(uint32_t num_npus)
-    : num_npus(num_npus), num_in_flight_cpu_ops(0), num_in_flight_gpu_comm_ops(0), 
-    num_in_flight_gpu_comp_ops(0) {}
+    : num_npus(num_npus),
+      num_in_flight_cpu_ops(0),
+      num_in_flight_gpu_comm_ops(0),
+      num_in_flight_gpu_comp_ops(0) {}
 
 void HardwareResource::occupy(const shared_ptr<Chakra::ETFeederNode> node) {
   if (node->is_cpu_op()) {
     assert(num_in_flight_cpu_ops == 0);
     ++num_in_flight_cpu_ops;
   } else {
-    if (node->type() == ChakraNodeType::COMP_NODE){
+    if (node->type() == ChakraNodeType::COMP_NODE) {
       assert(num_in_flight_gpu_comp_ops == 0);
       ++num_in_flight_gpu_comp_ops;
-    } else{
+    } else {
       assert(num_in_flight_gpu_comm_ops == 0);
       ++num_in_flight_gpu_comm_ops;
     }
@@ -37,7 +39,7 @@ void HardwareResource::release(const shared_ptr<Chakra::ETFeederNode> node) {
     --num_in_flight_cpu_ops;
     assert(num_in_flight_cpu_ops == 0);
   } else {
-    if (node->type() == ChakraNodeType::COMP_NODE){
+    if (node->type() == ChakraNodeType::COMP_NODE) {
       --num_in_flight_gpu_comp_ops;
       assert(num_in_flight_gpu_comp_ops == 0);
     } else {
@@ -50,24 +52,24 @@ void HardwareResource::release(const shared_ptr<Chakra::ETFeederNode> node) {
 bool HardwareResource::is_available(
     const shared_ptr<Chakra::ETFeederNode> node) const {
   if (node->is_cpu_op()) {
-      if (num_in_flight_cpu_ops == 0) {
+    if (num_in_flight_cpu_ops == 0) {
+      return true;
+    } else {
+      return false;
+    }
+  } else {
+    if (node->type() == ChakraNodeType::COMP_NODE) {
+      if (num_in_flight_gpu_comp_ops == 0) {
         return true;
       } else {
         return false;
       }
-  } else {
-      if (node->type() == ChakraNodeType::COMP_NODE){
-        if (num_in_flight_gpu_comp_ops == 0) {
-          return true;
-        } else {
-          return false;
-        }
+    } else {
+      if (num_in_flight_gpu_comm_ops == 0) {
+        return true;
       } else {
-        if (num_in_flight_gpu_comm_ops == 0) {
-          return true;
-        } else {
-          return false;
-        }
+        return false;
       }
+    }
   }
 }

--- a/astra-sim/workload/HardwareResource.cc
+++ b/astra-sim/workload/HardwareResource.cc
@@ -15,61 +15,91 @@ typedef ChakraProtoMsg::NodeType ChakraNodeType;
 
 HardwareResource::HardwareResource(uint32_t num_npus)
     : num_npus(num_npus),
-      num_in_flight_cpu_ops(0),
-      num_in_flight_gpu_comm_ops(0),
-      num_in_flight_gpu_comp_ops(0) {}
+      num_in_flight_cpu_comp_ops(0u),
+      num_in_flight_gpu_comp_ops(0u),
+      num_in_flight_comm_ops(0u),
+      num_in_flight_mem_ops(0u) {}
 
 void HardwareResource::occupy(const shared_ptr<Chakra::ETFeederNode> node) {
-  if (node->is_cpu_op()) {
-    assert(num_in_flight_cpu_ops == 0);
-    ++num_in_flight_cpu_ops;
-  } else {
-    if (node->type() == ChakraNodeType::COMP_NODE) {
-      assert(num_in_flight_gpu_comp_ops == 0);
-      ++num_in_flight_gpu_comp_ops;
-    } else {
-      assert(num_in_flight_gpu_comm_ops == 0);
-      ++num_in_flight_gpu_comm_ops;
-    }
+  switch (node->type()) {
+    case ChakraNodeType::COMP_NODE:
+      if (node->is_cpu_op()) {
+        assert(num_in_flight_cpu_comp_ops == 0);
+        ++num_in_flight_cpu_comp_ops;
+      } else {
+        assert(num_in_flight_gpu_comp_ops == 0);
+        ++num_in_flight_gpu_comp_ops;
+      }
+      break;
+    case ChakraNodeType::COMM_COLL_NODE:
+    case ChakraNodeType::COMM_SEND_NODE:
+    case ChakraNodeType::COMM_RECV_NODE:
+      assert(num_in_flight_comm_ops == 0);
+      ++num_in_flight_comm_ops;
+      break;
+    case ChakraNodeType::MEM_LOAD_NODE:
+    case ChakraNodeType::MEM_STORE_NODE:
+      assert(num_in_flight_mem_ops == 0);
+      ++num_in_flight_mem_ops;
+      break;
+    case ChakraNodeType::INVALID_NODE:
+      break;
+    default:
+      assert(false);
   }
 }
 
 void HardwareResource::release(const shared_ptr<Chakra::ETFeederNode> node) {
-  if (node->is_cpu_op()) {
-    --num_in_flight_cpu_ops;
-    assert(num_in_flight_cpu_ops == 0);
-  } else {
-    if (node->type() == ChakraNodeType::COMP_NODE) {
-      --num_in_flight_gpu_comp_ops;
-      assert(num_in_flight_gpu_comp_ops == 0);
-    } else {
-      --num_in_flight_gpu_comm_ops;
-      assert(num_in_flight_gpu_comm_ops == 0);
-    }
+  switch (node->type()) {
+    case ChakraNodeType::COMP_NODE:
+      if (node->is_cpu_op()) {
+        assert(num_in_flight_cpu_comp_ops > 0);
+        --num_in_flight_cpu_comp_ops;
+      } else {
+        assert(num_in_flight_gpu_comp_ops > 0);
+        --num_in_flight_gpu_comp_ops;
+      }
+      break;
+    case ChakraNodeType::COMM_COLL_NODE:
+    case ChakraNodeType::COMM_SEND_NODE:
+    case ChakraNodeType::COMM_RECV_NODE:
+      assert(num_in_flight_comm_ops > 0);
+      --num_in_flight_comm_ops;
+      break;
+    case ChakraNodeType::MEM_LOAD_NODE:
+    case ChakraNodeType::MEM_STORE_NODE:
+      assert(num_in_flight_mem_ops > 0);
+      --num_in_flight_mem_ops;
+      break;
+    case ChakraNodeType::INVALID_NODE:
+      break;
+    default:
+      assert(false);
   }
 }
 
 bool HardwareResource::is_available(
     const shared_ptr<Chakra::ETFeederNode> node) const {
-  if (node->is_cpu_op()) {
-    if (num_in_flight_cpu_ops == 0) {
+  switch (node->type()) {
+    case ChakraNodeType::COMP_NODE:
+      if (node->is_cpu_op())
+        return num_in_flight_cpu_comp_ops == 0;
+      else
+        return num_in_flight_gpu_comp_ops == 0;
+
+    case ChakraNodeType::COMM_COLL_NODE:
+    case ChakraNodeType::COMM_SEND_NODE:
+    case ChakraNodeType::COMM_RECV_NODE:
+      return num_in_flight_comm_ops == 0;
+
+    case ChakraNodeType::MEM_LOAD_NODE:
+    case ChakraNodeType::MEM_STORE_NODE:
+      return num_in_flight_mem_ops == 0;
+
+    case ChakraNodeType::INVALID_NODE:
       return true;
-    } else {
-      return false;
-    }
-  } else {
-    if (node->type() == ChakraNodeType::COMP_NODE) {
-      if (num_in_flight_gpu_comp_ops == 0) {
-        return true;
-      } else {
-        return false;
-      }
-    } else {
-      if (num_in_flight_gpu_comm_ops == 0) {
-        return true;
-      } else {
-        return false;
-      }
-    }
+
+    default:
+      assert(false);
   }
 }

--- a/astra-sim/workload/HardwareResource.hh
+++ b/astra-sim/workload/HardwareResource.hh
@@ -22,9 +22,10 @@ class HardwareResource {
   bool is_available(const std::shared_ptr<Chakra::ETFeederNode> node) const;
 
   const uint32_t num_npus;
-  uint32_t num_in_flight_cpu_ops;
+  uint32_t num_in_flight_cpu_comp_ops;
   uint32_t num_in_flight_gpu_comp_ops;
-  uint32_t num_in_flight_gpu_comm_ops;
+  uint32_t num_in_flight_comm_ops;
+  uint32_t num_in_flight_mem_ops;
 };
 
 } // namespace AstraSim

--- a/astra-sim/workload/HardwareResource.hh
+++ b/astra-sim/workload/HardwareResource.hh
@@ -10,7 +10,7 @@ LICENSE file in the root directory of this source tree.
 
 #include <cstdint>
 
-#include "extern/graph_frontend/chakra/src/feeder/et_feeder.h"
+#include "extern/graph_frontend/chakra/src/feeder_v2/et_feeder.h"
 
 namespace AstraSim {
 

--- a/astra-sim/workload/HardwareResource.hh
+++ b/astra-sim/workload/HardwareResource.hh
@@ -10,7 +10,7 @@ LICENSE file in the root directory of this source tree.
 
 #include <cstdint>
 
-#include "extern/graph_frontend/chakra/et_feeder/et_feeder.h"
+#include "extern/graph_frontend/chakra/src/feeder/et_feeder.h"
 
 namespace AstraSim {
 

--- a/astra-sim/workload/LocalMemoryTracker.cc
+++ b/astra-sim/workload/LocalMemoryTracker.cc
@@ -1,0 +1,204 @@
+#include "astra-sim/workload/LocalMemoryTracker.hh"
+
+#include <filesystem>
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include "astra-sim/common/Common.hh"
+#include "astra-sim/common/Logging.hh"
+#include "astra-sim/system/Sys.hh"
+#include "extern/graph_frontend/chakra/src/feeder_v2/et_feeder.h"
+#include "extern/graph_frontend/chakra/src/feeder_v2/et_feeder_node.h"
+#include "json/json.hpp"
+
+using namespace AstraSim;
+using json = nlohmann::json;
+
+LocalMemoryTracker::LocalMemoryTracker(
+    Workload* workload,
+    bool trackMemoryActivities) {
+  this->workload = workload;
+  this->trackMemoryActivities = trackMemoryActivities;
+  this->memoryContentSize = 0ul;
+  this->peakMemoryUsage = 0ul;
+}
+
+void LocalMemoryTracker::issueNode(
+    Chakra::ETFeeder* etFeeder,
+    std::shared_ptr<Chakra::ETFeederNode> node) {
+  // if (this->memoryContentSize > 1e12)
+  //   Sys::sys_panic("memory content size exceeded 1TB");
+  Tick now = Sys::boostedTick();
+  size_t tensorSize = node->tensor_size(0ul);
+  if (node->type() == ChakraProtoMsg::NodeType::COMM_RECV_NODE)
+    return;
+  size_t old_memoryContentSize = this->memoryContentSize;
+  this->memoryContentSize += tensorSize;
+  // if (this->memoryContentSize > 1e12)
+  //   Sys::sys_panic("memory content size exceeded 1TB");
+  memoryUsageTimeline.insert({now, this->memoryContentSize});
+  if (this->trackMemoryActivities) {
+    MemoryActivity writeActivity = {
+        MemoryActivityType::WRITE_START, node, node, now};
+    this->memoryActivities.push_back(writeActivity);
+    MemoryActivity allocActivity = {MemoryActivityType::ALLOC, node, node, now};
+    this->memoryActivities.push_back(allocActivity);
+    for (auto parentId : node->getChakraNode()->data_deps()) {
+      auto parent = etFeeder->lookupNode(parentId);
+      MemoryActivity readActivity = {
+          MemoryActivityType::READ_START, parent, node, now};
+      this->memoryActivities.push_back(readActivity);
+    }
+  }
+  if (this->memoryContentSize > this->peakMemoryUsage)
+    this->peakMemoryUsage = this->memoryContentSize;
+}
+
+void LocalMemoryTracker::finishedNode(
+    Chakra::ETFeeder* etFeeder,
+    std::shared_ptr<Chakra::ETFeederNode> node) {
+  Tick now = Sys::boostedTick();
+  size_t tensorSize = node->tensor_size(0ul);
+  if (node->type() == ChakraProtoMsg::NodeType::COMM_RECV_NODE) {
+    this->memoryContentSize += tensorSize;
+    // if (this->memoryContentSize > 1e12)
+    //   Sys::sys_panic("memory content size exceeded 1TB");
+    memoryUsageTimeline.insert({now, this->memoryContentSize});
+    if (this->trackMemoryActivities) {
+      MemoryActivity writeActivity = {
+          MemoryActivityType::WRITE_START, node, node, now - 100};
+      this->memoryActivities.push_back(writeActivity);
+      MemoryActivity allocActivity = {
+          MemoryActivityType::ALLOC, node, node, now - 100};
+      this->memoryActivities.push_back(allocActivity);
+      for (auto parentId : node->getChakraNode()->data_deps()) {
+        auto parent = etFeeder->lookupNode(parentId);
+        MemoryActivity readActivity = {
+            MemoryActivityType::READ_START, parent, node, now};
+        this->memoryActivities.push_back(readActivity);
+      }
+    }
+    if (this->memoryContentSize > this->peakMemoryUsage)
+      this->peakMemoryUsage = this->memoryContentSize;
+  }
+  if (this->trackMemoryActivities) {
+    MemoryActivity writeActivity = {
+        MemoryActivityType::WRITE_END, node, node, now};
+    this->memoryActivities.push_back(writeActivity);
+    for (auto parentId : node->getChakraNode()->data_deps()) {
+      auto parent = etFeeder->lookupNode(parentId);
+      MemoryActivity readActivity = {
+          MemoryActivityType::READ_END, parent, node, now};
+      this->memoryActivities.push_back(readActivity);
+    }
+  }
+
+  releasedNodes.emplace(node);
+  if (node->getDataChildren().size() == 0 && this->trackMemoryActivities) {
+    MemoryActivity freeActivity = {MemoryActivityType::FREE, node, node, now};
+    this->memoryActivities.push_back(freeActivity);
+  }
+  const auto data_deps = node->getChakraNode()->data_deps();
+  for (auto parentId : data_deps) {
+    auto parent = etFeeder->lookupNode(parentId);
+    bool depResolved = true;
+    for (auto child : parent->getDataChildren()) {
+      if (releasedNodes.count(child) == 0) {
+        depResolved = false;
+        break;
+      }
+    }
+    if (depResolved) {
+      size_t parent_size = parent->tensor_size(0ul);
+      this->memoryContentSize -= parent_size;
+      LoggerFactory::get_logger("local_memory_tracker")->critical("DEBUG: tensor_size={} memoryContentSize={}", parent->tensor_size(0ul), this->memoryContentSize);
+      LoggerFactory::get_logger("local_memory_tracker")->flush();
+      // if (this->memoryContentSize > 1e12)
+      //   Sys::sys_panic("memory content size exceeded 1TB");
+      this->memoryUsageTimeline.insert({now, this->memoryContentSize});
+      if (this->trackMemoryActivities) {
+        MemoryActivity freeActivity = {
+            MemoryActivityType::FREE, parent, node, now};
+        this->memoryActivities.push_back(freeActivity);
+      }
+    }
+  }
+}
+
+void LocalMemoryTracker::report(std::string reportFolder) const {
+  LoggerFactory::get_logger("local_memory_tracker")
+      ->info(
+          "sys[{}] peak memory usage: {}",
+          this->workload->sys->id,
+          this->peakMemoryUsage);
+  // report memory activities
+  if (this->trackMemoryActivities) {
+    assert(std::filesystem::exists(reportFolder));
+    json j;
+    j["traceEvents"] = std::vector<json>();
+    for (auto activity : this->memoryActivities) {
+      auto node = activity.dataOwner;
+      std::string ph, cat, type;
+      switch (activity.type) {
+        case READ_START:
+          ph = "B";
+          cat = "memory_activities";
+          type = "read";
+          break;
+        case WRITE_START:
+          ph = "B";
+          cat = "memory_activities";
+          type = "write";
+          break;
+        case ALLOC:
+          ph = "B";
+          cat = "memory_lifetime";
+          type = "alloc";
+          break;
+        case READ_END:
+          ph = "E";
+          cat = "memory_activities";
+          type = "read";
+          break;
+        case WRITE_END:
+          ph = "E";
+          cat = "memory_activities";
+          type = "write";
+          break;
+        case FREE:
+          ph = "E";
+          cat = "memory_lifetime";
+          type = "alloc";
+          break;
+        default:
+          Sys::sys_panic("");
+      }
+      json event = {
+          {"name", node->name()},
+          {"cat", "memory activities"},
+          {"ph", ph},
+          {"ts", 1e-3 * activity.tick},
+          {"pid", this->workload->sys->id},
+          {"tid", node->id()},
+          {"args",
+           json{
+               {"size", node->tensor_size(0ul)},
+               {"type", type},
+               {"caller", activity.caller->name()}}}};
+      j["traceEvents"].push_back(event);
+    }
+
+    auto chromeTracePath = reportFolder + "/" + "chrome_trace." +
+        std::to_string(this->workload->sys->id) + ".json";
+    std::ofstream file(chromeTracePath);
+    file << j.dump();
+    file.close();
+  }
+}
+
+LocalMemoryTracker::~LocalMemoryTracker() {
+  this->memoryActivities.clear();
+  this->memoryUsageTimeline.clear();
+  this->releasedNodes.clear();
+}

--- a/astra-sim/workload/LocalMemoryTracker.cc
+++ b/astra-sim/workload/LocalMemoryTracker.cc
@@ -44,7 +44,7 @@ void LocalMemoryTracker::issueNode(
     this->memoryActivities.push_back(writeActivity);
     MemoryActivity allocActivity = {MemoryActivityType::ALLOC, node, node, now};
     this->memoryActivities.push_back(allocActivity);
-    for (auto parentId : node->getChakraNode()->data_deps()) {
+    for (auto parentId : node->getChakraNode().lock()->data_deps()) {
       auto parent = etFeeder->lookupNode(parentId);
       MemoryActivity readActivity = {
           MemoryActivityType::READ_START, parent, node, now};
@@ -72,7 +72,7 @@ void LocalMemoryTracker::finishedNode(
       MemoryActivity allocActivity = {
           MemoryActivityType::ALLOC, node, node, now - 100};
       this->memoryActivities.push_back(allocActivity);
-      for (auto parentId : node->getChakraNode()->data_deps()) {
+      for (auto parentId : node->getChakraNode().lock()->data_deps()) {
         auto parent = etFeeder->lookupNode(parentId);
         MemoryActivity readActivity = {
             MemoryActivityType::READ_START, parent, node, now};
@@ -86,7 +86,7 @@ void LocalMemoryTracker::finishedNode(
     MemoryActivity writeActivity = {
         MemoryActivityType::WRITE_END, node, node, now};
     this->memoryActivities.push_back(writeActivity);
-    for (auto parentId : node->getChakraNode()->data_deps()) {
+    for (auto parentId : node->getChakraNode().lock()->data_deps()) {
       auto parent = etFeeder->lookupNode(parentId);
       MemoryActivity readActivity = {
           MemoryActivityType::READ_END, parent, node, now};
@@ -99,7 +99,7 @@ void LocalMemoryTracker::finishedNode(
     MemoryActivity freeActivity = {MemoryActivityType::FREE, node, node, now};
     this->memoryActivities.push_back(freeActivity);
   }
-  const auto data_deps = node->getChakraNode()->data_deps();
+  const auto data_deps = node->getChakraNode().lock()->data_deps();
   for (auto parentId : data_deps) {
     auto parent = etFeeder->lookupNode(parentId);
     bool depResolved = true;
@@ -112,8 +112,12 @@ void LocalMemoryTracker::finishedNode(
     if (depResolved) {
       size_t parent_size = parent->tensor_size(0ul);
       this->memoryContentSize -= parent_size;
-      LoggerFactory::get_logger("local_memory_tracker")->critical("DEBUG: tensor_size={} memoryContentSize={}", parent->tensor_size(0ul), this->memoryContentSize);
-      LoggerFactory::get_logger("local_memory_tracker")->flush();
+      // LoggerFactory::get_logger("local_memory_tracker")
+      //     ->critical(
+      //         "DEBUG: tensor_size={} memoryContentSize={}",
+      //         parent->tensor_size(0ul),
+      //         this->memoryContentSize);
+      // LoggerFactory::get_logger("local_memory_tracker")->flush();
       // if (this->memoryContentSize > 1e12)
       //   Sys::sys_panic("memory content size exceeded 1TB");
       this->memoryUsageTimeline.insert({now, this->memoryContentSize});

--- a/astra-sim/workload/LocalMemoryTracker.hh
+++ b/astra-sim/workload/LocalMemoryTracker.hh
@@ -13,6 +13,7 @@
 namespace AstraSim {
 
 class Workload;
+class Statistics;
 
 class LocalMemoryTracker {
  public:
@@ -27,33 +28,37 @@ class LocalMemoryTracker {
 
   typedef struct {
     MemoryActivityType type;
-    std::shared_ptr<Chakra::ETFeederNode> dataOwner;
-    std::shared_ptr<Chakra::ETFeederNode> caller;
+    NodeId dataOwner;
+    NodeId caller;
     Tick tick;
   } MemoryActivity;
 
-  LocalMemoryTracker(Workload* workload, bool trackMemoryActivities);
+  LocalMemoryTracker(Statistics* statistics, Chakra::ETFeeder* et_feeder);
 
-  void issueNode(
-      Chakra::ETFeeder* etFeeder,
-      std::shared_ptr<Chakra::ETFeederNode> node);
+  void extractMemoryActivities();
 
-  void finishedNode(
-      Chakra::ETFeeder* etFeeder,
-      std::shared_ptr<Chakra::ETFeederNode> node);
+  const std::unordered_map<NodeId, std::vector<MemoryActivity>>&
+  getReadWriteActivities() const;
 
-  void report(std::string reportFolder) const;
+  const std::vector<MemoryActivity>& getAllocFreeActivities() const;
 
-  ~LocalMemoryTracker();
+  void extractMemoryUsage();
+
+  const std::map<Tick, uint64_t>& getMemoryUsage() const;
+
+  void extractAvgPeakUsage();
+
+  const uint64_t getAverageMemoryUsage() const;
+  const uint64_t getPeakMemoryUsage() const;
 
  private:
-  Workload* workload;
-  bool trackMemoryActivities;
-  size_t memoryContentSize;
-  size_t peakMemoryUsage;
-  std::vector<MemoryActivity> memoryActivities;
-  std::map<Tick, size_t> memoryUsageTimeline;
-  std::unordered_set<std::shared_ptr<Chakra::ETFeederNode>> releasedNodes;
+  Statistics* statistics;
+  Chakra::ETFeeder* et_feeder;
+  std::unordered_map<NodeId, std::vector<MemoryActivity>> readWriteActivities;
+  std::vector<MemoryActivity> allocFreeActivities;
+  std::map<Tick, uint64_t> memory_usage;
+  uint64_t average_memory_usage;
+  uint64_t peak_memory_usage;
 };
 
 } // namespace AstraSim

--- a/astra-sim/workload/LocalMemoryTracker.hh
+++ b/astra-sim/workload/LocalMemoryTracker.hh
@@ -1,0 +1,61 @@
+#ifndef __LOCAL_MEMORY_TRACKER_HH__
+#define __LOCAL_MEMORY_TRACKER_HH__
+
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include "astra-sim/common/Common.hh"
+#include "astra-sim/common/Logging.hh"
+#include "extern/graph_frontend/chakra/src/feeder_v2/et_feeder.h"
+#include "extern/graph_frontend/chakra/src/feeder_v2/et_feeder_node.h"
+
+namespace AstraSim {
+
+class Workload;
+
+class LocalMemoryTracker {
+ public:
+  enum MemoryActivityType {
+    READ_START,
+    READ_END,
+    WRITE_START,
+    WRITE_END,
+    ALLOC,
+    FREE
+  };
+
+  typedef struct {
+    MemoryActivityType type;
+    std::shared_ptr<Chakra::ETFeederNode> dataOwner;
+    std::shared_ptr<Chakra::ETFeederNode> caller;
+    Tick tick;
+  } MemoryActivity;
+
+  LocalMemoryTracker(Workload* workload, bool trackMemoryActivities);
+
+  void issueNode(
+      Chakra::ETFeeder* etFeeder,
+      std::shared_ptr<Chakra::ETFeederNode> node);
+
+  void finishedNode(
+      Chakra::ETFeeder* etFeeder,
+      std::shared_ptr<Chakra::ETFeederNode> node);
+
+  void report(std::string reportFolder) const;
+
+  ~LocalMemoryTracker();
+
+ private:
+  Workload* workload;
+  bool trackMemoryActivities;
+  size_t memoryContentSize;
+  size_t peakMemoryUsage;
+  std::vector<MemoryActivity> memoryActivities;
+  std::map<Tick, size_t> memoryUsageTimeline;
+  std::unordered_set<std::shared_ptr<Chakra::ETFeederNode>> releasedNodes;
+};
+
+} // namespace AstraSim
+
+#endif

--- a/astra-sim/workload/Statistics.cc
+++ b/astra-sim/workload/Statistics.cc
@@ -17,8 +17,46 @@ void Statistics::record_start(
     Tick start_time,
     OperatorStatistics::OperatorType type) {
   operator_statistics[node_id] = OperatorStatistics(node_id, start_time, type);
+  start_times.insert({start_time, node_id});
 }
 
 void Statistics::record_end(NodeId node_id, Tick end_time) {
   this->get_operator_statistics(node_id).end_time = end_time;
+}
+
+Statistics::OperatorStatistics::OperatorType Statistics::OperatorStatistics::
+    get_operator_type(const std::shared_ptr<Chakra::ETFeederNode> node) {
+  const auto& node_type = node->type();
+  Statistics::OperatorStatistics::OperatorType stat_node_type;
+  switch (node_type) {
+    case ChakraNodeType::MEM_LOAD_NODE:
+    case ChakraNodeType::MEM_STORE_NODE:
+      stat_node_type = Statistics::OperatorStatistics::OperatorType::REMOTE_MEM;
+      break;
+    case ChakraNodeType::COMP_NODE:
+      stat_node_type = node->is_cpu_op()
+          ? Statistics::OperatorStatistics::OperatorType::CPU
+          : Statistics::OperatorStatistics::OperatorType::GPU;
+      break;
+    case ChakraNodeType::COMM_COLL_NODE:
+    case ChakraNodeType::COMM_SEND_NODE:
+    case ChakraNodeType::COMM_RECV_NODE:
+      stat_node_type = Statistics::OperatorStatistics::OperatorType::COMM;
+      break;
+    case ChakraNodeType::INVALID_NODE:
+      stat_node_type = Statistics::OperatorStatistics::OperatorType::INVALID;
+      break;
+    default:
+      LoggerFactory::get_logger("statistics")
+          ->critical(
+              "Invalid node_type, node.id={}, node.type={}",
+              node->id(),
+              static_cast<uint64_t>(node->type()));
+      assert(false);
+  }
+  return stat_node_type;
+}
+
+void Statistics::extract_type_time() const {
+  std::map<Tick, uint64_t> type_timeline;
 }

--- a/astra-sim/workload/Statistics.cc
+++ b/astra-sim/workload/Statistics.cc
@@ -1,0 +1,24 @@
+#include "astra-sim/workload/Statistics.hh"
+
+using namespace AstraSim;
+
+Statistics::OperatorStatistics& Statistics::get_operator_statistics(
+    NodeId node_id) {
+  return operator_statistics.at(node_id);
+}
+
+const Statistics::OperatorStatistics& Statistics::get_operator_statistics(
+    NodeId node_id) const {
+  return operator_statistics.at(node_id);
+}
+
+void Statistics::record_start(
+    NodeId node_id,
+    Tick start_time,
+    OperatorStatistics::OperatorType type) {
+  operator_statistics[node_id] = OperatorStatistics(node_id, start_time, type);
+}
+
+void Statistics::record_end(NodeId node_id, Tick end_time) {
+  this->get_operator_statistics(node_id).end_time = end_time;
+}

--- a/astra-sim/workload/Statistics.hh
+++ b/astra-sim/workload/Statistics.hh
@@ -1,9 +1,13 @@
 #ifndef ASTRASIM_WORKLOAD_STATISTICS_HH
 #define ASTRASIM_WORKLOAD_STATISTICS_HH
 
+#include <map>
 #include <optional>
 #include <unordered_map>
 #include "astra-sim/common/Common.hh"
+#include "astra-sim/common/Logging.hh"
+#include "extern/graph_frontend/chakra/src/feeder_v2/et_feeder.h"
+typedef ChakraProtoMsg::NodeType ChakraNodeType;
 
 typedef uint64_t NodeId;
 
@@ -13,6 +17,8 @@ class Statistics {
   class OperatorStatistics {
    public:
     enum class OperatorType { CPU, GPU, COMM, REMOTE_MEM, REPLAY, INVALID };
+    static OperatorType get_operator_type(
+        const std::shared_ptr<Chakra::ETFeederNode> node);
     OperatorStatistics(
         NodeId node_id,
         Tick start_time,
@@ -69,8 +75,11 @@ class Statistics {
     operator_statistics.clear();
   }
 
+  void extract_type_time() const;
+
  private:
   std::unordered_map<NodeId, OperatorStatistics> operator_statistics;
+  std::multimap<Tick, NodeId> start_times;
 };
 
 } // namespace AstraSim

--- a/astra-sim/workload/Statistics.hh
+++ b/astra-sim/workload/Statistics.hh
@@ -58,7 +58,7 @@ class Statistics {
   };
 
  public:
-  Statistics() {}
+  Statistics(int sys_id) : sys_id(sys_id) {}
 
   OperatorStatistics& get_operator_statistics(NodeId node_id);
 
@@ -75,9 +75,20 @@ class Statistics {
     operator_statistics.clear();
   }
 
-  void extract_type_time() const;
+  void report(std::shared_ptr<spdlog::logger> logger) const;
+
+  void report() const;
 
  private:
+  std::unordered_map<Statistics::OperatorStatistics::OperatorType, Tick>
+  extract_type_time() const;
+  Tick _calculateTotalRuntimeFromIntervals(
+      const std::vector<std::pair<Tick, Tick>>& intervals) const;
+  double compute_bound_percentage() const;
+  double average_compute_utilization() const;
+  double average_memory_utilization() const;
+  double average_operation_intensity() const;
+  int sys_id;
   std::unordered_map<NodeId, OperatorStatistics> operator_statistics;
   std::multimap<Tick, NodeId> start_times;
 };

--- a/astra-sim/workload/Statistics.hh
+++ b/astra-sim/workload/Statistics.hh
@@ -1,0 +1,78 @@
+#ifndef ASTRASIM_WORKLOAD_STATISTICS_HH
+#define ASTRASIM_WORKLOAD_STATISTICS_HH
+
+#include <optional>
+#include <unordered_map>
+#include "astra-sim/common/Common.hh"
+
+typedef uint64_t NodeId;
+
+namespace AstraSim {
+class Statistics {
+ public:
+  class OperatorStatistics {
+   public:
+    enum class OperatorType { CPU, GPU, COMM, REMOTE_MEM, REPLAY, INVALID };
+    OperatorStatistics(
+        NodeId node_id,
+        Tick start_time,
+        Tick end_time,
+        OperatorType type)
+        : node_id(node_id),
+          start_time(start_time),
+          end_time(end_time),
+          type(type) {}
+    OperatorStatistics(NodeId node_id, Tick start_time, OperatorType type)
+        : node_id(node_id),
+          start_time(start_time),
+          end_time(UINT64_MAX),
+          type(type) {}
+    OperatorStatistics()
+        : node_id(UINT64_MAX),
+          start_time(UINT64_MAX),
+          end_time(UINT64_MAX),
+          type(OperatorType::INVALID) {}
+
+    NodeId node_id;
+    Tick start_time;
+    Tick end_time;
+    OperatorType type;
+
+    // compute node
+    std::optional<double> memory_utilization;
+    std::optional<double> compute_utilization;
+    std::optional<double> operation_intensity;
+    std::optional<bool> is_memory_bound;
+
+    // communication node
+
+    // remote memory node
+
+    // replay node
+  };
+
+ public:
+  Statistics() {}
+
+  OperatorStatistics& get_operator_statistics(NodeId node_id);
+
+  const OperatorStatistics& get_operator_statistics(NodeId node_id) const;
+
+  void record_start(
+      NodeId node_id,
+      Tick start_time,
+      OperatorStatistics::OperatorType type);
+
+  void record_end(NodeId node_id, Tick end_time);
+
+  ~Statistics() {
+    operator_statistics.clear();
+  }
+
+ private:
+  std::unordered_map<NodeId, OperatorStatistics> operator_statistics;
+};
+
+} // namespace AstraSim
+
+#endif /*ASTRASIM_WORKLOAD_STATISTICS_HH*/

--- a/astra-sim/workload/Workload.cc
+++ b/astra-sim/workload/Workload.cc
@@ -18,7 +18,6 @@ LICENSE file in the root directory of this source tree.
 #include <cassert>
 #include <iostream>
 #include <queue>
-#include <cassert>
 
 using namespace std;
 using namespace AstraSim;
@@ -51,7 +50,7 @@ Workload::Workload(Sys* sys, string et_filename, string comm_group_filename) {
   this->hw_resource = new HardwareResource(1);
   this->sys = sys;
   initialize_comm_group(comm_group_filename);
-  this->stats = new Statistics(this, false);
+  this->stats = new Statistics(this);
   this->is_finished = false;
 }
 
@@ -431,5 +430,6 @@ void Workload::report() {
   Tick curr_tick = Sys::boostedTick();
   LoggerFactory::get_logger("workload")
       ->info("sys[{}] finished, {} cycles", sys->id, curr_tick);
+  stats->post_processing();
   stats->report();
 }

--- a/astra-sim/workload/Workload.cc
+++ b/astra-sim/workload/Workload.cc
@@ -223,13 +223,13 @@ void Workload::issue_comm(shared_ptr<Chakra::ETFeederNode> node) {
   if (node->type() == ChakraNodeType::COMM_COLL_NODE) {
     // check if comm_type is filled instead of default value.
   } else if (node->type() == ChakraNodeType::COMM_SEND_NODE) {
-    if (node->comm_src() != sys->id) {
+    if (node->comm_src(sys->id) != sys->id) {
       std::cerr << "sys issue a send comm node " << node->id() << " with src"
                 << node->comm_src() << " != sys.id" << sys->id << std::endl;
       exit(EXIT_FAILURE);
     }
   } else if (node->type() == ChakraNodeType::COMM_RECV_NODE) {
-    if (node->comm_dst() != sys->id) {
+    if (node->comm_dst(sys->id) != sys->id) {
       std::cerr << "sys issue a recv comm node " << node->id() << " with dst"
                 << node->comm_dst() << " != sys.id" << sys->id << std::endl;
       exit(EXIT_FAILURE);

--- a/astra-sim/workload/Workload.cc
+++ b/astra-sim/workload/Workload.cc
@@ -228,9 +228,9 @@ void Workload::issue_comm(shared_ptr<Chakra::ETFeederNode> node) {
   const uint32_t comm_priority = node->comm_priority();
 
   vector<bool> involved_dim;
-  for (int i = 0; i < node->involved_dim_size(); i++) {
-    involved_dim.push_back(node->involved_dim(i));
-  }
+  // involved_dim does not exist in ETFeeder anymore.
+  // We assume involved_dim equals 1, until Chakra supports communicator group.
+  involved_dim.push_back(true);
 
   if (node->type() == ChakraNodeType::COMM_COLL_NODE) {
     if (node->comm_type() == ChakraCollectiveCommType::ALL_REDUCE) {

--- a/astra-sim/workload/Workload.cc
+++ b/astra-sim/workload/Workload.cc
@@ -6,6 +6,7 @@ LICENSE file in the root directory of this source tree.
 #include "astra-sim/workload/Workload.hh"
 
 #include <json/json.hpp>
+#include "astra-sim/common/Logging.hh"
 #include "astra-sim/system/IntData.hh"
 #include "astra-sim/system/MemEventHandlerData.hh"
 #include "astra-sim/system/RecvPacketEventHandlerData.hh"
@@ -38,7 +39,7 @@ Workload::Workload(Sys* sys, string et_filename, string comm_group_filename) {
       error_msg =
           "Unknown workload file: " + workload_filename + " access error";
     }
-    cerr << error_msg << endl;
+    LoggerFactory::get_logger("workload")->critical(error_msg);
     exit(EXIT_FAILURE);
   }
   this->et_feeder = new ETFeeder(workload_filename);
@@ -112,6 +113,7 @@ void Workload::issue_dep_free_nodes() {
 }
 
 void Workload::issue(shared_ptr<Chakra::ETFeederNode> node) {
+  auto logger = LoggerFactory::get_logger("workload");
   if (sys->replay_only) {
     hw_resource->occupy(node);
     issue_replay(node);
@@ -119,9 +121,13 @@ void Workload::issue(shared_ptr<Chakra::ETFeederNode> node) {
     if ((node->type() == ChakraNodeType::MEM_LOAD_NODE) ||
         (node->type() == ChakraNodeType::MEM_STORE_NODE)) {
       if (sys->trace_enabled) {
-        cout << "issue,sys->id=" << sys->id << ",tick=" << Sys::boostedTick()
-             << ",node->id=" << node->id() << ",node->name=" << node->name()
-             << endl;
+        logger->debug(
+            "issue,sys->id={}, tick={}, node->id={}, node->name={}, node->type={}",
+            sys->id,
+            Sys::boostedTick(),
+            node->id(),
+            node->name(),
+            static_cast<uint64_t>(node->type()));
       }
       issue_remote_mem(node);
     } else if (
@@ -131,9 +137,13 @@ void Workload::issue(shared_ptr<Chakra::ETFeederNode> node) {
         skip_invalid(node);
       } else {
         if (sys->trace_enabled) {
-          cout << "issue,sys->id=" << sys->id << ",tick=" << Sys::boostedTick()
-               << ",node->id=" << node->id() << ",node->name=" << node->name()
-               << endl;
+          logger->debug(
+              "issue,sys->id={}, tick={}, node->id={}, node->name={}, node->type={}",
+              sys->id,
+              Sys::boostedTick(),
+              node->id(),
+              node->name(),
+              static_cast<uint64_t>(node->type()));
         }
         issue_comp(node);
       }
@@ -143,9 +153,15 @@ void Workload::issue(shared_ptr<Chakra::ETFeederNode> node) {
          (node->type() == ChakraNodeType::COMM_SEND_NODE) ||
          (node->type() == ChakraNodeType::COMM_RECV_NODE))) {
       if (sys->trace_enabled) {
-        cout << "issue,sys->id=" << sys->id << ",tick=" << Sys::boostedTick()
-             << ",node->id=" << node->id() << ",node->name=" << node->name()
-             << endl;
+        if (sys->trace_enabled) {
+          logger->debug(
+              "issue,sys->id={}, tick={}, node->id={}, node->name={}, node->type={}",
+              sys->id,
+              Sys::boostedTick(),
+              node->id(),
+              node->name(),
+              static_cast<uint64_t>(node->type()));
+        }
       }
       issue_comm(node);
     } else if (node->type() == ChakraNodeType::INVALID_NODE) {
@@ -291,7 +307,8 @@ void Workload::issue_comm(shared_ptr<Chakra::ETFeederNode> node) {
         &Sys::handleEvent,
         rcehd);
   } else {
-    cerr << "Unknown communication node type" << endl;
+    LoggerFactory::get_logger("workload")
+        ->critical("Unknown communication node type");
     exit(EXIT_FAILURE);
   }
 }
@@ -312,9 +329,14 @@ void Workload::call(EventType event, CallData* data) {
     shared_ptr<Chakra::ETFeederNode> node = et_feeder->lookupNode(node_id);
 
     if (sys->trace_enabled) {
-      cout << "callback,sys->id=" << sys->id << ",tick=" << Sys::boostedTick()
-           << ",node->id=" << node->id() << ",node->name=" << node->name()
-           << endl;
+      LoggerFactory::get_logger("workload")
+          ->debug(
+              "callback,sys->id={}, tick={}, node->id={}, node->name={}, node->type={}",
+              sys->id,
+              Sys::boostedTick(),
+              node->id(),
+              node->name(),
+              static_cast<uint64_t>(node->type()));
     }
 
     hw_resource->release(node);
@@ -339,9 +361,14 @@ void Workload::call(EventType event, CallData* data) {
           et_feeder->lookupNode(wlhd->node_id);
 
       if (sys->trace_enabled) {
-        cout << "callback,sys->id=" << sys->id << ",tick=" << Sys::boostedTick()
-             << ",node->id=" << node->id() << ",node->name=" << node->name()
-             << endl;
+        LoggerFactory::get_logger("workload")
+            ->debug(
+                "callback,sys->id={}, tick={}, node->id={}, node->name={}, node->type={}",
+                sys->id,
+                Sys::boostedTick(),
+                node->id(),
+                node->name(),
+                static_cast<uint64_t>(node->type()));
       }
 
       hw_resource->release(node);
@@ -370,5 +397,6 @@ void Workload::fire() {
 
 void Workload::report() {
   Tick curr_tick = Sys::boostedTick();
-  cout << "sys[" << sys->id << "] finished, " << curr_tick << " cycles" << endl;
+  LoggerFactory::get_logger("workload")
+      ->info("sys[{}] finished, {} cycles", sys->id, curr_tick);
 }

--- a/astra-sim/workload/Workload.cc
+++ b/astra-sim/workload/Workload.cc
@@ -197,7 +197,8 @@ void Workload::issue_cpu_comp(shared_ptr<Chakra::ETFeederNode> node) {
   double operational_intensity = static_cast<double>(node->num_ops()) /
       static_cast<double>(node->tensor_size());
   double perf = sys->roofline->get_perf(operational_intensity);
-  double elapsed_time = static_cast<double>(node->num_ops()) / perf;
+  double elapsed_time = static_cast<double>(node->num_ops()) / perf; // sec
+  uint64_t runtime = static_cast<uint64_t>(elapsed_time * 1e9); // sec -> ns
   uint64_t runtime = static_cast<uint64_t>(elapsed_time);
   sys->register_event(this, EventType::General, wlhd, runtime);
 

--- a/astra-sim/workload/Workload.cc
+++ b/astra-sim/workload/Workload.cc
@@ -114,60 +114,48 @@ void Workload::issue_dep_free_nodes() {
 
 void Workload::issue(shared_ptr<Chakra::ETFeederNode> node) {
   auto logger = LoggerFactory::get_logger("workload");
-  if (sys->replay_only) {
-    hw_resource->occupy(node);
-    issue_replay(node);
-  } else {
-    if ((node->type() == ChakraNodeType::MEM_LOAD_NODE) ||
-        (node->type() == ChakraNodeType::MEM_STORE_NODE)) {
-      if (sys->trace_enabled) {
-        logger->debug(
-            "issue,sys->id={}, tick={}, node->id={}, node->name={}, node->type={}",
-            sys->id,
-            Sys::boostedTick(),
-            node->id(),
-            node->name(),
-            static_cast<uint64_t>(node->type()));
-      }
-      issue_remote_mem(node);
-    } else if (
-        node->is_cpu_op() ||
-        (!node->is_cpu_op() && node->type() == ChakraNodeType::COMP_NODE)) {
-      if ((node->runtime() == 0) && (node->num_ops() == 0)) {
-        skip_invalid(node);
-      } else {
-        if (sys->trace_enabled) {
-          logger->debug(
-              "issue,sys->id={}, tick={}, node->id={}, node->name={}, node->type={}",
-              sys->id,
-              Sys::boostedTick(),
-              node->id(),
-              node->name(),
-              static_cast<uint64_t>(node->type()));
-        }
-        issue_comp(node);
-      }
-    } else if (
-        !node->is_cpu_op() &&
-        (node->type() == ChakraNodeType::COMM_COLL_NODE ||
-         (node->type() == ChakraNodeType::COMM_SEND_NODE) ||
-         (node->type() == ChakraNodeType::COMM_RECV_NODE))) {
-      if (sys->trace_enabled) {
-        if (sys->trace_enabled) {
-          logger->debug(
-              "issue,sys->id={}, tick={}, node->id={}, node->name={}, node->type={}",
-              sys->id,
-              Sys::boostedTick(),
-              node->id(),
-              node->name(),
-              static_cast<uint64_t>(node->type()));
-        }
-      }
-      issue_comm(node);
-    } else if (node->type() == ChakraNodeType::INVALID_NODE) {
-      skip_invalid(node);
-    }
+  if (sys->trace_enabled) {
+    logger->debug(
+        "issue,sys->id={}, tick={}, node->id={}, node->name={}, node->type={}",
+        sys->id,
+        Sys::boostedTick(),
+        node->id(),
+        node->name(),
+        static_cast<uint64_t>(node->type()));
   }
+  const auto& node_type = node->type();
+
+  hw_resource->occupy(node);
+
+  if (sys->replay_only) {
+    issue_replay(node);
+    return;
+  }
+
+  // else not replay_only
+  if ((node_type == ChakraNodeType::MEM_LOAD_NODE) ||
+      (node_type == ChakraNodeType::MEM_STORE_NODE)) {
+    issue_remote_mem(node);
+  } else if (node_type == ChakraNodeType::COMP_NODE) {
+    if (node->is_cpu_op())
+      issue_cpu_comp(node);
+    else
+      issue_gpu_comp(node);
+  } else if (
+      (node_type == ChakraNodeType::COMM_COLL_NODE) ||
+      (node_type == ChakraNodeType::COMM_SEND_NODE) ||
+      (node_type == ChakraNodeType::COMM_RECV_NODE)) {
+    issue_comm(node);
+  } else if (node_type == ChakraNodeType::INVALID_NODE) {
+    skip_invalid(node);
+  } else {
+    logger->critical(
+        "Invalid node_type, node.id={}, node.type={}",
+        node->id(),
+        static_cast<uint64_t>(node->type()));
+    assert(false);
+  }
+  return;
 }
 
 void Workload::issue_replay(shared_ptr<Chakra::ETFeederNode> node) {
@@ -182,8 +170,6 @@ void Workload::issue_replay(shared_ptr<Chakra::ETFeederNode> node) {
 }
 
 void Workload::issue_remote_mem(shared_ptr<Chakra::ETFeederNode> node) {
-  hw_resource->occupy(node);
-
   WorkloadLayerHandlerData* wlhd = new WorkloadLayerHandlerData;
   wlhd->sys_id = sys->id;
   wlhd->workload = this;
@@ -191,59 +177,85 @@ void Workload::issue_remote_mem(shared_ptr<Chakra::ETFeederNode> node) {
   sys->remote_mem->issue(node->tensor_size(), wlhd);
 }
 
-void Workload::issue_comp(shared_ptr<Chakra::ETFeederNode> node) {
-  hw_resource->occupy(node);
-
-  if (sys->roofline_enabled) {
-    WorkloadLayerHandlerData* wlhd = new WorkloadLayerHandlerData;
-    wlhd->node_id = node->id();
-
-    double operational_intensity = static_cast<double>(node->num_ops()) /
-        static_cast<double>(node->tensor_size());
-    double perf = sys->roofline->get_perf(operational_intensity);
-    double elapsed_time = static_cast<double>(node->num_ops()) / perf;
-    uint64_t runtime = static_cast<uint64_t>(elapsed_time);
-    sys->register_event(this, EventType::General, wlhd, runtime);
-  } else {
-    // advance this node forward the recorded "replayed" time specificed in the
-    // ET.
+void Workload::issue_cpu_comp(shared_ptr<Chakra::ETFeederNode> node) {
+  assert(node->is_cpu_op());
+  if (!sys->roofline_enabled) {
     issue_replay(node);
+    return;
   }
+
+  WorkloadLayerHandlerData* wlhd = new WorkloadLayerHandlerData;
+  wlhd->node_id = node->id();
+
+  double operational_intensity = static_cast<double>(node->num_ops()) /
+      static_cast<double>(node->tensor_size());
+  double perf = sys->roofline->get_perf(operational_intensity);
+  double elapsed_time = static_cast<double>(node->num_ops()) / perf;
+  uint64_t runtime = static_cast<uint64_t>(elapsed_time);
+  sys->register_event(this, EventType::General, wlhd, runtime);
+}
+
+void Workload::issue_gpu_comp(shared_ptr<Chakra::ETFeederNode> node) {
+  assert(!node->is_cpu_op());
+  if (!sys->roofline_enabled) {
+    issue_replay(node);
+    return;
+  }
+  throw std::runtime_error(
+      "Do not support non-replay gpu comp nodes yet, need to add another roofline model for gpu");
 }
 
 void Workload::issue_comm(shared_ptr<Chakra::ETFeederNode> node) {
-  hw_resource->occupy(node);
+  if (node->type() == ChakraNodeType::COMM_COLL_NODE) {
+    // check if comm_type is filled instead of default value.
+  } else if (node->type() == ChakraNodeType::COMM_SEND_NODE) {
+    if (!node->comm_src() != sys->id) {
+      std::cerr << "sys issue a send comm node " << node->id() << " with src"
+                << node->comm_src() << " != sys.id" << sys->id << std::endl;
+      exit(EXIT_FAILURE);
+    }
+  } else if (node->type() == ChakraNodeType::COMM_RECV_NODE) {
+    if (!node->comm_dst() != sys->id) {
+      std::cerr << "sys issue a recv comm node " << node->id() << " with dst"
+                << node->comm_dst() << " != sys.id" << sys->id << std::endl;
+      exit(EXIT_FAILURE);
+    }
+  } else {
+    std::cerr << "Unknown communication node type" << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
+  const uint32_t comm_priority = node->comm_priority();
 
   vector<bool> involved_dim;
   for (int i = 0; i < node->involved_dim_size(); i++) {
     involved_dim.push_back(node->involved_dim(i));
   }
 
-  if (!node->is_cpu_op() && (node->type() == ChakraNodeType::COMM_COLL_NODE)) {
+  if (node->type() == ChakraNodeType::COMM_COLL_NODE) {
     if (node->comm_type() == ChakraCollectiveCommType::ALL_REDUCE) {
       DataSet* fp = sys->generate_all_reduce(
-          node->comm_size(), involved_dim, comm_group, node->comm_priority());
+          node->comm_size(), involved_dim, comm_group, comm_priority);
       collective_comm_node_id_map[fp->my_id] = node->id();
       collective_comm_wrapper_map[fp->my_id] = fp;
       fp->set_notifier(this, EventType::CollectiveCommunicationFinished);
-
     } else if (node->comm_type() == ChakraCollectiveCommType::ALL_TO_ALL) {
       DataSet* fp = sys->generate_all_to_all(
-          node->comm_size(), involved_dim, comm_group, node->comm_priority());
+          node->comm_size(), involved_dim, comm_group, comm_priority);
       collective_comm_node_id_map[fp->my_id] = node->id();
       collective_comm_wrapper_map[fp->my_id] = fp;
       fp->set_notifier(this, EventType::CollectiveCommunicationFinished);
 
     } else if (node->comm_type() == ChakraCollectiveCommType::ALL_GATHER) {
       DataSet* fp = sys->generate_all_gather(
-          node->comm_size(), involved_dim, comm_group, node->comm_priority());
+          node->comm_size(), involved_dim, comm_group, comm_priority);
       collective_comm_node_id_map[fp->my_id] = node->id();
       collective_comm_wrapper_map[fp->my_id] = fp;
       fp->set_notifier(this, EventType::CollectiveCommunicationFinished);
 
     } else if (node->comm_type() == ChakraCollectiveCommType::REDUCE_SCATTER) {
       DataSet* fp = sys->generate_reduce_scatter(
-          node->comm_size(), involved_dim, comm_group, node->comm_priority());
+          node->comm_size(), involved_dim, comm_group, comm_priority);
       collective_comm_node_id_map[fp->my_id] = node->id();
       collective_comm_wrapper_map[fp->my_id] = fp;
       fp->set_notifier(this, EventType::CollectiveCommunicationFinished);
@@ -251,27 +263,11 @@ void Workload::issue_comm(shared_ptr<Chakra::ETFeederNode> node) {
     } else if (node->comm_type() == ChakraCollectiveCommType::BROADCAST) {
       // broadcast colelctive has not been implemented in ASTRA-SIM yet.
       // So, we just use its real system mesurements
-      uint64_t runtime = 1ul;
-      if (node->runtime() != 0ul)
-        // chakra runtimes are in microseconds and we should convert it into
-        // nanoseconds
-        runtime = node->runtime() * 1000;
-      DataSet* fp = new DataSet(1);
-      fp->set_notifier(this, EventType::CollectiveCommunicationFinished);
-      collective_comm_node_id_map[fp->my_id] = node->id();
-      collective_comm_wrapper_map[fp->my_id] = fp;
-      sys->register_event(
-          fp,
-          EventType::General,
-          nullptr,
-          // chakra runtimes are in microseconds and we should convert it into
-          // nanoseconds
-          runtime);
-      fp->set_notifier(this, EventType::CollectiveCommunicationFinished);
+      issue_replay(node);
     }
   } else if (node->type() == ChakraNodeType::COMM_SEND_NODE) {
     sim_request snd_req;
-    snd_req.srcRank = node->comm_src();
+    snd_req.srcRank = sys->id;
     snd_req.dstRank = node->comm_dst();
     snd_req.reqType = UINT8;
     SendPacketEventHandlerData* sehd = new SendPacketEventHandlerData;
@@ -316,6 +312,7 @@ void Workload::issue_comm(shared_ptr<Chakra::ETFeederNode> node) {
 void Workload::skip_invalid(shared_ptr<Chakra::ETFeederNode> node) {
   et_feeder->freeChildrenNodes(node->id());
   et_feeder->removeNode(node->id());
+  hw_resource->release(node);
 }
 
 void Workload::call(EventType event, CallData* data) {
@@ -383,9 +380,10 @@ void Workload::call(EventType event, CallData* data) {
   }
 
   if (!et_feeder->hasNodesToIssue() &&
-      (hw_resource->num_in_flight_cpu_ops == 0) &&
+      (hw_resource->num_in_flight_cpu_comp_ops == 0) &&
       (hw_resource->num_in_flight_gpu_comp_ops == 0) &&
-      (hw_resource->num_in_flight_gpu_comm_ops == 0)) {
+      (hw_resource->num_in_flight_comm_ops == 0) &&
+      (hw_resource->num_in_flight_mem_ops == 0)) {
     report();
     is_finished = true;
   }

--- a/astra-sim/workload/Workload.cc
+++ b/astra-sim/workload/Workload.cc
@@ -283,6 +283,7 @@ void Workload::issue_comm(shared_ptr<Chakra::ETFeederNode> node) {
         node->comm_dst(),
         node->comm_tag(),
         &snd_req,
+        Sys::FrontEndSendRecvType::NATIVE,
         &Sys::handleEvent,
         sehd);
   } else if (node->type() == ChakraNodeType::COMM_RECV_NODE) {
@@ -300,6 +301,7 @@ void Workload::issue_comm(shared_ptr<Chakra::ETFeederNode> node) {
         node->comm_src(),
         node->comm_tag(),
         &rcv_req,
+        Sys::FrontEndSendRecvType::NATIVE,
         &Sys::handleEvent,
         rcehd);
   } else {

--- a/astra-sim/workload/Workload.hh
+++ b/astra-sim/workload/Workload.hh
@@ -33,7 +33,8 @@ class Workload : public Callable {
   void issue(std::shared_ptr<Chakra::ETFeederNode> node);
   void issue_replay(std::shared_ptr<Chakra::ETFeederNode> node);
   void issue_remote_mem(std::shared_ptr<Chakra::ETFeederNode> node);
-  void issue_comp(std::shared_ptr<Chakra::ETFeederNode> node);
+  void issue_cpu_comp(std::shared_ptr<Chakra::ETFeederNode> node);
+  void issue_gpu_comp(std::shared_ptr<Chakra::ETFeederNode> node);
   void issue_comm(std::shared_ptr<Chakra::ETFeederNode> node);
   void skip_invalid(std::shared_ptr<Chakra::ETFeederNode> node);
   void call(EventType event, CallData* data);

--- a/astra-sim/workload/Workload.hh
+++ b/astra-sim/workload/Workload.hh
@@ -47,7 +47,7 @@ class Workload : public Callable {
   Chakra::ETFeeder* et_feeder;
   CommunicatorGroup* comm_group;
   HardwareResource* hw_resource;
-  Statistics stats;
+  Statistics* stats;
   Sys* sys;
   std::unordered_map<int, uint64_t> collective_comm_node_id_map;
   std::unordered_map<int, DataSet*> collective_comm_wrapper_map;

--- a/astra-sim/workload/Workload.hh
+++ b/astra-sim/workload/Workload.hh
@@ -13,7 +13,8 @@ LICENSE file in the root directory of this source tree.
 #include "astra-sim/system/Callable.hh"
 #include "astra-sim/system/CommunicatorGroup.hh"
 #include "astra-sim/workload/HardwareResource.hh"
-#include "extern/graph_frontend/chakra/src/feeder/et_feeder.h"
+#include "astra-sim/workload/Statistics.hh"
+#include "extern/graph_frontend/chakra/src/feeder_v2/et_feeder.h"
 
 namespace AstraSim {
 
@@ -46,6 +47,7 @@ class Workload : public Callable {
   Chakra::ETFeeder* et_feeder;
   CommunicatorGroup* comm_group;
   HardwareResource* hw_resource;
+  Statistics stats;
   Sys* sys;
   std::unordered_map<int, uint64_t> collective_comm_node_id_map;
   std::unordered_map<int, DataSet*> collective_comm_wrapper_map;

--- a/astra-sim/workload/Workload.hh
+++ b/astra-sim/workload/Workload.hh
@@ -13,7 +13,7 @@ LICENSE file in the root directory of this source tree.
 #include "astra-sim/system/Callable.hh"
 #include "astra-sim/system/CommunicatorGroup.hh"
 #include "astra-sim/workload/HardwareResource.hh"
-#include "extern/graph_frontend/chakra/et_feeder/et_feeder.h"
+#include "extern/graph_frontend/chakra/src/feeder/et_feeder.h"
 
 namespace AstraSim {
 

--- a/build/astra_analytical/build.sh
+++ b/build/astra_analytical/build.sh
@@ -4,7 +4,7 @@ set -e
 # set paths
 SCRIPT_DIR=$(dirname "$(realpath "$0")")
 BUILD_DIR="${SCRIPT_DIR:?}"/build
-CHAKRA_ET_DIR="${SCRIPT_DIR:?}"/../../extern/graph_frontend/chakra/et_def
+CHAKRA_ET_DIR="${SCRIPT_DIR:?}"/../../extern/graph_frontend/chakra/schema/protobuf
 
 # set functions
 function compile_chakra_et() {
@@ -51,6 +51,9 @@ function compile_astrasim_analytical_as_debug() {
 
 function cleanup() {
   rm -rf "${BUILD_DIR:?}"
+  rm -f "${CHAKRA_ET_DIR}/et_def.pb.cc"
+  rm -f "${CHAKRA_ET_DIR}/et_def.pb.h"
+  rm -f "${CHAKRA_ET_DIR}/et_def_pb2.py"
 }
 
 function create_symlink_astrasim() {

--- a/extern/helper/spdlog_setup/conf.h
+++ b/extern/helper/spdlog_setup/conf.h
@@ -1,0 +1,351 @@
+/**
+ * Implementation of public facing functions in spdlog_setup.
+ * @author Chen Weiguang
+ * @version 0.3.3-pre
+ */
+
+#pragma once
+
+#include "details/conf_impl.h"
+#include "details/setup_error.h"
+#include "details/template_impl.h"
+
+namespace spdlog_setup {
+// declaration section
+
+/**
+ * Performs spdlog configuration setup from file, with tag values to be
+ * replaced into various primitive values.
+ * @param pre_toml_path Path to the pre-TOML configuration file path.
+ * @throw setup_error
+ */
+template <class... Ps>
+void from_file_with_tag_replacement(
+    const std::string &pre_toml_path, Ps &&... ps);
+
+/**
+ * Performs spdlog configuration setup from both base and override files, with
+ * tag values to be replaced into various primitive values for both files. The
+ * base file is required while the override file is optional.
+ * @param base_pre_toml_path Path to the base pre-TOML configuration file path.
+ * @param override_pre_toml_path Path to the override pre-TOML configuration
+ * file path.
+ * @return true if override file is used, otherwise false.
+ * @throw setup_error
+ */
+template <class... Ps>
+auto from_file_and_override_with_tag_replacement(
+    const std::string &base_pre_toml_path,
+    const std::string &override_pre_toml_path,
+    const Ps &... ps) -> bool;
+
+/**
+ * Performs spdlog configuration setup from file.
+ * @param toml_path Path to the TOML configuration file path.
+ * @throw setup_error
+ */
+void from_file(const std::string &toml_path);
+
+/**
+ * Performs spdlog configuration setup from both base and override files. The
+ * base file is required while the override file is optional.
+ * The configuration values from the override file will be merged into the base
+ * configuration values to form the overall configuration values.
+ * @param base_toml_path Path to the base TOML configuration file path.
+ * @param override_toml_path Path to the override TOML configuration file path.
+ * @return true if override file is used, otherwise false.
+ * @throw setup_error
+ */
+auto from_file_and_override(
+    const std::string &base_toml_path, const std::string &override_toml_path)
+    -> bool;
+
+/**
+ * Serializes the current logger level tagged with its logger name, and saves
+ * into the a file. Currently only able to save the logger name and level.
+ * Useful for creating override file. May choose to add the serialized content
+ * to the file, or completely overwrite the file with just this serialized
+ * content.
+ * @param logger Logger to serialize and save.
+ * @param toml_path Path to save the serialized content into.
+ * @param overwrite Default false to add content into override file, true to
+ * ignore the existing file if present, and overwrite the file.
+ * @throw setup_error
+ */
+void save_logger_to_file(
+    const std::shared_ptr<spdlog::logger> &logger,
+    const std::string &toml_path,
+    const bool overwrite = false);
+
+/**
+ * Resets the given logger back to its base configuration from file, while
+ * removing the entry in the override file. Throws exception if the base file
+ * does not contain any configuration for the logger.
+ * @param logger_name Logger name whose configuration to remove in file.
+ * @param toml_path Path whose file to delete the logger entry from.
+ * @return true if entry of logger name is found for deletion, else false and
+ * deletion has no effect on the file.
+ * @throw setup_error
+ */
+auto delete_logger_in_file(
+    const std::string &logger_name, const std::string &toml_path) -> bool;
+
+// implementation section
+
+template <class... Ps>
+void from_file_with_tag_replacement(
+    const std::string &pre_toml_path, Ps &&... ps) {
+
+    // std
+    using std::exception;
+    using std::forward;
+    using std::stringstream;
+
+    try {
+        stringstream toml_ss;
+
+        details::read_template_file_into_stringstream(
+            toml_ss, pre_toml_path, forward<Ps>(ps)...);
+
+        cpptoml::parser parser(toml_ss);
+        const auto config = parser.parse();
+
+        details::setup(config);
+    } catch (const setup_error &) {
+        throw;
+    } catch (const exception &e) {
+        throw setup_error(e.what());
+    }
+}
+
+template <class... Ps>
+auto from_file_and_override_with_tag_replacement(
+    const std::string &base_pre_toml_path,
+    const std::string &override_pre_toml_path,
+    const Ps &... ps) -> bool {
+
+    // std
+    using std::exception;
+    using std::forward;
+    using std::ifstream;
+    using std::move;
+    using std::stringstream;
+
+    try {
+        stringstream base_toml_ss;
+
+        details::read_template_file_into_stringstream(
+            base_toml_ss, base_pre_toml_path, ps...);
+
+        cpptoml::parser base_parser(base_toml_ss);
+        const auto merged_config = base_parser.parse();
+
+        const auto has_override = [&override_pre_toml_path] {
+            ifstream istr(override_pre_toml_path);
+            return static_cast<bool>(istr);
+        }();
+
+        if (has_override) {
+            stringstream override_toml_ss;
+
+            details::read_template_file_into_stringstream(
+                override_toml_ss, override_pre_toml_path, ps...);
+
+            cpptoml::parser override_parser(override_toml_ss);
+            const auto override_config = override_parser.parse();
+
+            // merged_config is interior mutated
+            details::merge_config_root(merged_config, override_config);
+        }
+
+        details::setup(merged_config);
+        return has_override;
+    } catch (const setup_error &) {
+        throw;
+    } catch (const exception &e) {
+        throw setup_error(e.what());
+    }
+}
+
+inline void from_file(const std::string &toml_path) {
+    // std
+    using std::exception;
+    using std::string;
+
+    try {
+        const auto config = cpptoml::parse_file(toml_path);
+        details::setup(config);
+    } catch (const exception &e) {
+        throw setup_error(e.what());
+    }
+}
+
+inline auto from_file_and_override(
+    const std::string &base_toml_path, const std::string &override_toml_path)
+    -> bool {
+
+    // std
+    using std::exception;
+    using std::ifstream;
+    using std::string;
+
+    try {
+        const auto merged_config = cpptoml::parse_file(base_toml_path);
+
+        const auto has_override = [&override_toml_path] {
+            ifstream istr(override_toml_path);
+            return static_cast<bool>(istr);
+        }();
+
+        if (has_override) {
+            const auto override_config =
+                cpptoml::parse_file(override_toml_path);
+
+            // merged_config is interior mutated
+            details::merge_config_root(merged_config, override_config);
+        }
+
+        details::setup(merged_config);
+        return has_override;
+    } catch (const exception &e) {
+        throw setup_error(e.what());
+    }
+}
+
+inline void save_logger_to_file(
+    const std::shared_ptr<spdlog::logger> &logger,
+    const std::string &toml_path,
+    const bool overwrite) {
+
+    using details::find_item_by_name;
+    using details::level_to_str;
+    using details::write_to_config_file;
+    using details::names::LEVEL;
+    using details::names::LOGGER_TABLE;
+    using details::names::NAME;
+
+    // fmt
+    using fmt::format;
+
+    // std
+    using std::exception;
+    using std::find_if;
+    using std::shared_ptr;
+    using std::string;
+
+    try {
+        const auto config = ([overwrite, &toml_path] {
+            if (overwrite) {
+                return cpptoml::make_table();
+            } else {
+                return cpptoml::parse_file(toml_path);
+            }
+        })();
+
+        if (!config) {
+            throw setup_error(
+                format("Unable to parse file at '{}' for saving", toml_path));
+        }
+
+        auto &config_ref = *config;
+
+        const auto curr_loggers = ([&config_ref] {
+            const auto curr_loggers = config_ref.get_table_array(LOGGER_TABLE);
+
+            if (curr_loggers) {
+                return curr_loggers;
+            } else {
+                const auto new_loggers = cpptoml::make_table_array();
+                config_ref.insert(LOGGER_TABLE, new_loggers);
+                return new_loggers;
+            }
+        })();
+
+        auto &curr_loggers_ref = *curr_loggers;
+
+        const auto found_curr_logger =
+            find_item_by_name(curr_loggers_ref, logger->name());
+
+        const auto curr_logger =
+            ([&found_curr_logger, &curr_loggers_ref, &logger] {
+                if (found_curr_logger) {
+                    return found_curr_logger;
+                } else {
+                    const auto new_curr_logger = cpptoml::make_table();
+                    new_curr_logger->insert(NAME, logger->name());
+
+                    curr_loggers_ref.insert(
+                        curr_loggers_ref.end(), new_curr_logger);
+
+                    return new_curr_logger;
+                }
+            }());
+
+        // insert can overwrite the value
+        auto &curr_logger_ref = *curr_logger;
+        curr_logger_ref.insert(LEVEL, level_to_str(logger->level()));
+        write_to_config_file(*config, toml_path);
+    } catch (const setup_error &) {
+        throw;
+    } catch (const exception &e) {
+        throw setup_error(e.what());
+    }
+}
+
+inline auto delete_logger_in_file(
+    const std::string &logger_name, const std::string &toml_path) -> bool {
+
+    using details::find_item_iter_by_name;
+    using details::level_to_str;
+    using details::write_to_config_file;
+    using details::names::LEVEL;
+    using details::names::LOGGER_TABLE;
+    using details::names::NAME;
+
+    // fmt
+    using fmt::format;
+
+    // std
+    using std::exception;
+    using std::find_if;
+    using std::shared_ptr;
+    using std::string;
+
+    try {
+        const auto config = cpptoml::parse_file(toml_path);
+
+        if (!config) {
+            throw setup_error(format(
+                "Unable to parse file at '{}' for deleting logger '{}'",
+                toml_path,
+                logger_name));
+        }
+
+        const auto &config_ref = *config;
+        const auto curr_loggers = config_ref.get_table_array(LOGGER_TABLE);
+
+        if (!curr_loggers) {
+            throw setup_error(format(
+                "Unable to find any logger table array for file at '{}'",
+                toml_path));
+        }
+
+        auto &curr_loggers_ref = *curr_loggers;
+
+        const auto found_curr_logger_it =
+            find_item_iter_by_name(curr_loggers_ref, logger_name);
+
+        if (found_curr_logger_it == curr_loggers_ref.end()) {
+            return false;
+        }
+
+        curr_loggers_ref.erase(found_curr_logger_it);
+        write_to_config_file(*config, toml_path);
+        return true;
+    } catch (const setup_error &) {
+        throw;
+    } catch (const exception &e) {
+        throw setup_error(e.what());
+    }
+}
+} // namespace spdlog_setup

--- a/extern/helper/spdlog_setup/details/conf_impl.h
+++ b/extern/helper/spdlog_setup/details/conf_impl.h
@@ -1,0 +1,1465 @@
+/**
+ * Implementation of non-public facing functions in spdlog_setup.
+ * @author Chen Weiguang
+ * @version 0.3.3-pre
+ */
+
+#pragma once
+
+#ifndef FMT_HEADER_ONLY
+#define FMT_HEADER_ONLY
+#endif
+
+#include "third_party/cpptoml.h"
+#if defined(SPDLOG_SETUP_CPPTOML_EXTERNAL)
+#include "cpptoml.h"
+#endif
+#include "setup_error.h"
+
+// Just so that it works for v1.3.0
+#include "spdlog/spdlog.h"
+
+// To support all asynchronous loggers
+#include "spdlog/async.h"
+
+#include "spdlog/fmt/fmt.h"
+
+#include "spdlog/sinks/basic_file_sink.h"
+#include "spdlog/sinks/daily_file_sink.h"
+#include "spdlog/sinks/null_sink.h"
+#include "spdlog/sinks/rotating_file_sink.h"
+#include "spdlog/sinks/sink.h"
+#include "spdlog/sinks/stdout_sinks.h"
+
+#ifdef _WIN32
+#include "spdlog/sinks/msvc_sink.h"
+#include "spdlog/sinks/wincolor_sink.h"
+#else
+#include "spdlog/sinks/ansicolor_sink.h"
+#include "spdlog/sinks/syslog_sink.h"
+#endif
+
+#include <algorithm>
+#include <cstdint>
+#include <exception>
+#include <fstream>
+#include <memory>
+#include <regex>
+#include <sstream>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#ifdef _WIN32
+#include <Windows.h>
+#include <io.h>
+
+#ifndef F_OK
+#define F_OK 0
+#endif
+#else
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+namespace spdlog_setup {
+namespace details {
+// declaration section
+
+/**
+ * Describes the sink types in enumeration form.
+ */
+enum class sink_type {
+    /** Represents stdout_sink_st */
+    StdoutSinkSt,
+
+    /** Represents stdout_sink_mt */
+    StdoutSinkMt,
+
+    /** Represents stderr_sink_st */
+    StderrSinkSt,
+
+    /** Represents stderr_sink_mt */
+    StderrSinkMt,
+
+    /**
+     * Represents either wincolor_stdout_sink_st (Windows) or
+     * ansicolor_stdout_sink_st (Linux)
+     */
+    ColorStdoutSinkSt,
+
+    /**
+     * Represents either wincolor_stdout_sink_mt (Windows) or
+     * ansicolor_stdout_sink_mt (Linux)
+     */
+    ColorStdoutSinkMt,
+
+    /**
+     * Represents either wincolor_stderr_sink_st (Windows) or
+     * ansicolor_stderr_sink_st (Linux)
+     */
+    ColorStderrSinkSt,
+
+    /**
+     * Represents either wincolor_stderr_sink_mt (Windows) or
+     * ansicolor_stderr_sink_mt (Linux)
+     */
+    ColorStderrSinkMt,
+
+    /** Represents basic_file_sink_st */
+    BasicFileSinkSt,
+
+    /** Represents basic_file_sink_mt */
+    BasicFileSinkMt,
+
+    /** Represents rotating_file_sink_st */
+    RotatingFileSinkSt,
+
+    /** Represents rotating_file_sink_mt */
+    RotatingFileSinkMt,
+
+    /** Represents daily_file_sink_st */
+    DailyFileSinkSt,
+
+    /** Represents daily_file_sink_mt */
+    DailyFileSinkMt,
+
+    /** Represents null_sink_st */
+    NullSinkSt,
+
+    /** Represents null_sink_mt */
+    NullSinkMt,
+
+    /** Represents syslog_sink_st */
+    SyslogSinkSt,
+
+    /** Represents syslog_sink_st */
+    SyslogSinkMt,
+
+    /** Represents msvc_sink_st */
+    MSVCSinkSt,
+
+    /** Represents msvc_sink_mt */
+    MSVCSinkMt,
+};
+
+/**
+ * Describes the logger sync types in enumeration form.
+ */
+enum class sync_type {
+    /** Represent sync type */
+    Sync,
+
+    /** Represent async type */
+    Async,
+};
+
+namespace defaults {
+static constexpr auto ASYNC_OVERFLOW_POLICY =
+    spdlog::async_overflow_policy::block;
+static constexpr auto THREAD_POOL_QUEUE_SIZE = 8192;
+static constexpr auto THREAD_POOL_NUM_THREADS = 1;
+} // namespace defaults
+
+namespace names {
+// table names
+static constexpr auto GLOBAL_THREAD_POOL_TABLE = "global_thread_pool";
+static constexpr auto LOGGER_TABLE = "logger";
+static constexpr auto PATTERN_TABLE = "pattern";
+static constexpr auto SINK_TABLE = "sink";
+static constexpr auto THREAD_POOL_TABLE = "thread_pool";
+
+// field names
+static constexpr auto ASYNC = "async";
+static constexpr auto BASE_FILENAME = "base_filename";
+static constexpr auto BLOCK = "block";
+static constexpr auto CREATE_PARENT_DIR = "create_parent_dir";
+static constexpr auto FILENAME = "filename";
+static constexpr auto GLOBAL_PATTERN = "global_pattern";
+static constexpr auto IDENT = "ident";
+static constexpr auto LEVEL = "level";
+static constexpr auto FLUSH_LEVEL = "flush_level";
+static constexpr auto MAX_FILES = "max_files";
+static constexpr auto MAX_SIZE = "max_size";
+static constexpr auto NAME = "name";
+static constexpr auto NUM_THREADS = "num_threads";
+static constexpr auto OVERRUN_OLDEST = "overrun_oldest";
+static constexpr auto OVERFLOW_POLICY = "overflow_policy";
+static constexpr auto PATTERN = "pattern";
+static constexpr auto QUEUE_SIZE = "queue_size";
+static constexpr auto ROTATION_HOUR = "rotation_hour";
+static constexpr auto ROTATION_MINUTE = "rotation_minute";
+static constexpr auto SINKS = "sinks";
+static constexpr auto SYNC = "sync";
+static constexpr auto SYSLOG_FACILITY = "syslog_facility";
+static constexpr auto SYSLOG_OPTION = "syslog_option";
+static constexpr auto THREAD_POOL = "thread_pool";
+static constexpr auto TRUNCATE = "truncate";
+static constexpr auto TYPE = "type";
+static constexpr auto VALUE = "value";
+} // namespace names
+
+const std::unordered_map<std::string, sync_type> SYNC_MAP{{
+    {names::SYNC, sync_type::Sync},
+    {names::ASYNC, sync_type::Async},
+}};
+
+const std::unordered_map<std::string, spdlog::async_overflow_policy>
+    ASYNC_OVERFLOW_POLICY_MAP{{
+        {names::BLOCK, spdlog::async_overflow_policy::block},
+        {names::OVERRUN_OLDEST, spdlog::async_overflow_policy::overrun_oldest},
+    }};
+
+inline auto get_parent_path(const std::string &file_path) -> std::string {
+    // string
+    using std::string;
+
+#ifdef _WIN32
+    static constexpr auto DIR_SLASHES = "\\/";
+#else
+    static constexpr auto DIR_SLASHES = '/';
+#endif
+
+    const auto last_slash_index = file_path.find_last_of(DIR_SLASHES);
+
+    if (last_slash_index == string::npos) {
+        return "";
+    }
+
+    return file_path.substr(0, last_slash_index);
+}
+
+inline bool native_create_dir(const std::string &dir_path) noexcept {
+#ifdef _WIN32
+    // non-zero for success in Windows
+    return CreateDirectoryA(dir_path.c_str(), nullptr) != 0;
+#else
+    // zero for success for GNU
+    return mkdir(dir_path.c_str(), 0775) == 0;
+#endif
+}
+
+inline auto file_exists(const std::string &file_path) noexcept -> bool {
+    static constexpr auto FILE_NOT_FOUND = -1;
+
+#ifdef _WIN32
+    return _access(file_path.c_str(), F_OK) != FILE_NOT_FOUND;
+#else
+    return access(file_path.c_str(), F_OK) != FILE_NOT_FOUND;
+#endif
+}
+
+inline void create_dirs_impl(const std::string &dir_path) {
+    // fmt
+    using fmt::format;
+
+#ifdef _WIN32
+    // check for both empty and drive letter
+    if (dir_path.empty() || (dir_path.length() == 2 && dir_path[1] == ':')) {
+        return;
+    }
+#else
+    if (dir_path.empty()) {
+        return;
+    }
+#endif
+
+    if (!file_exists(dir_path)) {
+        create_dirs_impl(get_parent_path(dir_path));
+
+        if (!native_create_dir(dir_path)) {
+            throw setup_error(
+                format("Unable to create directory at '{}'", dir_path));
+        }
+    }
+}
+
+inline void create_directories(const std::string &dir_path) {
+    create_dirs_impl(dir_path);
+}
+
+inline auto
+find_item_iter_by_name(cpptoml::table_array &items, const std::string &name)
+    -> cpptoml::table_array::iterator {
+
+    using names::NAME;
+
+    // std
+    using std::find_if;
+    using std::shared_ptr;
+    using std::string;
+
+    return find_if(
+        items.begin(),
+        items.end(),
+        [&name](const shared_ptr<cpptoml::table> item) {
+            const auto item_name_opt = item->get_as<string>(NAME);
+            return item_name_opt && *item_name_opt == name;
+        });
+}
+
+inline auto
+find_item_by_name(cpptoml::table_array &items, const std::string &name)
+    -> std::shared_ptr<cpptoml::table> {
+
+    const auto item_it = find_item_iter_by_name(items, name);
+
+    if (item_it == items.end()) {
+        return nullptr;
+    }
+
+    return *item_it;
+}
+
+inline void write_to_config_file(
+    const cpptoml::table &config, const std::string &toml_path) {
+
+    // fmt
+    using fmt::format;
+
+    // std
+    using std::ofstream;
+
+    ofstream override_str(toml_path);
+
+    if (!override_str) {
+        throw setup_error(format("Unable to open '{}' for writing", toml_path));
+    }
+
+    auto writer = cpptoml::toml_writer(override_str);
+    writer.visit(config);
+}
+
+template <class... Ps>
+void read_template_file_into_stringstream(
+    std::stringstream &toml_ss, const std::string &file_path, Ps &&... ps) {
+
+    // fmt
+    using fmt::format;
+
+    // std
+    using std::exception;
+    using std::forward;
+    using std::ifstream;
+    using std::move;
+    using std::string;
+    using std::stringstream;
+
+    try {
+        ifstream file_stream(file_path);
+
+        if (!file_stream) {
+            throw setup_error(format("Error reading file at '{}'", file_path));
+        }
+
+        stringstream pre_toml_ss;
+        pre_toml_ss << file_stream.rdbuf();
+
+        const auto pre_toml_content = pre_toml_ss.str();
+
+        const auto toml_content =
+            format(pre_toml_content, std::forward<Ps>(ps)...);
+
+        toml_ss << toml_content;
+    } catch (const exception &e) {
+        throw setup_error(e.what());
+    }
+}
+
+inline void merge_config_items(
+    cpptoml::table &base_ref,
+    const std::shared_ptr<cpptoml::table_array> &base_items,
+    const std::shared_ptr<cpptoml::table_array> &ovr_items) {
+
+    using names::NAME;
+
+    // std
+    using std::string;
+
+    if (base_items && ovr_items) {
+        auto &base_items_ref = *base_items;
+        const auto &ovr_items_ref = *ovr_items;
+
+        for (const auto &ovr_item : ovr_items_ref) {
+            const auto &ovr_item_ref = *ovr_item;
+            const auto ovr_name_opt = ovr_item->get_as<string>(NAME);
+
+            if (!ovr_name_opt) {
+                throw setup_error(
+                    "One of the items in override does not have a name");
+            }
+
+            const auto &ovr_name = *ovr_name_opt;
+
+            const auto found_base_item =
+                find_item_by_name(base_items_ref, ovr_name);
+
+            if (found_base_item) {
+                // merge from override to base
+                auto &found_base_item_ref = *found_base_item;
+
+                for (const auto &ovr_item_kv : ovr_item_ref) {
+                    found_base_item_ref.insert(
+                        ovr_item_kv.first, ovr_item_kv.second);
+                }
+            } else {
+                // insert new override item entry
+                base_items_ref.push_back(ovr_item);
+            }
+        }
+    } else if (!base_items && ovr_items) {
+        base_ref.insert(names::LOGGER_TABLE, ovr_items);
+    }
+}
+
+inline void merge_config_root(
+    const std::shared_ptr<cpptoml::table> &base,
+    const std::shared_ptr<cpptoml::table> &ovr) {
+
+    using names::LOGGER_TABLE;
+    using names::PATTERN_TABLE;
+    using names::SINK_TABLE;
+
+    if (!base) {
+        throw setup_error("Base config cannot be null for merging");
+    }
+
+    if (!ovr) {
+        throw setup_error("Override config cannot be null for merging");
+    }
+
+    auto &base_ref = *base;
+    const auto &ovr_ref = *ovr;
+
+    // directly target items to merge
+
+    // sinks
+    const auto base_sinks = base_ref.get_table_array(names::SINK_TABLE);
+    const auto ovr_sinks = ovr_ref.get_table_array(names::SINK_TABLE);
+    merge_config_items(base_ref, base_sinks, ovr_sinks);
+
+    // patterns
+    const auto base_patterns = base_ref.get_table_array(names::PATTERN_TABLE);
+    const auto ovr_patterns = ovr_ref.get_table_array(names::PATTERN_TABLE);
+    merge_config_items(base_ref, base_patterns, ovr_patterns);
+
+    // loggers
+    const auto base_loggers = base_ref.get_table_array(names::LOGGER_TABLE);
+    const auto ovr_loggers = ovr_ref.get_table_array(names::LOGGER_TABLE);
+    merge_config_items(base_ref, base_loggers, ovr_loggers);
+} // namespace details
+
+template <class T, class Fn>
+void if_value_from_table(
+    const std::shared_ptr<cpptoml::table> &table,
+    const char field[],
+    Fn &&if_value_fn) {
+
+    const auto value_opt = table->get_as<T>(field);
+
+    if (value_opt) {
+        if_value_fn(*value_opt);
+    }
+}
+
+template <class T>
+auto value_from_table_opt(
+    const std::shared_ptr<cpptoml::table> &table, const char field[])
+    -> cpptoml::option<T> {
+
+    // std
+    using std::string;
+
+    return table->get_as<string>(field);
+}
+
+template <class T>
+auto value_from_table_or(
+    const std::shared_ptr<cpptoml::table> &table,
+    const char field[],
+    const T &alt_val) -> T {
+
+    const auto value_opt = table->get_as<T>(field);
+
+    if (value_opt) {
+        return *value_opt;
+    } else {
+        return alt_val;
+    }
+}
+
+template <class T>
+auto value_from_table(
+    const std::shared_ptr<cpptoml::table> &table,
+    const char field[],
+    const std::string &err_msg) -> T {
+
+    const auto value_opt = table->get_as<T>(field);
+
+    if (!value_opt) {
+        throw setup_error(err_msg);
+    }
+
+    return *value_opt;
+}
+
+template <class T>
+auto array_from_table(
+    const std::shared_ptr<cpptoml::table> &table,
+    const char field[],
+    const std::string &err_msg) -> std::vector<T> {
+
+    const auto array_opt = table->get_array_of<T>(field);
+
+    if (!array_opt) {
+        throw setup_error(err_msg);
+    }
+
+    return *array_opt;
+}
+
+template <class Map, class Key>
+auto find_value_from_map(
+    const Map &m, const Key &key, const std::string &err_msg) ->
+    typename Map::mapped_type {
+
+    const auto iter = m.find(key);
+
+    if (iter == m.cend()) {
+        throw setup_error(err_msg);
+    }
+
+    return iter->second;
+}
+
+template <class Fn, class ErrFn>
+auto add_msg_on_err(Fn &&fn, ErrFn &&add_msg_on_err_fn) ->
+    typename std::result_of<Fn()>::type {
+
+    // std
+    using std::exception;
+    using std::move;
+    using std::string;
+
+    try {
+        return fn();
+    } catch (const exception &e) {
+        throw setup_error(add_msg_on_err_fn(e.what()));
+    }
+}
+
+inline auto parse_max_size(const std::string &max_size_str) -> uint64_t {
+    // fmt
+    using fmt::format;
+
+    // std
+    using std::exception;
+    using std::regex;
+    using std::regex_match;
+    using std::smatch;
+    using std::stoull;
+    using std::string;
+    using std::regex_constants::icase;
+
+    try {
+        static const regex RE(R"_(^\s*(\d+)\s*(T|G|M|K|)(:?B|)\s*$)_", icase);
+
+        smatch matches;
+        const auto has_match = regex_match(max_size_str, matches, RE);
+
+        if (has_match && matches.size() == 4) {
+            const uint64_t base_val = stoull(matches[1]);
+            const string suffix = matches[2];
+
+            if (suffix == "") {
+                // byte
+                return base_val;
+            } else if (suffix == "K") {
+                // kilobyte
+                return base_val * 1024;
+            } else if (suffix == "M") {
+                // megabyte
+                return base_val * 1024 * 1024;
+            } else if (suffix == "G") {
+                // gigabyte
+                return base_val * 1024 * 1024 * 1024;
+            } else if (suffix == "T") {
+                // terabyte
+                return base_val * 1024 * 1024 * 1024 * 1024;
+            } else {
+                throw setup_error(format(
+                    "Unexpected suffix '{}' for max size parsing", suffix));
+            }
+        } else {
+            throw setup_error(format(
+                "Invalid string '{}' for max size parsing", max_size_str));
+        }
+    } catch (const exception &e) {
+        throw setup_error(format(
+            "Unexpected exception for max size parsing on string '{}': {}",
+            max_size_str,
+            e.what()));
+    }
+}
+
+inline auto sink_type_from_str(const std::string &type) -> sink_type {
+    // fmt
+    using fmt::format;
+
+    // std
+    using std::string;
+    using std::unordered_map;
+
+    static const unordered_map<string, sink_type> MAPPING{
+        {"stdout_sink_st", sink_type::StdoutSinkSt},
+        {"stdout_sink_mt", sink_type::StdoutSinkMt},
+        {"stderr_sink_st", sink_type::StderrSinkSt},
+        {"stderr_sink_mt", sink_type::StderrSinkMt},
+        {"color_stdout_sink_st", sink_type::ColorStdoutSinkSt},
+        {"color_stdout_sink_mt", sink_type::ColorStdoutSinkMt},
+        {"color_stderr_sink_st", sink_type::ColorStderrSinkSt},
+        {"color_stderr_sink_mt", sink_type::ColorStderrSinkMt},
+        {"basic_file_sink_st", sink_type::BasicFileSinkSt},
+        {"basic_file_sink_mt", sink_type::BasicFileSinkMt},
+        {"rotating_file_sink_st", sink_type::RotatingFileSinkSt},
+        {"rotating_file_sink_mt", sink_type::RotatingFileSinkMt},
+        {"daily_file_sink_st", sink_type::DailyFileSinkSt},
+        {"daily_file_sink_mt", sink_type::DailyFileSinkMt},
+        {"null_sink_st", sink_type::NullSinkSt},
+        {"null_sink_mt", sink_type::NullSinkMt},
+#ifdef SPDLOG_ENABLE_SYSLOG
+        {"syslog_sink_st", sink_type::SyslogSinkSt},
+        {"syslog_sink_mt", sink_type::SyslogSinkMt},
+#endif
+        {"msvc_sink_st", sink_type::MSVCSinkSt},
+        {"msvc_sink_mt", sink_type::MSVCSinkMt},
+    };
+
+    return find_value_from_map(
+        MAPPING, type, format("Invalid sink type '{}' found", type));
+}
+
+inline void create_parent_dir_if_present(
+    const std::shared_ptr<cpptoml::table> &sink_table,
+    const std::string &filename) {
+
+    using names::CREATE_PARENT_DIR;
+
+    // std
+    using std::string;
+
+    if_value_from_table<bool>(
+        sink_table, CREATE_PARENT_DIR, [&filename](const bool flag) {
+            if (flag) {
+                create_directories(get_parent_path(filename));
+            }
+        });
+}
+
+inline auto level_from_str(const std::string &level)
+    -> spdlog::level::level_enum {
+
+    // fmt
+    using fmt::format;
+
+    // spdlog
+    namespace lv = spdlog::level;
+
+    if (level == "trace") {
+        return lv::trace;
+    } else if (level == "debug") {
+        return lv::debug;
+    } else if (level == "info") {
+        return lv::info;
+    } else if (level == "warn") {
+        return lv::warn;
+    } else if (level == "err") {
+        return lv::err;
+    } else if (level == "critical") {
+        return lv::critical;
+    } else if (level == "off") {
+        return lv::off;
+    } else {
+        throw setup_error(format("Invalid level string '{}' provided", level));
+    }
+}
+
+inline auto level_to_str(const spdlog::level::level_enum level) -> std::string {
+    // fmt
+    using fmt::format;
+
+    // spdlog
+    namespace lv = spdlog::level;
+
+    if (level == lv::trace) {
+        return "trace";
+    } else if (level == lv::debug) {
+        return "debug";
+    } else if (level == lv::info) {
+        return "info";
+    } else if (level == lv::warn) {
+        return "warn";
+    } else if (level == lv::err) {
+        return "err";
+    } else if (level == lv::critical) {
+        return "critical";
+    } else if (level == lv::off) {
+        return "off";
+    } else {
+        throw setup_error(format(
+            "Invalid level enum '{}' provided", static_cast<int>(level)));
+    }
+}
+
+inline void set_sink_level_if_present(
+    const std::shared_ptr<cpptoml::table> &sink_table,
+    const std::shared_ptr<spdlog::sinks::sink> &sink) {
+
+    using names::LEVEL;
+
+    // std
+    using std::string;
+
+    if_value_from_table<string>(
+        sink_table, LEVEL, [&sink](const string &level) {
+            const auto level_enum = level_from_str(level);
+            sink->set_level(level_enum);
+        });
+}
+
+template <class BasicFileSink>
+auto setup_basic_file_sink(const std::shared_ptr<cpptoml::table> &sink_table)
+    -> std::shared_ptr<spdlog::sinks::sink> {
+
+    using names::FILENAME;
+    using names::LEVEL;
+    using names::TRUNCATE;
+
+    // fmt
+    using fmt::format;
+
+    // std
+    using std::make_shared;
+    using std::string;
+
+    static constexpr auto DEFAULT_TRUNCATE = false;
+
+    const auto filename = value_from_table<string>(
+        sink_table,
+        FILENAME,
+        format(
+            "Missing '{}' field of string value for basic_file_sink",
+            FILENAME));
+
+    // must create the directory before creating the sink
+    create_parent_dir_if_present(sink_table, filename);
+
+    const auto truncate =
+        value_from_table_or<bool>(sink_table, TRUNCATE, DEFAULT_TRUNCATE);
+
+    return make_shared<BasicFileSink>(filename, truncate);
+}
+
+template <class RotatingFileSink>
+auto setup_rotating_file_sink(const std::shared_ptr<cpptoml::table> &sink_table)
+    -> std::shared_ptr<spdlog::sinks::sink> {
+
+    using names::BASE_FILENAME;
+    using names::MAX_FILES;
+    using names::MAX_SIZE;
+
+    // fmt
+    using fmt::format;
+
+    // std
+    using std::make_shared;
+    using std::string;
+
+    const auto base_filename = value_from_table<string>(
+        sink_table,
+        BASE_FILENAME,
+        format(
+            "Missing '{}' field of string value for rotating_file_sink",
+            BASE_FILENAME));
+
+    // must create the directory before creating the sink
+    create_parent_dir_if_present(sink_table, base_filename);
+
+    const auto max_filesize_str = value_from_table<string>(
+        sink_table,
+        MAX_SIZE,
+        format(
+            "Missing '{}' field of string value for rotating_file_sink",
+            MAX_SIZE));
+
+    const auto max_filesize = parse_max_size(max_filesize_str);
+
+    const auto max_files = value_from_table<uint64_t>(
+        sink_table,
+        MAX_FILES,
+        format(
+            "Missing '{}' field of u64 value for rotating_file_sink",
+            MAX_FILES));
+
+    return make_shared<RotatingFileSink>(
+        base_filename, max_filesize, max_files);
+}
+
+template <class DailyFileSink>
+auto setup_daily_file_sink(const std::shared_ptr<cpptoml::table> &sink_table)
+    -> std::shared_ptr<spdlog::sinks::sink> {
+
+    using names::BASE_FILENAME;
+    using names::ROTATION_HOUR;
+    using names::ROTATION_MINUTE;
+
+    // fmt
+    using fmt::format;
+
+    // std
+    using std::make_shared;
+    using std::string;
+
+    const auto base_filename = value_from_table<string>(
+        sink_table,
+        BASE_FILENAME,
+        format(
+            "Missing '{}' field of string value for daily_file_sink",
+            BASE_FILENAME));
+
+    // must create the directory before creating the sink
+    create_parent_dir_if_present(sink_table, base_filename);
+
+    const auto rotation_hour = value_from_table<int32_t>(
+        sink_table,
+        ROTATION_HOUR,
+        format(
+            "Missing '{}' field of string value for daily_file_sink",
+            ROTATION_HOUR));
+
+    const auto rotation_minute = value_from_table<int32_t>(
+        sink_table,
+        ROTATION_MINUTE,
+        format(
+            "Missing '{}' field of string value for daily_file_sink",
+            ROTATION_MINUTE));
+
+    return make_shared<DailyFileSink>(
+        base_filename, rotation_hour, rotation_minute);
+}
+
+#ifdef SPDLOG_ENABLE_SYSLOG
+
+template <class SyslogSink>
+auto setup_syslog_sink(const std::shared_ptr<cpptoml::table> &sink_table)
+    -> std::shared_ptr<spdlog::sinks::sink> {
+
+    using names::IDENT;
+    using names::SYSLOG_FACILITY;
+    using names::SYSLOG_OPTION;
+
+    // fmt
+    using fmt::format;
+
+    // std
+    using std::make_shared;
+    using std::string;
+
+    // all are optional fields
+    static constexpr auto DEFAULT_IDENT = "";
+    static constexpr auto DEFAULT_SYSLOG_OPTION = 0;
+    static constexpr auto DEFAULT_SYSLOG_FACILITY = LOG_USER;
+
+    const auto ident =
+        value_from_table_or<string>(sink_table, IDENT, DEFAULT_IDENT);
+
+    const auto syslog_option = value_from_table_or<int32_t>(
+        sink_table, SYSLOG_OPTION, DEFAULT_SYSLOG_OPTION);
+
+    const auto syslog_facility = value_from_table_or<int32_t>(
+        sink_table, SYSLOG_FACILITY, DEFAULT_SYSLOG_FACILITY);
+
+    return make_shared<SyslogSink>(ident, syslog_option, syslog_facility);
+}
+
+#endif
+
+inline auto sink_from_sink_type(
+    const sink_type sink_val, const std::shared_ptr<cpptoml::table> &sink_table)
+    -> std::shared_ptr<spdlog::sinks::sink> {
+
+    // fmt
+    using fmt::format;
+
+    // spdlog
+    using spdlog::sinks::basic_file_sink_mt;
+    using spdlog::sinks::basic_file_sink_st;
+    using spdlog::sinks::daily_file_sink_mt;
+    using spdlog::sinks::daily_file_sink_st;
+    using spdlog::sinks::null_sink_mt;
+    using spdlog::sinks::null_sink_st;
+    using spdlog::sinks::rotating_file_sink_mt;
+    using spdlog::sinks::rotating_file_sink_st;
+    using spdlog::sinks::sink;
+    using spdlog::sinks::stderr_sink_mt;
+    using spdlog::sinks::stderr_sink_st;
+    using spdlog::sinks::stdout_sink_mt;
+    using spdlog::sinks::stdout_sink_st;
+
+    // std
+    using std::make_shared;
+
+#ifdef _WIN32
+    using color_stdout_sink_st = spdlog::sinks::wincolor_stdout_sink_st;
+    using color_stdout_sink_mt = spdlog::sinks::wincolor_stdout_sink_mt;
+    using color_stderr_sink_st = spdlog::sinks::wincolor_stderr_sink_st;
+    using color_stderr_sink_mt = spdlog::sinks::wincolor_stderr_sink_mt;
+    using msvc_sink_st = spdlog::sinks::msvc_sink_st;
+    using msvc_sink_mt = spdlog::sinks::msvc_sink_mt;
+#else
+    using color_stdout_sink_st = spdlog::sinks::ansicolor_stdout_sink_st;
+    using color_stdout_sink_mt = spdlog::sinks::ansicolor_stdout_sink_mt;
+    using color_stderr_sink_st = spdlog::sinks::ansicolor_stderr_sink_st;
+    using color_stderr_sink_mt = spdlog::sinks::ansicolor_stderr_sink_mt;
+
+    using spdlog::sinks::syslog_sink_mt;
+    using spdlog::sinks::syslog_sink_st;
+#endif
+
+    switch (sink_val) {
+    case sink_type::StdoutSinkSt:
+        return make_shared<stdout_sink_st>();
+
+    case sink_type::StdoutSinkMt:
+        return make_shared<stdout_sink_mt>();
+
+    case sink_type::StderrSinkSt:
+        return make_shared<stderr_sink_st>();
+
+    case sink_type::StderrSinkMt:
+        return make_shared<stderr_sink_mt>();
+
+    case sink_type::ColorStdoutSinkSt:
+        return make_shared<color_stdout_sink_st>();
+
+    case sink_type::ColorStdoutSinkMt:
+        return make_shared<color_stdout_sink_mt>();
+
+    case sink_type::ColorStderrSinkSt:
+        return make_shared<color_stderr_sink_st>();
+
+    case sink_type::ColorStderrSinkMt:
+        return make_shared<color_stderr_sink_mt>();
+
+    case sink_type::BasicFileSinkSt:
+        return setup_basic_file_sink<basic_file_sink_st>(sink_table);
+
+    case sink_type::BasicFileSinkMt:
+        return setup_basic_file_sink<basic_file_sink_mt>(sink_table);
+
+    case sink_type::RotatingFileSinkSt:
+        return setup_rotating_file_sink<rotating_file_sink_st>(sink_table);
+
+    case sink_type::RotatingFileSinkMt:
+        return setup_rotating_file_sink<rotating_file_sink_mt>(sink_table);
+
+    case sink_type::DailyFileSinkSt:
+        return setup_daily_file_sink<daily_file_sink_st>(sink_table);
+
+    case sink_type::DailyFileSinkMt:
+        return setup_daily_file_sink<daily_file_sink_mt>(sink_table);
+
+    case sink_type::NullSinkSt:
+        return make_shared<null_sink_st>();
+
+    case sink_type::NullSinkMt:
+        return make_shared<null_sink_mt>();
+
+#ifdef SPDLOG_ENABLE_SYSLOG
+    case sink_type::SyslogSinkSt:
+        return setup_syslog_sink<syslog_sink_st>(sink_table);
+
+    case sink_type::SyslogSinkMt:
+        return setup_syslog_sink<syslog_sink_mt>(sink_table);
+#endif
+
+#ifdef _WIN32
+    case sink_type::MSVCSinkSt:
+        return make_shared<msvc_sink_st>();
+    case sink_type::MSVCSinkMt:
+        return make_shared<msvc_sink_mt>();
+#endif
+
+    default:
+        throw setup_error(format(
+            "Unexpected sink error with sink enum value '{}'",
+            static_cast<int>(sink_val)));
+    }
+}
+
+inline void set_logger_level_if_present(
+    const std::shared_ptr<cpptoml::table> &logger_table,
+    const std::shared_ptr<spdlog::logger> &logger) {
+
+    using names::LEVEL;
+
+    // std
+    using std::string;
+
+    if_value_from_table<string>(
+        logger_table, LEVEL, [&logger](const string &level) {
+            const auto level_enum = level_from_str(level);
+            logger->set_level(level_enum);
+        });
+}
+
+inline void set_logger_flush_level_if_present(
+    const std::shared_ptr<cpptoml::table> &logger_table,
+    const std::shared_ptr<spdlog::logger> &logger) {
+
+    using names::FLUSH_LEVEL;
+
+    // std
+    using std::string;
+
+    if_value_from_table<string>(
+        logger_table, FLUSH_LEVEL, [&logger](const string &flush_level) {
+            const auto level_enum = level_from_str(flush_level);
+            logger->flush_on(level_enum);
+        });
+}
+
+inline auto setup_sink(const std::shared_ptr<cpptoml::table> &sink_table)
+    -> std::shared_ptr<spdlog::sinks::sink> {
+
+    using names::TYPE;
+
+    // fmt
+    using fmt::format;
+
+    // std
+    using std::move;
+    using std::string;
+
+    const auto type_val = value_from_table<string>(
+        sink_table, TYPE, format("Sink missing '{}' field", TYPE));
+
+    const auto sink_val = sink_type_from_str(type_val);
+    auto sink = sink_from_sink_type(sink_val, sink_table);
+
+    // set optional parts and return back the same sink
+    set_sink_level_if_present(sink_table, sink);
+
+    return sink;
+}
+
+inline auto setup_sinks(const std::shared_ptr<cpptoml::table> &config)
+    -> std::unordered_map<std::string, std::shared_ptr<spdlog::sinks::sink>> {
+
+    using names::NAME;
+    using names::SINK_TABLE;
+
+    // fmt
+    using fmt::format;
+
+    // std
+    using std::move;
+    using std::shared_ptr;
+    using std::string;
+    using std::unordered_map;
+
+    const auto sinks = config->get_table_array(SINK_TABLE);
+
+    if (!sinks) {
+        throw setup_error("No sinks configured for set-up");
+    }
+
+    unordered_map<string, shared_ptr<spdlog::sinks::sink>> sinks_map;
+
+    for (const auto &sink_table : *sinks) {
+        auto name = value_from_table<string>(
+            sink_table,
+            NAME,
+            format("One of the sinks does not have a '{}' field", NAME));
+
+        auto sink = add_msg_on_err(
+            [&sink_table] { return setup_sink(sink_table); },
+            [&name](const string &err_msg) {
+                return format("Sink '{}' error:\n > {}", name, err_msg);
+            });
+
+        sinks_map.emplace(move(name), move(sink));
+    }
+
+    return sinks_map;
+}
+
+inline auto setup_patterns(const std::shared_ptr<cpptoml::table> &config)
+    -> std::unordered_map<std::string, std::string> {
+
+    using names::NAME;
+    using names::PATTERN_TABLE;
+    using names::VALUE;
+
+    // fmt
+    using fmt::format;
+
+    // std
+    using std::move;
+    using std::string;
+    using std::unordered_map;
+
+    // possible to return an entire empty pattern map
+    unordered_map<string, string> patterns_map;
+
+    const auto patterns = config->get_table_array(PATTERN_TABLE);
+
+    if (patterns) {
+        for (const auto &pattern_table : *patterns) {
+            auto name = value_from_table<string>(
+                pattern_table,
+                NAME,
+                format("One of the patterns does not have a '{}' field", NAME));
+
+            auto value = value_from_table<string>(
+                pattern_table,
+                VALUE,
+                format("Pattern '{}' does not have '{}' field", name, VALUE));
+
+            patterns_map.emplace(move(name), move(value));
+        }
+    }
+
+    return patterns_map;
+}
+
+inline auto
+setup_thread_pools(const std::shared_ptr<cpptoml::table> &config) -> std::
+    unordered_map<std::string, std::shared_ptr<spdlog::details::thread_pool>> {
+
+    using names::GLOBAL_THREAD_POOL_TABLE;
+    using names::NAME;
+    using names::NUM_THREADS;
+    using names::QUEUE_SIZE;
+    using names::THREAD_POOL_TABLE;
+
+    // fmt
+    using fmt::format;
+
+    // spdlog
+    using spdlog::init_thread_pool;
+    using spdlog::details::thread_pool;
+
+    // std
+    using std::make_shared;
+    using std::move;
+    using std::shared_ptr;
+    using std::string;
+    using std::unordered_map;
+
+    // reinitialize global thread pool for async loggers if present
+    const auto global_thread_pool_table =
+        config->get_table(GLOBAL_THREAD_POOL_TABLE);
+
+    if (global_thread_pool_table) {
+        const auto queue_size = value_from_table_or<size_t>(
+            global_thread_pool_table,
+            QUEUE_SIZE,
+            defaults::THREAD_POOL_QUEUE_SIZE);
+
+        const auto num_threads = value_from_table_or<size_t>(
+            global_thread_pool_table,
+            NUM_THREADS,
+            defaults::THREAD_POOL_NUM_THREADS);
+
+        init_thread_pool(queue_size, num_threads);
+    }
+
+    // possible to return an entire empty thread pools map
+    unordered_map<string, shared_ptr<thread_pool>> thread_pools_map;
+
+    const auto thread_pools = config->get_table_array(THREAD_POOL_TABLE);
+
+    if (thread_pools) {
+        for (const auto &thread_pool_table : *thread_pools) {
+            auto name = value_from_table<string>(
+                thread_pool_table,
+                NAME,
+                format(
+                    "One of the thread pools does not have a '{}' field",
+                    NAME));
+
+            const auto queue_size = value_from_table<size_t>(
+                thread_pool_table,
+                QUEUE_SIZE,
+                format(
+                    "Thread pool '{}' does not have '{}' field",
+                    name,
+                    QUEUE_SIZE));
+
+            const auto num_threads = value_from_table<size_t>(
+                thread_pool_table,
+                NUM_THREADS,
+                format(
+                    "Thread pool '{}' does not have '{}' field",
+                    name,
+                    NUM_THREADS));
+
+            thread_pools_map.emplace(
+                move(name), make_shared<thread_pool>(queue_size, num_threads));
+        }
+    }
+
+    return thread_pools_map;
+}
+
+inline auto setup_sync_logger(
+    const std::string &name,
+    const std::vector<std::shared_ptr<spdlog::sinks::sink>> &logger_sinks)
+    -> std::shared_ptr<spdlog::logger> {
+    return std::make_shared<spdlog::logger>(
+        name, logger_sinks.cbegin(), logger_sinks.cend());
+}
+
+inline auto setup_async_logger(
+    const std::string &name,
+    const std::shared_ptr<cpptoml::table> &logger_table,
+    const std::vector<std::shared_ptr<spdlog::sinks::sink>> &logger_sinks,
+    const std::unordered_map<
+        std::string,
+        std::shared_ptr<spdlog::details::thread_pool>> &thread_pools_map)
+    -> std::shared_ptr<spdlog::logger> {
+    const auto &thread_pool_name_opt =
+        value_from_table_opt<std::string>(logger_table, names::THREAD_POOL);
+
+    auto thread_pool = static_cast<bool>(thread_pool_name_opt)
+                ? [&name, &thread_pools_map, &thread_pool_name_opt]() {
+                    const auto &thread_pool_name = *thread_pool_name_opt;
+
+                    return find_value_from_map(
+                        thread_pools_map,
+                        thread_pool_name,
+                        fmt::format(
+                            "Unable to find thread pool '{}' for logger '{}'",
+                            thread_pool_name,
+                            name));
+                }()
+                : spdlog::thread_pool();
+
+    const auto &async_overflow_policy_raw_opt =
+        value_from_table_opt<std::string>(logger_table, names::OVERFLOW_POLICY);
+
+    const auto async_overflow_policy = static_cast<bool>(async_overflow_policy_raw_opt)
+                ? [&async_overflow_policy_raw_opt, &name]() {
+                    const auto &async_overflow_policy_raw = *async_overflow_policy_raw_opt;
+
+                    return find_value_from_map(
+                        ASYNC_OVERFLOW_POLICY_MAP,
+                        async_overflow_policy_raw,
+                        fmt::format(
+                            "Invalid async overflow policy type given '{}' for logger '{}'",
+                            async_overflow_policy_raw,
+                            name)
+                    );
+                }()
+                : defaults::ASYNC_OVERFLOW_POLICY;
+
+    return std::make_shared<spdlog::async_logger>(
+        name,
+        logger_sinks.cbegin(),
+        logger_sinks.cend(),
+        std::move(thread_pool),
+        async_overflow_policy);
+}
+
+inline auto setup_logger(
+    const std::shared_ptr<cpptoml::table> &logger_table,
+    const std::unordered_map<std::string, std::shared_ptr<spdlog::sinks::sink>>
+        &sinks_map,
+    const std::unordered_map<std::string, std::string> &patterns_map,
+    const std::unordered_map<
+        std::string,
+        std::shared_ptr<spdlog::details::thread_pool>> &thread_pools_map,
+    const cpptoml::option<std::string> &global_pattern_opt)
+    -> std::shared_ptr<spdlog::logger> {
+
+    using fmt::format;
+    using names::PATTERN;
+    using std::exception;
+    using std::string;
+
+    const auto name = value_from_table<std::string>(
+        logger_table,
+        names::NAME,
+        fmt::format(
+            "One of the loggers does not have a '{}' field", names::NAME));
+
+    const auto sinks = array_from_table<std::string>(
+        logger_table,
+        names::SINKS,
+        fmt::format(
+            "Logger '{}' does not have a '{}' field of sink names",
+            name,
+            names::SINKS));
+
+    std::vector<std::shared_ptr<spdlog::sinks::sink>> logger_sinks;
+    logger_sinks.reserve(sinks.size());
+
+    for (const auto &sink_name : sinks) {
+        auto sink = find_value_from_map(
+            sinks_map,
+            sink_name,
+            fmt::format(
+                "Unable to find sink '{}' for logger '{}'", sink_name, name));
+
+        logger_sinks.push_back(move(sink));
+    }
+
+    const auto &sync_raw_opt =
+        value_from_table_opt<std::string>(logger_table, names::TYPE);
+
+    const auto sync =
+        sync_raw_opt ? find_value_from_map(
+                           SYNC_MAP,
+                           *sync_raw_opt,
+                           fmt::format(
+                               "Invalid sync type given '{}' for logger '{}'",
+                               *sync_raw_opt,
+                               name))
+                     : sync_type::Sync;
+
+    std::shared_ptr<spdlog::logger> logger;
+
+    switch (sync) {
+    case sync_type::Sync:
+        logger = setup_sync_logger(name, logger_sinks);
+        break;
+
+    case sync_type::Async:
+        logger = setup_async_logger(
+            name, logger_table, logger_sinks, thread_pools_map);
+        break;
+
+    default:
+        throw setup_error("Reached a buggy scenario of sync_type not fully "
+                          "pattern matched. Please raise an issue.");
+    }
+
+    // optional fields
+    add_msg_on_err(
+        [&logger_table, &logger] {
+            set_logger_level_if_present(logger_table, logger);
+        },
+        [&logger](const string &err_msg) {
+            return format(
+                "Logger '{}' set level error:\n > {}", logger->name(), err_msg);
+        });
+
+    add_msg_on_err(
+        [&logger_table, &logger] {
+            set_logger_flush_level_if_present(logger_table, logger);
+        },
+        [&logger](const string &err_msg) {
+            return format(
+                "Logger '{}' set flush level error:\n > {}",
+                logger->name(),
+                err_msg);
+        });
+
+    const auto pattern_name_opt =
+        value_from_table_opt<string>(logger_table, PATTERN);
+
+    using pattern_option_t = cpptoml::option<string>;
+
+    auto pattern_value_opt =
+        pattern_name_opt ? [&logger,
+                            &patterns_map,
+                            &pattern_name_opt]() {
+        const auto &pattern_name = *pattern_name_opt;
+
+        const auto pattern_value = find_value_from_map(
+            patterns_map,
+            pattern_name,
+            format(
+                "Pattern name '{}' cannot be found for logger '{}'",
+                pattern_name,
+                logger->name()));
+
+        return pattern_option_t(pattern_value);
+    }()
+
+        : pattern_option_t();
+
+    // global_pattern_opt cannot be moved since it needs to be cloned for
+    // each iteration
+    const auto selected_pattern_opt =
+        pattern_value_opt ? move(pattern_value_opt) : global_pattern_opt;
+
+    try {
+        if (selected_pattern_opt) {
+            logger->set_pattern(*selected_pattern_opt);
+        }
+    } catch (const exception &e) {
+        throw setup_error(format(
+            "Error setting pattern to logger '{}': {}",
+            logger->name(),
+            e.what()));
+    }
+
+    return logger;
+}
+
+inline void setup_loggers(
+    const std::shared_ptr<cpptoml::table> &config,
+    const std::unordered_map<std::string, std::shared_ptr<spdlog::sinks::sink>>
+        &sinks_map,
+    const std::unordered_map<std::string, std::string> &patterns_map,
+    const std::unordered_map<
+        std::string,
+        std::shared_ptr<spdlog::details::thread_pool>> &thread_pools_map) {
+
+    using names::GLOBAL_PATTERN;
+    using names::LOGGER_TABLE;
+
+    // std
+    using std::string;
+
+    const auto loggers = config->get_table_array(LOGGER_TABLE);
+
+    if (!loggers) {
+        throw setup_error("No loggers configured for set-up");
+    }
+
+    // set up possibly the global pattern if present
+    const auto global_pattern_opt =
+        value_from_table_opt<string>(config, GLOBAL_PATTERN);
+
+    for (const auto &logger_table : *loggers) {
+        const auto logger = setup_logger(
+            logger_table,
+            sinks_map,
+            patterns_map,
+            thread_pools_map,
+            global_pattern_opt);
+
+        spdlog::register_logger(logger);
+    }
+}
+
+inline void setup(const std::shared_ptr<cpptoml::table> &config) {
+    // set up sinks
+    const auto sinks_map = setup_sinks(config);
+
+    // set up patterns
+    const auto patterns_map = setup_patterns(config);
+
+    // set up thread pools
+    const auto thread_pools_map = setup_thread_pools(config);
+
+    // set up loggers, setting the respective sinks and patterns
+    setup_loggers(config, sinks_map, patterns_map, thread_pools_map);
+}
+} // namespace details
+} // namespace spdlog_setup

--- a/extern/helper/spdlog_setup/details/setup_error.h
+++ b/extern/helper/spdlog_setup/details/setup_error.h
@@ -1,0 +1,53 @@
+/**
+ * Implementation of setup_error in spdlog_setup.
+ * @author Chen Weiguang
+ * @version 0.3.3-pre
+ */
+
+#pragma once
+
+#include <exception>
+#include <string>
+
+namespace spdlog_setup {
+// declaration section
+
+/**
+ * Set-up error with textual description.
+ */
+class setup_error : public std::exception {
+  public:
+    /**
+     * Constructor accepting the error message.
+     * @param msg Error message to contain.
+     * @throw std::bad_alloc
+     */
+    setup_error(const char *const msg);
+
+    /**
+     * Constructor accepting the error message.
+     * @param msg Error message to contain.
+     * @throw std::bad_alloc
+     */
+    setup_error(std::string msg);
+
+    /**
+     * Returns the error message.
+     * @return Error message.
+     */
+    auto what() const noexcept -> const char * override;
+
+  private:
+    std::string msg;
+};
+
+// implementation section
+
+inline setup_error::setup_error(const char *const msg) : msg(msg) {}
+
+inline setup_error::setup_error(std::string msg) : msg(std::move(msg)) {}
+
+inline auto setup_error::what() const noexcept -> const char * {
+    return msg.c_str();
+}
+} // namespace spdlog_setup

--- a/extern/helper/spdlog_setup/details/template_impl.h
+++ b/extern/helper/spdlog_setup/details/template_impl.h
@@ -1,0 +1,172 @@
+/**
+ * Implementation of the mini template engine in spdlog_setup.
+ * @author Chen Weiguang
+ * @version 0.3.3-pre
+ */
+
+#pragma once
+
+#include "setup_error.h"
+
+#include "spdlog/fmt/fmt.h"
+
+#include <sstream>
+#include <string>
+#include <unordered_map>
+
+namespace spdlog_setup {
+namespace details {
+// declaration section
+
+enum class render_state {
+    text,
+    var_starting,
+    var,
+    var_name_start,
+    var_name_done,
+    var_ending,
+    verbatim_double,
+};
+
+inline auto is_valid_var_char(const char c) -> bool {
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+           (c >= '0' && c <= '9') || c == '_';
+}
+
+inline auto render(
+    const std::string &tmpl,
+    const std::unordered_map<std::string, std::string> &m) -> std::string {
+    // fmt
+    using fmt::format;
+
+    // std
+    using std::stringstream;
+
+    stringstream output;
+    stringstream var_buffer;
+    auto state = render_state::text;
+
+    for (const auto c : tmpl) {
+        switch (state) {
+        case render_state::text:
+            switch (c) {
+            case '{':
+                state = render_state::var_starting;
+                break;
+            default:
+                output << c;
+                break;
+            }
+            break;
+
+        case render_state::var_starting:
+            switch (c) {
+            case '{':
+                state = render_state::var;
+                break;
+            default:
+                output << '{' << c;
+                break;
+            }
+            break;
+
+        case render_state::var:
+            switch (c) {
+            case ' ':
+                // chomp away
+                break;
+            case '"':
+                state = render_state::verbatim_double;
+                break;
+            case '}':
+                state = render_state::var_ending;
+                break;
+            default:
+                if (!is_valid_var_char(c)) {
+                    throw setup_error(format(
+                        "Found invalid char '{}' in variable interpolation",
+                        c));
+                }
+                state = render_state::var_name_start;
+                var_buffer << c;
+                break;
+            }
+            break;
+
+        case render_state::var_name_start:
+            switch (c) {
+            case ' ':
+                state = render_state::var_name_done;
+                break;
+            case '}':
+                state = render_state::var_ending;
+                break;
+            default:
+                if (!is_valid_var_char(c)) {
+                    throw setup_error(
+                        format("Found invalid char '{}' in variable name", c));
+                }
+                var_buffer << c;
+                break;
+            }
+            break;
+
+        case render_state::var_name_done:
+            switch (c) {
+            case ' ':
+                // chomp away
+                break;
+            case '}':
+                state = render_state::var_ending;
+                break;
+            default:
+                throw setup_error(format(
+                    "Found invalid char '{}' after variable name '{}'",
+                    c,
+                    var_buffer.str()));
+            }
+            break;
+
+        case render_state::var_ending:
+            switch (c) {
+            case '}': {
+                state = render_state::text;
+                const auto var_value_itr = m.find(var_buffer.str());
+                var_buffer.str("");
+
+                if (var_value_itr != m.cend()) {
+                    output << var_value_itr->second;
+                }
+                break;
+            }
+            default:
+                throw setup_error(
+                    format("Found invalid char '{}' when expecting '}}'", c));
+            }
+            break;
+
+        case render_state::verbatim_double:
+            switch (c) {
+            case '"':
+                state = render_state::var_name_done;
+                break;
+            default:
+                output << c;
+                break;
+            }
+            break;
+
+        default:
+            throw setup_error(
+                "Reached impossible case while rendering template");
+        }
+    }
+
+    if (state != render_state::text) {
+        throw setup_error("Invalid state reached after parsing last char");
+    }
+
+    return output.str();
+}
+} // namespace details
+} // namespace spdlog_setup

--- a/extern/helper/spdlog_setup/details/third_party/cpptoml.h
+++ b/extern/helper/spdlog_setup/details/third_party/cpptoml.h
@@ -1,0 +1,3075 @@
+/**
+ * @file cpptoml.h
+ * @author Chase Geigle
+ * @date May 2013
+ */
+
+#ifndef CPPTOML_H
+#define CPPTOML_H
+
+#include <algorithm>
+#include <cassert>
+#include <clocale>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <iomanip>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include <limits>
+
+#if __cplusplus > 201103L
+#define CPPTOML_DEPRECATED(reason) [[deprecated(reason)]]
+#elif defined(__clang__)
+#define CPPTOML_DEPRECATED(reason) __attribute__((deprecated(reason)))
+#elif defined(__GNUG__)
+#define CPPTOML_DEPRECATED(reason) __attribute__((deprecated))
+#elif defined(_MSC_VER)
+#if _MSC_VER < 1910
+#define CPPTOML_DEPRECATED(reason) __declspec(deprecated)
+#else
+#define CPPTOML_DEPRECATED(reason) [[deprecated(reason)]]
+#endif
+#endif
+
+namespace cpptoml {
+class writer; // forward declaration
+class base;   // forward declaration
+#if defined(CPPTOML_USE_MAP)
+// a std::map will ensure that entries a sorted, albeit at a slight
+// performance penalty relative to the (default) unordered_map
+using string_to_base_map = std::map<std::string, std::shared_ptr<base>>;
+#else
+// by default an unordered_map is used for best performance as the
+// toml specification does not require entries to be sorted
+using string_to_base_map =
+    std::unordered_map<std::string, std::shared_ptr<base>>;
+#endif
+
+// if defined, `base` will retain type information in form of an enum class
+// such that static_cast can be used instead of dynamic_cast
+// #define CPPTOML_NO_RTTI
+
+template <class T> class option {
+  public:
+    option() : empty_{true} {
+        // nothing
+    }
+
+    option(T value) : empty_{false}, value_(std::move(value)) {
+        // nothing
+    }
+
+    explicit operator bool() const { return !empty_; }
+
+    const T &operator*() const { return value_; }
+
+    const T *operator->() const { return &value_; }
+
+    template <class U> T value_or(U &&alternative) const {
+        if (!empty_)
+            return value_;
+        return static_cast<T>(std::forward<U>(alternative));
+    }
+
+  private:
+    bool empty_;
+    T value_;
+};
+
+struct local_date {
+    int year = 0;
+    int month = 0;
+    int day = 0;
+};
+
+struct local_time {
+    int hour = 0;
+    int minute = 0;
+    int second = 0;
+    int microsecond = 0;
+};
+
+struct zone_offset {
+    int hour_offset = 0;
+    int minute_offset = 0;
+};
+
+struct local_datetime : local_date, local_time {};
+
+struct offset_datetime : local_datetime, zone_offset {
+    static inline struct offset_datetime from_zoned(const struct tm &t) {
+        offset_datetime dt;
+        dt.year = t.tm_year + 1900;
+        dt.month = t.tm_mon + 1;
+        dt.day = t.tm_mday;
+        dt.hour = t.tm_hour;
+        dt.minute = t.tm_min;
+        dt.second = t.tm_sec;
+
+        char buf[16];
+        strftime(buf, 16, "%z", &t);
+
+        int offset = std::stoi(buf);
+        dt.hour_offset = offset / 100;
+        dt.minute_offset = offset % 100;
+        return dt;
+    }
+
+    CPPTOML_DEPRECATED("from_local has been renamed to from_zoned")
+    static inline struct offset_datetime from_local(const struct tm &t) {
+        return from_zoned(t);
+    }
+
+    static inline struct offset_datetime from_utc(const struct tm &t) {
+        offset_datetime dt;
+        dt.year = t.tm_year + 1900;
+        dt.month = t.tm_mon + 1;
+        dt.day = t.tm_mday;
+        dt.hour = t.tm_hour;
+        dt.minute = t.tm_min;
+        dt.second = t.tm_sec;
+        return dt;
+    }
+};
+
+CPPTOML_DEPRECATED("datetime has been renamed to offset_datetime")
+typedef offset_datetime datetime;
+
+class fill_guard {
+  public:
+    fill_guard(std::ostream &os) : os_(os), fill_{os.fill()} {
+        // nothing
+    }
+
+    ~fill_guard() { os_.fill(fill_); }
+
+  private:
+    std::ostream &os_;
+    std::ostream::char_type fill_;
+};
+
+inline std::ostream &operator<<(std::ostream &os, const local_date &dt) {
+    fill_guard g{os};
+    os.fill('0');
+
+    using std::setw;
+    os << setw(4) << dt.year << "-" << setw(2) << dt.month << "-" << setw(2)
+       << dt.day;
+
+    return os;
+}
+
+inline std::ostream &operator<<(std::ostream &os, const local_time &ltime) {
+    fill_guard g{os};
+    os.fill('0');
+
+    using std::setw;
+    os << setw(2) << ltime.hour << ":" << setw(2) << ltime.minute << ":"
+       << setw(2) << ltime.second;
+
+    if (ltime.microsecond > 0) {
+        os << ".";
+        int power = 100000;
+        for (int curr_us = ltime.microsecond; curr_us; power /= 10) {
+            auto num = curr_us / power;
+            os << num;
+            curr_us -= num * power;
+        }
+    }
+
+    return os;
+}
+
+inline std::ostream &operator<<(std::ostream &os, const zone_offset &zo) {
+    fill_guard g{os};
+    os.fill('0');
+
+    using std::setw;
+
+    if (zo.hour_offset != 0 || zo.minute_offset != 0) {
+        if (zo.hour_offset > 0) {
+            os << "+";
+        } else {
+            os << "-";
+        }
+        os << setw(2) << std::abs(zo.hour_offset) << ":" << setw(2)
+           << std::abs(zo.minute_offset);
+    } else {
+        os << "Z";
+    }
+
+    return os;
+}
+
+inline std::ostream &operator<<(std::ostream &os, const local_datetime &dt) {
+    return os << static_cast<const local_date &>(dt) << "T"
+              << static_cast<const local_time &>(dt);
+}
+
+inline std::ostream &operator<<(std::ostream &os, const offset_datetime &dt) {
+    return os << static_cast<const local_datetime &>(dt)
+              << static_cast<const zone_offset &>(dt);
+}
+
+template <class T, class... Ts> struct is_one_of;
+
+template <class T, class V> struct is_one_of<T, V> : std::is_same<T, V> {};
+
+template <class T, class V, class... Ts> struct is_one_of<T, V, Ts...> {
+    const static bool value =
+        std::is_same<T, V>::value || is_one_of<T, Ts...>::value;
+};
+
+template <class T> class value;
+
+template <class T>
+struct valid_value : is_one_of<
+                         T,
+                         std::string,
+                         int64_t,
+                         double,
+                         bool,
+                         local_date,
+                         local_time,
+                         local_datetime,
+                         offset_datetime> {};
+
+template <class T, class Enable = void> struct value_traits;
+
+template <class T> struct valid_value_or_string_convertible {
+
+    const static bool value =
+        valid_value<typename std::decay<T>::type>::value ||
+        std::is_convertible<T, std::string>::value;
+};
+
+template <class T>
+struct value_traits<
+    T,
+    typename std::enable_if<
+        valid_value_or_string_convertible<T>::value>::type> {
+    using value_type = typename std::conditional<
+        valid_value<typename std::decay<T>::type>::value,
+        typename std::decay<T>::type,
+        std::string>::type;
+
+    using type = value<value_type>;
+
+    static value_type construct(T &&val) { return value_type(val); }
+};
+
+template <class T>
+struct value_traits<
+    T,
+    typename std::enable_if<
+        !valid_value_or_string_convertible<T>::value &&
+        std::is_floating_point<typename std::decay<T>::type>::value>::type> {
+    using value_type = typename std::decay<T>::type;
+
+    using type = value<double>;
+
+    static value_type construct(T &&val) { return value_type(val); }
+};
+
+template <class T>
+struct value_traits<
+    T,
+    typename std::enable_if<
+        !valid_value_or_string_convertible<T>::value &&
+        !std::is_floating_point<typename std::decay<T>::type>::value &&
+        std::is_signed<typename std::decay<T>::type>::value>::type> {
+    using value_type = int64_t;
+
+    using type = value<int64_t>;
+
+    static value_type construct(T &&val) {
+        if (val < (std::numeric_limits<int64_t>::min)())
+            throw std::underflow_error{"constructed value cannot be "
+                                       "represented by a 64-bit signed "
+                                       "integer"};
+
+        if (val > (std::numeric_limits<int64_t>::max)())
+            throw std::overflow_error{"constructed value cannot be represented "
+                                      "by a 64-bit signed integer"};
+
+        return static_cast<int64_t>(val);
+    }
+};
+
+template <class T>
+struct value_traits<
+    T,
+    typename std::enable_if<
+        !valid_value_or_string_convertible<T>::value &&
+        std::is_unsigned<typename std::decay<T>::type>::value>::type> {
+    using value_type = int64_t;
+
+    using type = value<int64_t>;
+
+    static value_type construct(T &&val) {
+        if (val > static_cast<uint64_t>((std::numeric_limits<int64_t>::max)()))
+            throw std::overflow_error{"constructed value cannot be represented "
+                                      "by a 64-bit signed integer"};
+
+        return static_cast<int64_t>(val);
+    }
+};
+
+class array;
+class table;
+class table_array;
+
+template <class T> struct array_of_trait {
+    using return_type = option<std::vector<T>>;
+};
+
+template <> struct array_of_trait<array> {
+    using return_type = option<std::vector<std::shared_ptr<array>>>;
+};
+
+template <class T>
+inline std::shared_ptr<typename value_traits<T>::type> make_value(T &&val);
+inline std::shared_ptr<array> make_array();
+
+namespace detail {
+template <class T> inline std::shared_ptr<T> make_element();
+}
+
+inline std::shared_ptr<table> make_table();
+inline std::shared_ptr<table_array> make_table_array(bool is_inline = false);
+
+#if defined(CPPTOML_NO_RTTI)
+/// Base type used to store underlying data type explicitly if RTTI is disabled
+enum class base_type {
+    NONE,
+    STRING,
+    LOCAL_TIME,
+    LOCAL_DATE,
+    LOCAL_DATETIME,
+    OFFSET_DATETIME,
+    INT,
+    FLOAT,
+    BOOL,
+    TABLE,
+    ARRAY,
+    TABLE_ARRAY
+};
+
+/// Type traits class to convert C++ types to enum member
+template <class T> struct base_type_traits;
+
+template <> struct base_type_traits<std::string> {
+    static const base_type type = base_type::STRING;
+};
+
+template <> struct base_type_traits<local_time> {
+    static const base_type type = base_type::LOCAL_TIME;
+};
+
+template <> struct base_type_traits<local_date> {
+    static const base_type type = base_type::LOCAL_DATE;
+};
+
+template <> struct base_type_traits<local_datetime> {
+    static const base_type type = base_type::LOCAL_DATETIME;
+};
+
+template <> struct base_type_traits<offset_datetime> {
+    static const base_type type = base_type::OFFSET_DATETIME;
+};
+
+template <> struct base_type_traits<int64_t> {
+    static const base_type type = base_type::INT;
+};
+
+template <> struct base_type_traits<double> {
+    static const base_type type = base_type::FLOAT;
+};
+
+template <> struct base_type_traits<bool> {
+    static const base_type type = base_type::BOOL;
+};
+
+template <> struct base_type_traits<table> {
+    static const base_type type = base_type::TABLE;
+};
+
+template <> struct base_type_traits<array> {
+    static const base_type type = base_type::ARRAY;
+};
+
+template <> struct base_type_traits<table_array> {
+    static const base_type type = base_type::TABLE_ARRAY;
+};
+#endif
+
+/**
+ * A generic base TOML value used for type erasure.
+ */
+class base : public std::enable_shared_from_this<base> {
+  public:
+    virtual ~base() = default;
+
+    virtual std::shared_ptr<base> clone() const = 0;
+
+    /**
+     * Determines if the given TOML element is a value.
+     */
+    virtual bool is_value() const { return false; }
+
+    /**
+     * Determines if the given TOML element is a table.
+     */
+    virtual bool is_table() const { return false; }
+
+    /**
+     * Converts the TOML element into a table.
+     */
+    std::shared_ptr<table> as_table() {
+        if (is_table())
+            return std::static_pointer_cast<table>(shared_from_this());
+        return nullptr;
+    }
+    /**
+     * Determines if the TOML element is an array of "leaf" elements.
+     */
+    virtual bool is_array() const { return false; }
+
+    /**
+     * Converts the TOML element to an array.
+     */
+    std::shared_ptr<array> as_array() {
+        if (is_array())
+            return std::static_pointer_cast<array>(shared_from_this());
+        return nullptr;
+    }
+
+    /**
+     * Determines if the given TOML element is an array of tables.
+     */
+    virtual bool is_table_array() const { return false; }
+
+    /**
+     * Converts the TOML element into a table array.
+     */
+    std::shared_ptr<table_array> as_table_array() {
+        if (is_table_array())
+            return std::static_pointer_cast<table_array>(shared_from_this());
+        return nullptr;
+    }
+
+    /**
+     * Attempts to coerce the TOML element into a concrete TOML value
+     * of type T.
+     */
+    template <class T> std::shared_ptr<value<T>> as();
+
+    template <class T> std::shared_ptr<const value<T>> as() const;
+
+    template <class Visitor, class... Args>
+    void accept(Visitor &&visitor, Args &&... args) const;
+
+#if defined(CPPTOML_NO_RTTI)
+    base_type type() const { return type_; }
+
+  protected:
+    base(const base_type t) : type_(t) {
+        // nothing
+    }
+
+  private:
+    const base_type type_ = base_type::NONE;
+
+#else
+  protected:
+    base() {
+        // nothing
+    }
+#endif
+};
+
+/**
+ * A concrete TOML value representing the "leaves" of the "tree".
+ */
+template <class T> class value : public base {
+    struct make_shared_enabler {
+        // nothing; this is a private key accessible only to friends
+    };
+
+    template <class U>
+    friend std::shared_ptr<typename value_traits<U>::type>
+    cpptoml::make_value(U &&val);
+
+  public:
+    static_assert(valid_value<T>::value, "invalid value type");
+
+    std::shared_ptr<base> clone() const override;
+
+    value(const make_shared_enabler &, const T &val) : value(val) {
+        // nothing; note that users cannot actually invoke this function
+        // because they lack access to the make_shared_enabler.
+    }
+
+    bool is_value() const override { return true; }
+
+    /**
+     * Gets the data associated with this value.
+     */
+    T &get() { return data_; }
+
+    /**
+     * Gets the data associated with this value. Const version.
+     */
+    const T &get() const { return data_; }
+
+  private:
+    T data_;
+
+    /**
+     * Constructs a value from the given data.
+     */
+#if defined(CPPTOML_NO_RTTI)
+    value(const T &val) : base(base_type_traits<T>::type), data_(val) {}
+#else
+    value(const T &val) : data_(val) {}
+#endif
+
+    value(const value &val) = delete;
+    value &operator=(const value &val) = delete;
+};
+
+template <class T>
+std::shared_ptr<typename value_traits<T>::type> make_value(T &&val) {
+    using value_type = typename value_traits<T>::type;
+    using enabler = typename value_type::make_shared_enabler;
+    return std::make_shared<value_type>(
+        enabler{}, value_traits<T>::construct(std::forward<T>(val)));
+}
+
+template <class T> inline std::shared_ptr<value<T>> base::as() {
+#if defined(CPPTOML_NO_RTTI)
+    if (type() == base_type_traits<T>::type)
+        return std::static_pointer_cast<value<T>>(shared_from_this());
+    else
+        return nullptr;
+#else
+    return std::dynamic_pointer_cast<value<T>>(shared_from_this());
+#endif
+}
+
+// special case value<double> to allow getting an integer parameter as a
+// double value
+template <> inline std::shared_ptr<value<double>> base::as() {
+#if defined(CPPTOML_NO_RTTI)
+    if (type() == base_type::FLOAT)
+        return std::static_pointer_cast<value<double>>(shared_from_this());
+
+    if (type() == base_type::INT) {
+        auto v = std::static_pointer_cast<value<int64_t>>(shared_from_this());
+        return make_value<double>(static_cast<double>(v->get()));
+    }
+#else
+    if (auto v = std::dynamic_pointer_cast<value<double>>(shared_from_this()))
+        return v;
+
+    if (auto v = std::dynamic_pointer_cast<value<int64_t>>(shared_from_this()))
+        return make_value<double>(static_cast<double>(v->get()));
+#endif
+
+    return nullptr;
+}
+
+template <class T> inline std::shared_ptr<const value<T>> base::as() const {
+#if defined(CPPTOML_NO_RTTI)
+    if (type() == base_type_traits<T>::type)
+        return std::static_pointer_cast<const value<T>>(shared_from_this());
+    else
+        return nullptr;
+#else
+    return std::dynamic_pointer_cast<const value<T>>(shared_from_this());
+#endif
+}
+
+// special case value<double> to allow getting an integer parameter as a
+// double value
+template <> inline std::shared_ptr<const value<double>> base::as() const {
+#if defined(CPPTOML_NO_RTTI)
+    if (type() == base_type::FLOAT)
+        return std::static_pointer_cast<const value<double>>(
+            shared_from_this());
+
+    if (type() == base_type::INT) {
+        auto v = as<int64_t>();
+        // the below has to be a non-const value<double> due to a bug in
+        // libc++: https://llvm.org/bugs/show_bug.cgi?id=18843
+        return make_value<double>(static_cast<double>(v->get()));
+    }
+#else
+    if (auto v =
+            std::dynamic_pointer_cast<const value<double>>(shared_from_this()))
+        return v;
+
+    if (auto v = as<int64_t>()) {
+        // the below has to be a non-const value<double> due to a bug in
+        // libc++: https://llvm.org/bugs/show_bug.cgi?id=18843
+        return make_value<double>(static_cast<double>(v->get()));
+    }
+#endif
+
+    return nullptr;
+}
+
+/**
+ * Exception class for array insertion errors.
+ */
+class array_exception : public std::runtime_error {
+  public:
+    array_exception(const std::string &err) : std::runtime_error{err} {}
+};
+
+class array : public base {
+  public:
+    friend std::shared_ptr<array> make_array();
+
+    std::shared_ptr<base> clone() const override;
+
+    virtual bool is_array() const override { return true; }
+
+    using size_type = std::size_t;
+
+    /**
+     * arrays can be iterated over
+     */
+    using iterator = std::vector<std::shared_ptr<base>>::iterator;
+
+    /**
+     * arrays can be iterated over.  Const version.
+     */
+    using const_iterator = std::vector<std::shared_ptr<base>>::const_iterator;
+
+    iterator begin() { return values_.begin(); }
+
+    const_iterator begin() const { return values_.begin(); }
+
+    iterator end() { return values_.end(); }
+
+    const_iterator end() const { return values_.end(); }
+
+    /**
+     * Obtains the array (vector) of base values.
+     */
+    std::vector<std::shared_ptr<base>> &get() { return values_; }
+
+    /**
+     * Obtains the array (vector) of base values. Const version.
+     */
+    const std::vector<std::shared_ptr<base>> &get() const { return values_; }
+
+    std::shared_ptr<base> at(size_t idx) const { return values_.at(idx); }
+
+    /**
+     * Obtains an array of value<T>s. Note that elements may be
+     * nullptr if they cannot be converted to a value<T>.
+     */
+    template <class T> std::vector<std::shared_ptr<value<T>>> array_of() const {
+        std::vector<std::shared_ptr<value<T>>> result(values_.size());
+
+        std::transform(
+            values_.begin(),
+            values_.end(),
+            result.begin(),
+            [&](std::shared_ptr<base> v) { return v->as<T>(); });
+
+        return result;
+    }
+
+    /**
+     * Obtains a option<vector<T>>. The option will be empty if the array
+     * contains values that are not of type T.
+     */
+    template <class T>
+    inline typename array_of_trait<T>::return_type get_array_of() const {
+        std::vector<T> result;
+        result.reserve(values_.size());
+
+        for (const auto &val : values_) {
+            if (auto v = val->as<T>())
+                result.push_back(v->get());
+            else
+                return {};
+        }
+
+        return {std::move(result)};
+    }
+
+    /**
+     * Obtains an array of arrays. Note that elements may be nullptr
+     * if they cannot be converted to a array.
+     */
+    std::vector<std::shared_ptr<array>> nested_array() const {
+        std::vector<std::shared_ptr<array>> result(values_.size());
+
+        std::transform(
+            values_.begin(),
+            values_.end(),
+            result.begin(),
+            [&](std::shared_ptr<base> v) -> std::shared_ptr<array> {
+                if (v->is_array())
+                    return std::static_pointer_cast<array>(v);
+                return std::shared_ptr<array>{};
+            });
+
+        return result;
+    }
+
+    /**
+     * Add a value to the end of the array
+     */
+    template <class T> void push_back(const std::shared_ptr<value<T>> &val) {
+        if (values_.empty() || values_[0]->as<T>()) {
+            values_.push_back(val);
+        } else {
+            throw array_exception{"Arrays must be homogenous."};
+        }
+    }
+
+    /**
+     * Add an array to the end of the array
+     */
+    void push_back(const std::shared_ptr<array> &val) {
+        if (values_.empty() || values_[0]->is_array()) {
+            values_.push_back(val);
+        } else {
+            throw array_exception{"Arrays must be homogenous."};
+        }
+    }
+
+    /**
+     * Convenience function for adding a simple element to the end
+     * of the array.
+     */
+    template <class T>
+    void push_back(T &&val, typename value_traits<T>::type * = 0) {
+        push_back(make_value(std::forward<T>(val)));
+    }
+
+    /**
+     * Insert a value into the array
+     */
+    template <class T>
+    iterator insert(iterator position, const std::shared_ptr<value<T>> &value) {
+        if (values_.empty() || values_[0]->as<T>()) {
+            return values_.insert(position, value);
+        } else {
+            throw array_exception{"Arrays must be homogenous."};
+        }
+    }
+
+    /**
+     * Insert an array into the array
+     */
+    iterator insert(iterator position, const std::shared_ptr<array> &value) {
+        if (values_.empty() || values_[0]->is_array()) {
+            return values_.insert(position, value);
+        } else {
+            throw array_exception{"Arrays must be homogenous."};
+        }
+    }
+
+    /**
+     * Convenience function for inserting a simple element in the array
+     */
+    template <class T>
+    iterator
+    insert(iterator position, T &&val, typename value_traits<T>::type * = 0) {
+        return insert(position, make_value(std::forward<T>(val)));
+    }
+
+    /**
+     * Erase an element from the array
+     */
+    iterator erase(iterator position) { return values_.erase(position); }
+
+    /**
+     * Clear the array
+     */
+    void clear() { values_.clear(); }
+
+    /**
+     * Reserve space for n values.
+     */
+    void reserve(size_type n) { values_.reserve(n); }
+
+  private:
+#if defined(CPPTOML_NO_RTTI)
+    array() : base(base_type::ARRAY) {
+        // empty
+    }
+#else
+    array() = default;
+#endif
+
+    template <class InputIterator>
+    array(InputIterator begin, InputIterator end) : values_{begin, end} {
+        // nothing
+    }
+
+    array(const array &obj) = delete;
+    array &operator=(const array &obj) = delete;
+
+    std::vector<std::shared_ptr<base>> values_;
+};
+
+inline std::shared_ptr<array> make_array() {
+    struct make_shared_enabler : public array {
+        make_shared_enabler() {
+            // nothing
+        }
+    };
+
+    return std::make_shared<make_shared_enabler>();
+}
+
+namespace detail {
+template <> inline std::shared_ptr<array> make_element<array>() {
+    return make_array();
+}
+} // namespace detail
+
+/**
+ * Obtains a option<vector<T>>. The option will be empty if the array
+ * contains values that are not of type T.
+ */
+template <>
+inline typename array_of_trait<array>::return_type
+array::get_array_of<array>() const {
+    std::vector<std::shared_ptr<array>> result;
+    result.reserve(values_.size());
+
+    for (const auto &val : values_) {
+        if (auto v = val->as_array())
+            result.push_back(v);
+        else
+            return {};
+    }
+
+    return {std::move(result)};
+}
+
+class table;
+
+class table_array : public base {
+    friend class table;
+    friend std::shared_ptr<table_array> make_table_array(bool);
+
+  public:
+    std::shared_ptr<base> clone() const override;
+
+    using size_type = std::size_t;
+
+    /**
+     * arrays can be iterated over
+     */
+    using iterator = std::vector<std::shared_ptr<table>>::iterator;
+
+    /**
+     * arrays can be iterated over.  Const version.
+     */
+    using const_iterator = std::vector<std::shared_ptr<table>>::const_iterator;
+
+    iterator begin() { return array_.begin(); }
+
+    const_iterator begin() const { return array_.begin(); }
+
+    iterator end() { return array_.end(); }
+
+    const_iterator end() const { return array_.end(); }
+
+    virtual bool is_table_array() const override { return true; }
+
+    std::vector<std::shared_ptr<table>> &get() { return array_; }
+
+    const std::vector<std::shared_ptr<table>> &get() const { return array_; }
+
+    /**
+     * Add a table to the end of the array
+     */
+    void push_back(const std::shared_ptr<table> &val) { array_.push_back(val); }
+
+    /**
+     * Insert a table into the array
+     */
+    iterator insert(iterator position, const std::shared_ptr<table> &value) {
+        return array_.insert(position, value);
+    }
+
+    /**
+     * Erase an element from the array
+     */
+    iterator erase(iterator position) { return array_.erase(position); }
+
+    /**
+     * Clear the array
+     */
+    void clear() { array_.clear(); }
+
+    /**
+     * Reserve space for n tables.
+     */
+    void reserve(size_type n) { array_.reserve(n); }
+
+    /**
+     * Whether or not the table array is declared inline. This mostly
+     * matters for parsing, where statically defined arrays cannot be
+     * appended to using the array-of-table syntax.
+     */
+    bool is_inline() const { return is_inline_; }
+
+  private:
+#if defined(CPPTOML_NO_RTTI)
+    table_array(bool is_inline = false)
+        : base(base_type::TABLE_ARRAY), is_inline_(is_inline) {
+        // nothing
+    }
+#else
+    table_array(bool is_inline = false) : is_inline_(is_inline) {
+        // nothing
+    }
+#endif
+
+    table_array(const table_array &obj) = delete;
+    table_array &operator=(const table_array &rhs) = delete;
+
+    std::vector<std::shared_ptr<table>> array_;
+    const bool is_inline_ = false;
+};
+
+inline std::shared_ptr<table_array> make_table_array(bool is_inline) {
+    struct make_shared_enabler : public table_array {
+        make_shared_enabler(bool mse_is_inline) : table_array(mse_is_inline) {
+            // nothing
+        }
+    };
+
+    return std::make_shared<make_shared_enabler>(is_inline);
+}
+
+namespace detail {
+template <> inline std::shared_ptr<table_array> make_element<table_array>() {
+    return make_table_array(true);
+}
+} // namespace detail
+
+// The below are overloads for fetching specific value types out of a value
+// where special casting behavior (like bounds checking) is desired
+
+template <class T>
+typename std::enable_if<
+    !std::is_floating_point<T>::value && std::is_signed<T>::value,
+    option<T>>::type
+get_impl(const std::shared_ptr<base> &elem) {
+    if (auto v = elem->as<int64_t>()) {
+        if (v->get() < (std::numeric_limits<T>::min)())
+            throw std::underflow_error{
+                "T cannot represent the value requested in get"};
+
+        if (v->get() > (std::numeric_limits<T>::max)())
+            throw std::overflow_error{
+                "T cannot represent the value requested in get"};
+
+        return {static_cast<T>(v->get())};
+    } else {
+        return {};
+    }
+}
+
+template <class T>
+typename std::enable_if<
+    !std::is_same<T, bool>::value && std::is_unsigned<T>::value,
+    option<T>>::type
+get_impl(const std::shared_ptr<base> &elem) {
+    if (auto v = elem->as<int64_t>()) {
+        if (v->get() < 0)
+            throw std::underflow_error{"T cannot store negative value in get"};
+
+        if (static_cast<uint64_t>(v->get()) > (std::numeric_limits<T>::max)())
+            throw std::overflow_error{
+                "T cannot represent the value requested in get"};
+
+        return {static_cast<T>(v->get())};
+    } else {
+        return {};
+    }
+}
+
+template <class T>
+typename std::enable_if<
+    !std::is_integral<T>::value || std::is_same<T, bool>::value,
+    option<T>>::type
+get_impl(const std::shared_ptr<base> &elem) {
+    if (auto v = elem->as<T>()) {
+        return {v->get()};
+    } else {
+        return {};
+    }
+}
+
+/**
+ * Represents a TOML keytable.
+ */
+class table : public base {
+  public:
+    friend class table_array;
+    friend std::shared_ptr<table> make_table();
+
+    std::shared_ptr<base> clone() const override;
+
+    /**
+     * tables can be iterated over.
+     */
+    using iterator = string_to_base_map::iterator;
+
+    /**
+     * tables can be iterated over. Const version.
+     */
+    using const_iterator = string_to_base_map::const_iterator;
+
+    iterator begin() { return map_.begin(); }
+
+    const_iterator begin() const { return map_.begin(); }
+
+    iterator end() { return map_.end(); }
+
+    const_iterator end() const { return map_.end(); }
+
+    bool is_table() const override { return true; }
+
+    bool empty() const { return map_.empty(); }
+
+    /**
+     * Determines if this key table contains the given key.
+     */
+    bool contains(const std::string &key) const {
+        return map_.find(key) != map_.end();
+    }
+
+    /**
+     * Determines if this key table contains the given key. Will
+     * resolve "qualified keys". Qualified keys are the full access
+     * path separated with dots like "grandparent.parent.child".
+     */
+    bool contains_qualified(const std::string &key) const {
+        return resolve_qualified(key);
+    }
+
+    /**
+     * Obtains the base for a given key.
+     * @throw std::out_of_range if the key does not exist
+     */
+    std::shared_ptr<base> get(const std::string &key) const {
+        return map_.at(key);
+    }
+
+    /**
+     * Obtains the base for a given key. Will resolve "qualified
+     * keys". Qualified keys are the full access path separated with
+     * dots like "grandparent.parent.child".
+     *
+     * @throw std::out_of_range if the key does not exist
+     */
+    std::shared_ptr<base> get_qualified(const std::string &key) const {
+        std::shared_ptr<base> p;
+        resolve_qualified(key, &p);
+        return p;
+    }
+
+    /**
+     * Obtains a table for a given key, if possible.
+     */
+    std::shared_ptr<table> get_table(const std::string &key) const {
+        if (contains(key) && get(key)->is_table())
+            return std::static_pointer_cast<table>(get(key));
+        return nullptr;
+    }
+
+    /**
+     * Obtains a table for a given key, if possible. Will resolve
+     * "qualified keys".
+     */
+    std::shared_ptr<table> get_table_qualified(const std::string &key) const {
+        if (contains_qualified(key) && get_qualified(key)->is_table())
+            return std::static_pointer_cast<table>(get_qualified(key));
+        return nullptr;
+    }
+
+    /**
+     * Obtains an array for a given key.
+     */
+    std::shared_ptr<array> get_array(const std::string &key) const {
+        if (!contains(key))
+            return nullptr;
+        return get(key)->as_array();
+    }
+
+    /**
+     * Obtains an array for a given key. Will resolve "qualified keys".
+     */
+    std::shared_ptr<array> get_array_qualified(const std::string &key) const {
+        if (!contains_qualified(key))
+            return nullptr;
+        return get_qualified(key)->as_array();
+    }
+
+    /**
+     * Obtains a table_array for a given key, if possible.
+     */
+    std::shared_ptr<table_array> get_table_array(const std::string &key) const {
+        if (!contains(key))
+            return nullptr;
+        return get(key)->as_table_array();
+    }
+
+    /**
+     * Obtains a table_array for a given key, if possible. Will resolve
+     * "qualified keys".
+     */
+    std::shared_ptr<table_array>
+    get_table_array_qualified(const std::string &key) const {
+        if (!contains_qualified(key))
+            return nullptr;
+        return get_qualified(key)->as_table_array();
+    }
+
+    /**
+     * Helper function that attempts to get a value corresponding
+     * to the template parameter from a given key.
+     */
+    template <class T> option<T> get_as(const std::string &key) const {
+        try {
+            return get_impl<T>(get(key));
+        } catch (const std::out_of_range &) {
+            return {};
+        }
+    }
+
+    /**
+     * Helper function that attempts to get a value corresponding
+     * to the template parameter from a given key. Will resolve "qualified
+     * keys".
+     */
+    template <class T>
+    option<T> get_qualified_as(const std::string &key) const {
+        try {
+            return get_impl<T>(get_qualified(key));
+        } catch (const std::out_of_range &) {
+            return {};
+        }
+    }
+
+    /**
+     * Helper function that attempts to get an array of values of a given
+     * type corresponding to the template parameter for a given key.
+     *
+     * If the key doesn't exist, doesn't exist as an array type, or one or
+     * more keys inside the array type are not of type T, an empty option
+     * is returned. Otherwise, an option containing a vector of the values
+     * is returned.
+     */
+    template <class T>
+    inline typename array_of_trait<T>::return_type
+    get_array_of(const std::string &key) const {
+        if (auto v = get_array(key)) {
+            std::vector<T> result;
+            result.reserve(v->get().size());
+
+            for (const auto &b : v->get()) {
+                if (auto val = b->as<T>())
+                    result.push_back(val->get());
+                else
+                    return {};
+            }
+            return {std::move(result)};
+        }
+
+        return {};
+    }
+
+    /**
+     * Helper function that attempts to get an array of values of a given
+     * type corresponding to the template parameter for a given key. Will
+     * resolve "qualified keys".
+     *
+     * If the key doesn't exist, doesn't exist as an array type, or one or
+     * more keys inside the array type are not of type T, an empty option
+     * is returned. Otherwise, an option containing a vector of the values
+     * is returned.
+     */
+    template <class T>
+    inline typename array_of_trait<T>::return_type
+    get_qualified_array_of(const std::string &key) const {
+        if (auto v = get_array_qualified(key)) {
+            std::vector<T> result;
+            result.reserve(v->get().size());
+
+            for (const auto &b : v->get()) {
+                if (auto val = b->as<T>())
+                    result.push_back(val->get());
+                else
+                    return {};
+            }
+            return {std::move(result)};
+        }
+
+        return {};
+    }
+
+    /**
+     * Adds an element to the keytable.
+     */
+    void insert(const std::string &key, const std::shared_ptr<base> &value) {
+        map_[key] = value;
+    }
+
+    /**
+     * Convenience shorthand for adding a simple element to the
+     * keytable.
+     */
+    template <class T>
+    void insert(
+        const std::string &key, T &&val, typename value_traits<T>::type * = 0) {
+        insert(key, make_value(std::forward<T>(val)));
+    }
+
+    /**
+     * Removes an element from the table.
+     */
+    void erase(const std::string &key) { map_.erase(key); }
+
+  private:
+#if defined(CPPTOML_NO_RTTI)
+    table() : base(base_type::TABLE) {
+        // nothing
+    }
+#else
+    table() {
+        // nothing
+    }
+#endif
+
+    table(const table &obj) = delete;
+    table &operator=(const table &rhs) = delete;
+
+    std::vector<std::string>
+    split(const std::string &value, char separator) const {
+        std::vector<std::string> result;
+        std::string::size_type p = 0;
+        std::string::size_type q;
+        while ((q = value.find(separator, p)) != std::string::npos) {
+            result.emplace_back(value, p, q - p);
+            p = q + 1;
+        }
+        result.emplace_back(value, p);
+        return result;
+    }
+
+    // If output parameter p is specified, fill it with the pointer to the
+    // specified entry and throw std::out_of_range if it couldn't be found.
+    //
+    // Otherwise, just return true if the entry could be found or false
+    // otherwise and do not throw.
+    bool resolve_qualified(
+        const std::string &key, std::shared_ptr<base> *p = nullptr) const {
+        auto parts = split(key, '.');
+        auto last_key = parts.back();
+        parts.pop_back();
+
+        auto cur_table = this;
+        for (const auto &part : parts) {
+            cur_table = cur_table->get_table(part).get();
+            if (!cur_table) {
+                if (!p)
+                    return false;
+
+                throw std::out_of_range{key + " is not a valid key"};
+            }
+        }
+
+        if (!p)
+            return cur_table->map_.count(last_key) != 0;
+
+        *p = cur_table->map_.at(last_key);
+        return true;
+    }
+
+    string_to_base_map map_;
+};
+
+/**
+ * Helper function that attempts to get an array of arrays for a given
+ * key.
+ *
+ * If the key doesn't exist, doesn't exist as an array type, or one or
+ * more keys inside the array type are not of type T, an empty option
+ * is returned. Otherwise, an option containing a vector of the values
+ * is returned.
+ */
+template <>
+inline typename array_of_trait<array>::return_type
+table::get_array_of<array>(const std::string &key) const {
+    if (auto v = get_array(key)) {
+        std::vector<std::shared_ptr<array>> result;
+        result.reserve(v->get().size());
+
+        for (const auto &b : v->get()) {
+            if (auto val = b->as_array())
+                result.push_back(val);
+            else
+                return {};
+        }
+
+        return {std::move(result)};
+    }
+
+    return {};
+}
+
+/**
+ * Helper function that attempts to get an array of arrays for a given
+ * key. Will resolve "qualified keys".
+ *
+ * If the key doesn't exist, doesn't exist as an array type, or one or
+ * more keys inside the array type are not of type T, an empty option
+ * is returned. Otherwise, an option containing a vector of the values
+ * is returned.
+ */
+template <>
+inline typename array_of_trait<array>::return_type
+table::get_qualified_array_of<array>(const std::string &key) const {
+    if (auto v = get_array_qualified(key)) {
+        std::vector<std::shared_ptr<array>> result;
+        result.reserve(v->get().size());
+
+        for (const auto &b : v->get()) {
+            if (auto val = b->as_array())
+                result.push_back(val);
+            else
+                return {};
+        }
+
+        return {std::move(result)};
+    }
+
+    return {};
+}
+
+std::shared_ptr<table> make_table() {
+    struct make_shared_enabler : public table {
+        make_shared_enabler() {
+            // nothing
+        }
+    };
+
+    return std::make_shared<make_shared_enabler>();
+}
+
+namespace detail {
+template <> inline std::shared_ptr<table> make_element<table>() {
+    return make_table();
+}
+} // namespace detail
+
+template <class T> std::shared_ptr<base> value<T>::clone() const {
+    return make_value(data_);
+}
+
+inline std::shared_ptr<base> array::clone() const {
+    auto result = make_array();
+    result->reserve(values_.size());
+    for (const auto &ptr : values_)
+        result->values_.push_back(ptr->clone());
+    return result;
+}
+
+inline std::shared_ptr<base> table_array::clone() const {
+    auto result = make_table_array(is_inline());
+    result->reserve(array_.size());
+    for (const auto &ptr : array_)
+        result->array_.push_back(ptr->clone()->as_table());
+    return result;
+}
+
+inline std::shared_ptr<base> table::clone() const {
+    auto result = make_table();
+    for (const auto &pr : map_)
+        result->insert(pr.first, pr.second->clone());
+    return result;
+}
+
+/**
+ * Exception class for all TOML parsing errors.
+ */
+class parse_exception : public std::runtime_error {
+  public:
+    parse_exception(const std::string &err) : std::runtime_error{err} {}
+
+    parse_exception(const std::string &err, std::size_t line_number)
+        : std::runtime_error{err + " at line " + std::to_string(line_number)} {}
+};
+
+inline bool is_number(char c) { return c >= '0' && c <= '9'; }
+
+inline bool is_hex(char c) {
+    return is_number(c) || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+}
+
+/**
+ * Helper object for consuming expected characters.
+ */
+template <class OnError> class consumer {
+  public:
+    consumer(
+        std::string::iterator &it,
+        const std::string::iterator &end,
+        OnError &&on_error)
+        : it_(it), end_(end), on_error_(std::forward<OnError>(on_error)) {
+        // nothing
+    }
+
+    void operator()(char c) {
+        if (it_ == end_ || *it_ != c)
+            on_error_();
+        ++it_;
+    }
+
+    template <std::size_t N> void operator()(const char (&str)[N]) {
+        std::for_each(
+            std::begin(str), std::end(str) - 1, [&](char c) { (*this)(c); });
+    }
+
+    void eat_or(char a, char b) {
+        if (it_ == end_ || (*it_ != a && *it_ != b))
+            on_error_();
+        ++it_;
+    }
+
+    int eat_digits(int len) {
+        int val = 0;
+        for (int i = 0; i < len; ++i) {
+            if (!is_number(*it_) || it_ == end_)
+                on_error_();
+            val = 10 * val + (*it_++ - '0');
+        }
+        return val;
+    }
+
+    void error() { on_error_(); }
+
+  private:
+    std::string::iterator &it_;
+    const std::string::iterator &end_;
+    OnError on_error_;
+};
+
+template <class OnError>
+consumer<OnError> make_consumer(
+    std::string::iterator &it,
+    const std::string::iterator &end,
+    OnError &&on_error) {
+    return consumer<OnError>(it, end, std::forward<OnError>(on_error));
+}
+
+// replacement for std::getline to handle incorrectly line-ended files
+// https://stackoverflow.com/questions/6089231/getting-std-ifstream-to-handle-lf-cr-and-crlf
+namespace detail {
+inline std::istream &getline(std::istream &input, std::string &line) {
+    line.clear();
+
+    std::istream::sentry sentry{input, true};
+    auto sb = input.rdbuf();
+
+    while (true) {
+        auto c = sb->sbumpc();
+        if (c == '\r') {
+            if (sb->sgetc() == '\n')
+                c = sb->sbumpc();
+        }
+
+        if (c == '\n')
+            return input;
+
+        if (c == std::istream::traits_type::eof()) {
+            if (line.empty())
+                input.setstate(std::ios::eofbit);
+            return input;
+        }
+
+        line.push_back(static_cast<char>(c));
+    }
+}
+} // namespace detail
+
+/**
+ * The parser class.
+ */
+class parser {
+  public:
+    /**
+     * Parsers are constructed from streams.
+     */
+    parser(std::istream &stream) : input_(stream) {
+        // nothing
+    }
+
+    parser &operator=(const parser &parser) = delete;
+
+    /**
+     * Parses the stream this parser was created on until EOF.
+     * @throw parse_exception if there are errors in parsing
+     */
+    std::shared_ptr<table> parse() {
+        std::shared_ptr<table> root = make_table();
+
+        table *curr_table = root.get();
+
+        while (detail::getline(input_, line_)) {
+            line_number_++;
+            auto it = line_.begin();
+            auto end = line_.end();
+            consume_whitespace(it, end);
+            if (it == end || *it == '#')
+                continue;
+            if (*it == '[') {
+                curr_table = root.get();
+                parse_table(it, end, curr_table);
+            } else {
+                parse_key_value(it, end, curr_table);
+                consume_whitespace(it, end);
+                eol_or_comment(it, end);
+            }
+        }
+        return root;
+    }
+
+  private:
+#if defined _MSC_VER
+    __declspec(noreturn)
+#elif defined __GNUC__
+    __attribute__((noreturn))
+#endif
+        void throw_parse_exception(const std::string &err) {
+        throw parse_exception{err, line_number_};
+    }
+
+    void parse_table(
+        std::string::iterator &it,
+        const std::string::iterator &end,
+        table *&curr_table) {
+        // remove the beginning keytable marker
+        ++it;
+        if (it == end)
+            throw_parse_exception("Unexpected end of table");
+        if (*it == '[')
+            parse_table_array(it, end, curr_table);
+        else
+            parse_single_table(it, end, curr_table);
+    }
+
+    void parse_single_table(
+        std::string::iterator &it,
+        const std::string::iterator &end,
+        table *&curr_table) {
+        if (it == end || *it == ']')
+            throw_parse_exception("Table name cannot be empty");
+
+        std::string full_table_name;
+        bool inserted = false;
+
+        auto key_end = [](char c) { return c == ']'; };
+
+        auto key_part_handler = [&](const std::string &part) {
+            if (part.empty())
+                throw_parse_exception("Empty component of table name");
+
+            if (!full_table_name.empty())
+                full_table_name += '.';
+            full_table_name += part;
+
+            if (curr_table->contains(part)) {
+#if !defined(__PGI)
+                auto b = curr_table->get(part);
+#else
+                // Workaround for PGI compiler
+                std::shared_ptr<base> b = curr_table->get(part);
+#endif
+                if (b->is_table())
+                    curr_table = static_cast<table *>(b.get());
+                else if (b->is_table_array())
+                    curr_table = std::static_pointer_cast<table_array>(b)
+                                     ->get()
+                                     .back()
+                                     .get();
+                else
+                    throw_parse_exception(
+                        "Key " + full_table_name + "already exists as a value");
+            } else {
+                inserted = true;
+                curr_table->insert(part, make_table());
+                curr_table = static_cast<table *>(curr_table->get(part).get());
+            }
+        };
+
+        key_part_handler(parse_key(it, end, key_end, key_part_handler));
+
+        if (it == end)
+            throw_parse_exception(
+                "Unterminated table declaration; did you forget a ']'?");
+
+        if (*it != ']') {
+            std::string errmsg{"Unexpected character in table definition: "};
+            errmsg += '"';
+            errmsg += *it;
+            errmsg += '"';
+            throw_parse_exception(errmsg);
+        }
+
+        // table already existed
+        if (!inserted) {
+            auto is_value = [](const std::pair<
+                                const std::string &,
+                                const std::shared_ptr<base> &> &p) {
+                return p.second->is_value();
+            };
+
+            // if there are any values, we can't add values to this table
+            // since it has already been defined. If there aren't any
+            // values, then it was implicitly created by something like
+            // [a.b]
+            if (curr_table->empty() ||
+                std::any_of(curr_table->begin(), curr_table->end(), is_value)) {
+                throw_parse_exception(
+                    "Redefinition of table " + full_table_name);
+            }
+        }
+
+        ++it;
+        consume_whitespace(it, end);
+        eol_or_comment(it, end);
+    }
+
+    void parse_table_array(
+        std::string::iterator &it,
+        const std::string::iterator &end,
+        table *&curr_table) {
+        ++it;
+        if (it == end || *it == ']')
+            throw_parse_exception("Table array name cannot be empty");
+
+        auto key_end = [](char c) { return c == ']'; };
+
+        std::string full_ta_name;
+        auto key_part_handler = [&](const std::string &part) {
+            if (part.empty())
+                throw_parse_exception("Empty component of table array name");
+
+            if (!full_ta_name.empty())
+                full_ta_name += '.';
+            full_ta_name += part;
+
+            if (curr_table->contains(part)) {
+#if !defined(__PGI)
+                auto b = curr_table->get(part);
+#else
+                // Workaround for PGI compiler
+                std::shared_ptr<base> b = curr_table->get(part);
+#endif
+
+                // if this is the end of the table array name, add an
+                // element to the table array that we just looked up,
+                // provided it was not declared inline
+                if (it != end && *it == ']') {
+                    if (!b->is_table_array()) {
+                        throw_parse_exception(
+                            "Key " + full_ta_name + " is not a table array");
+                    }
+
+                    auto v = b->as_table_array();
+
+                    if (v->is_inline()) {
+                        throw_parse_exception(
+                            "Static array " + full_ta_name +
+                            " cannot be appended to");
+                    }
+
+                    v->get().push_back(make_table());
+                    curr_table = v->get().back().get();
+                }
+                // otherwise, just keep traversing down the key name
+                else {
+                    if (b->is_table())
+                        curr_table = static_cast<table *>(b.get());
+                    else if (b->is_table_array())
+                        curr_table = std::static_pointer_cast<table_array>(b)
+                                         ->get()
+                                         .back()
+                                         .get();
+                    else
+                        throw_parse_exception(
+                            "Key " + full_ta_name +
+                            " already exists as a value");
+                }
+            } else {
+                // if this is the end of the table array name, add a new
+                // table array and a new table inside that array for us to
+                // add keys to next
+                if (it != end && *it == ']') {
+                    curr_table->insert(part, make_table_array());
+                    auto arr = std::static_pointer_cast<table_array>(
+                        curr_table->get(part));
+                    arr->get().push_back(make_table());
+                    curr_table = arr->get().back().get();
+                }
+                // otherwise, create the implicitly defined table and move
+                // down to it
+                else {
+                    curr_table->insert(part, make_table());
+                    curr_table =
+                        static_cast<table *>(curr_table->get(part).get());
+                }
+            }
+        };
+
+        key_part_handler(parse_key(it, end, key_end, key_part_handler));
+
+        // consume the last "]]"
+        auto eat = make_consumer(it, end, [this]() {
+            throw_parse_exception("Unterminated table array name");
+        });
+        eat(']');
+        eat(']');
+
+        consume_whitespace(it, end);
+        eol_or_comment(it, end);
+    }
+
+    void parse_key_value(
+        std::string::iterator &it,
+        std::string::iterator &end,
+        table *curr_table) {
+        auto key_end = [](char c) { return c == '='; };
+
+        auto key_part_handler = [&](const std::string &part) {
+            // two cases: this key part exists already, in which case it must
+            // be a table, or it doesn't exist in which case we must create
+            // an implicitly defined table
+            if (curr_table->contains(part)) {
+                auto val = curr_table->get(part);
+                if (val->is_table()) {
+                    curr_table = static_cast<table *>(val.get());
+                } else {
+                    throw_parse_exception(
+                        "Key " + part + " already exists as a value");
+                }
+            } else {
+                auto newtable = make_table();
+                curr_table->insert(part, newtable);
+                curr_table = newtable.get();
+            }
+        };
+
+        auto key = parse_key(it, end, key_end, key_part_handler);
+
+        if (curr_table->contains(key))
+            throw_parse_exception("Key " + key + " already present");
+        if (it == end || *it != '=')
+            throw_parse_exception("Value must follow after a '='");
+        ++it;
+        consume_whitespace(it, end);
+        curr_table->insert(key, parse_value(it, end));
+        consume_whitespace(it, end);
+    }
+
+    template <class KeyEndFinder, class KeyPartHandler>
+    std::string parse_key(
+        std::string::iterator &it,
+        const std::string::iterator &end,
+        KeyEndFinder &&key_end,
+        KeyPartHandler &&key_part_handler) {
+        // parse the key as a series of one or more simple-keys joined with '.'
+        while (it != end && !key_end(*it)) {
+            auto part = parse_simple_key(it, end);
+            consume_whitespace(it, end);
+
+            if (it == end || key_end(*it)) {
+                return part;
+            }
+
+            if (*it != '.') {
+                std::string errmsg{"Unexpected character in key: "};
+                errmsg += '"';
+                errmsg += *it;
+                errmsg += '"';
+                throw_parse_exception(errmsg);
+            }
+
+            key_part_handler(part);
+
+            // consume the dot
+            ++it;
+        }
+
+        throw_parse_exception("Unexpected end of key");
+    }
+
+    std::string parse_simple_key(
+        std::string::iterator &it, const std::string::iterator &end) {
+        consume_whitespace(it, end);
+
+        if (it == end)
+            throw_parse_exception("Unexpected end of key (blank key?)");
+
+        if (*it == '"' || *it == '\'') {
+            return string_literal(it, end, *it);
+        } else {
+            auto bke = std::find_if(it, end, [](char c) {
+                return c == '.' || c == '=' || c == ']';
+            });
+            return parse_bare_key(it, bke);
+        }
+    }
+
+    std::string parse_bare_key(
+        std::string::iterator &it, const std::string::iterator &end) {
+        if (it == end) {
+            throw_parse_exception("Bare key missing name");
+        }
+
+        auto key_end = end;
+        --key_end;
+        consume_backwards_whitespace(key_end, it);
+        ++key_end;
+        std::string key{it, key_end};
+
+        if (std::find(it, key_end, '#') != key_end) {
+            throw_parse_exception("Bare key " + key + " cannot contain #");
+        }
+
+        if (std::find_if(it, key_end, [](char c) {
+                return c == ' ' || c == '\t';
+            }) != key_end) {
+            throw_parse_exception(
+                "Bare key " + key + " cannot contain whitespace");
+        }
+
+        if (std::find_if(it, key_end, [](char c) {
+                return c == '[' || c == ']';
+            }) != key_end) {
+            throw_parse_exception(
+                "Bare key " + key + " cannot contain '[' or ']'");
+        }
+
+        it = end;
+        return key;
+    }
+
+    enum class parse_type {
+        STRING = 1,
+        LOCAL_TIME,
+        LOCAL_DATE,
+        LOCAL_DATETIME,
+        OFFSET_DATETIME,
+        INT,
+        FLOAT,
+        BOOL,
+        ARRAY,
+        INLINE_TABLE
+    };
+
+    std::shared_ptr<base>
+    parse_value(std::string::iterator &it, std::string::iterator &end) {
+        parse_type type = determine_value_type(it, end);
+        switch (type) {
+        case parse_type::STRING:
+            return parse_string(it, end);
+        case parse_type::LOCAL_TIME:
+            return parse_time(it, end);
+        case parse_type::LOCAL_DATE:
+        case parse_type::LOCAL_DATETIME:
+        case parse_type::OFFSET_DATETIME:
+            return parse_date(it, end);
+        case parse_type::INT:
+        case parse_type::FLOAT:
+            return parse_number(it, end);
+        case parse_type::BOOL:
+            return parse_bool(it, end);
+        case parse_type::ARRAY:
+            return parse_array(it, end);
+        case parse_type::INLINE_TABLE:
+            return parse_inline_table(it, end);
+        default:
+            throw_parse_exception("Failed to parse value");
+        }
+    }
+
+    parse_type determine_value_type(
+        const std::string::iterator &it, const std::string::iterator &end) {
+        if (it == end) {
+            throw_parse_exception("Failed to parse value type");
+        }
+        if (*it == '"' || *it == '\'') {
+            return parse_type::STRING;
+        } else if (is_time(it, end)) {
+            return parse_type::LOCAL_TIME;
+        } else if (auto dtype = date_type(it, end)) {
+            return *dtype;
+        } else if (
+            is_number(*it) || *it == '-' || *it == '+' ||
+            (*it == 'i' && it + 1 != end && it[1] == 'n' && it + 2 != end &&
+             it[2] == 'f') ||
+            (*it == 'n' && it + 1 != end && it[1] == 'a' && it + 2 != end &&
+             it[2] == 'n')) {
+            return determine_number_type(it, end);
+        } else if (*it == 't' || *it == 'f') {
+            return parse_type::BOOL;
+        } else if (*it == '[') {
+            return parse_type::ARRAY;
+        } else if (*it == '{') {
+            return parse_type::INLINE_TABLE;
+        }
+        throw_parse_exception("Failed to parse value type");
+    }
+
+    parse_type determine_number_type(
+        const std::string::iterator &it, const std::string::iterator &end) {
+        // determine if we are an integer or a float
+        auto check_it = it;
+        if (*check_it == '-' || *check_it == '+')
+            ++check_it;
+
+        if (check_it == end)
+            throw_parse_exception("Malformed number");
+
+        if (*check_it == 'i' || *check_it == 'n')
+            return parse_type::FLOAT;
+
+        while (check_it != end && is_number(*check_it))
+            ++check_it;
+        if (check_it != end && *check_it == '.') {
+            ++check_it;
+            while (check_it != end && is_number(*check_it))
+                ++check_it;
+            return parse_type::FLOAT;
+        } else {
+            return parse_type::INT;
+        }
+    }
+
+    std::shared_ptr<value<std::string>>
+    parse_string(std::string::iterator &it, std::string::iterator &end) {
+        auto delim = *it;
+        assert(delim == '"' || delim == '\'');
+
+        // end is non-const here because we have to be able to potentially
+        // parse multiple lines in a string, not just one
+        auto check_it = it;
+        ++check_it;
+        if (check_it != end && *check_it == delim) {
+            ++check_it;
+            if (check_it != end && *check_it == delim) {
+                it = ++check_it;
+                return parse_multiline_string(it, end, delim);
+            }
+        }
+        return make_value<std::string>(string_literal(it, end, delim));
+    }
+
+    std::shared_ptr<value<std::string>> parse_multiline_string(
+        std::string::iterator &it, std::string::iterator &end, char delim) {
+        std::stringstream ss;
+
+        auto is_ws = [](char c) { return c == ' ' || c == '\t'; };
+
+        bool consuming = false;
+        std::shared_ptr<value<std::string>> ret;
+
+        auto handle_line = [&](std::string::iterator &local_it,
+                               std::string::iterator &local_end) {
+            if (consuming) {
+                local_it = std::find_if_not(local_it, local_end, is_ws);
+
+                // whole line is whitespace
+                if (local_it == local_end)
+                    return;
+            }
+
+            consuming = false;
+
+            while (local_it != local_end) {
+                // handle escaped characters
+                if (delim == '"' && *local_it == '\\') {
+                    auto check = local_it;
+                    // check if this is an actual escape sequence or a
+                    // whitespace escaping backslash
+                    ++check;
+                    consume_whitespace(check, local_end);
+                    if (check == local_end) {
+                        consuming = true;
+                        break;
+                    }
+
+                    ss << parse_escape_code(local_it, local_end);
+                    continue;
+                }
+
+                // if we can end the string
+                if (std::distance(local_it, local_end) >= 3) {
+                    auto check = local_it;
+                    // check for """
+                    if (*check++ == delim && *check++ == delim &&
+                        *check++ == delim) {
+                        local_it = check;
+                        ret = make_value<std::string>(ss.str());
+                        break;
+                    }
+                }
+
+                ss << *local_it++;
+            }
+        };
+
+        // handle the remainder of the current line
+        handle_line(it, end);
+        if (ret)
+            return ret;
+
+        // start eating lines
+        while (detail::getline(input_, line_)) {
+            ++line_number_;
+
+            it = line_.begin();
+            end = line_.end();
+
+            handle_line(it, end);
+
+            if (ret)
+                return ret;
+
+            if (!consuming)
+                ss << std::endl;
+        }
+
+        throw_parse_exception("Unterminated multi-line basic string");
+    }
+
+    std::string string_literal(
+        std::string::iterator &it,
+        const std::string::iterator &end,
+        char delim) {
+        ++it;
+        std::string val;
+        while (it != end) {
+            // handle escaped characters
+            if (delim == '"' && *it == '\\') {
+                val += parse_escape_code(it, end);
+            } else if (*it == delim) {
+                ++it;
+                consume_whitespace(it, end);
+                return val;
+            } else {
+                val += *it++;
+            }
+        }
+        throw_parse_exception("Unterminated string literal");
+    }
+
+    std::string parse_escape_code(
+        std::string::iterator &it, const std::string::iterator &end) {
+        ++it;
+        if (it == end)
+            throw_parse_exception("Invalid escape sequence");
+        char value;
+        if (*it == 'b') {
+            value = '\b';
+        } else if (*it == 't') {
+            value = '\t';
+        } else if (*it == 'n') {
+            value = '\n';
+        } else if (*it == 'f') {
+            value = '\f';
+        } else if (*it == 'r') {
+            value = '\r';
+        } else if (*it == '"') {
+            value = '"';
+        } else if (*it == '\\') {
+            value = '\\';
+        } else if (*it == 'u' || *it == 'U') {
+            return parse_unicode(it, end);
+        } else {
+            throw_parse_exception("Invalid escape sequence");
+        }
+        ++it;
+        return std::string(1, value);
+    }
+
+    std::string
+    parse_unicode(std::string::iterator &it, const std::string::iterator &end) {
+        bool large = *it++ == 'U';
+        auto codepoint = parse_hex(it, end, large ? 0x10000000 : 0x1000);
+
+        if ((codepoint > 0xd7ff && codepoint < 0xe000) ||
+            codepoint > 0x10ffff) {
+            throw_parse_exception(
+                "Unicode escape sequence is not a Unicode scalar value");
+        }
+
+        std::string result;
+        // See Table 3-6 of the Unicode standard
+        if (codepoint <= 0x7f) {
+            // 1-byte codepoints: 00000000 0xxxxxxx
+            // repr: 0xxxxxxx
+            result += static_cast<char>(codepoint & 0x7f);
+        } else if (codepoint <= 0x7ff) {
+            // 2-byte codepoints: 00000yyy yyxxxxxx
+            // repr: 110yyyyy 10xxxxxx
+            //
+            // 0x1f = 00011111
+            // 0xc0 = 11000000
+            //
+            result += static_cast<char>(0xc0 | ((codepoint >> 6) & 0x1f));
+            //
+            // 0x80 = 10000000
+            // 0x3f = 00111111
+            //
+            result += static_cast<char>(0x80 | (codepoint & 0x3f));
+        } else if (codepoint <= 0xffff) {
+            // 3-byte codepoints: zzzzyyyy yyxxxxxx
+            // repr: 1110zzzz 10yyyyyy 10xxxxxx
+            //
+            // 0xe0 = 11100000
+            // 0x0f = 00001111
+            //
+            result += static_cast<char>(0xe0 | ((codepoint >> 12) & 0x0f));
+            result += static_cast<char>(0x80 | ((codepoint >> 6) & 0x1f));
+            result += static_cast<char>(0x80 | (codepoint & 0x3f));
+        } else {
+            // 4-byte codepoints: 000uuuuu zzzzyyyy yyxxxxxx
+            // repr: 11110uuu 10uuzzzz 10yyyyyy 10xxxxxx
+            //
+            // 0xf0 = 11110000
+            // 0x07 = 00000111
+            //
+            result += static_cast<char>(0xf0 | ((codepoint >> 18) & 0x07));
+            result += static_cast<char>(0x80 | ((codepoint >> 12) & 0x3f));
+            result += static_cast<char>(0x80 | ((codepoint >> 6) & 0x3f));
+            result += static_cast<char>(0x80 | (codepoint & 0x3f));
+        }
+        return result;
+    }
+
+    uint32_t parse_hex(
+        std::string::iterator &it,
+        const std::string::iterator &end,
+        uint32_t place) {
+        uint32_t value = 0;
+        while (place > 0) {
+            if (it == end)
+                throw_parse_exception("Unexpected end of unicode sequence");
+
+            if (!is_hex(*it))
+                throw_parse_exception("Invalid unicode escape sequence");
+
+            value += place * hex_to_digit(*it++);
+            place /= 16;
+        }
+        return value;
+    }
+
+    uint32_t hex_to_digit(char c) {
+        if (is_number(c))
+            return static_cast<uint32_t>(c - '0');
+        return 10 +
+               static_cast<uint32_t>(c - ((c >= 'a' && c <= 'f') ? 'a' : 'A'));
+    }
+
+    std::shared_ptr<base>
+    parse_number(std::string::iterator &it, const std::string::iterator &end) {
+        auto check_it = it;
+        auto check_end = find_end_of_number(it, end);
+
+        auto eat_sign = [&]() {
+            if (check_it != end && (*check_it == '-' || *check_it == '+'))
+                ++check_it;
+        };
+
+        auto check_no_leading_zero = [&]() {
+            if (check_it != end && *check_it == '0' &&
+                check_it + 1 != check_end && check_it[1] != '.') {
+                throw_parse_exception("Numbers may not have leading zeros");
+            }
+        };
+
+        auto eat_digits = [&](bool (*check_char)(char)) {
+            auto beg = check_it;
+            while (check_it != end && check_char(*check_it)) {
+                ++check_it;
+                if (check_it != end && *check_it == '_') {
+                    ++check_it;
+                    if (check_it == end || !check_char(*check_it))
+                        throw_parse_exception("Malformed number");
+                }
+            }
+
+            if (check_it == beg)
+                throw_parse_exception("Malformed number");
+        };
+
+        auto eat_hex = [&]() { eat_digits(&is_hex); };
+
+        auto eat_numbers = [&]() { eat_digits(&is_number); };
+
+        if (check_it != end && *check_it == '0' && check_it + 1 != check_end &&
+            (check_it[1] == 'x' || check_it[1] == 'o' || check_it[1] == 'b')) {
+            ++check_it;
+            char base = *check_it;
+            ++check_it;
+            if (base == 'x') {
+                eat_hex();
+                return parse_int(it, check_it, 16);
+            } else if (base == 'o') {
+                auto start = check_it;
+                eat_numbers();
+                auto val = parse_int(start, check_it, 8, "0");
+                it = start;
+                return val;
+            } else // if (base == 'b')
+            {
+                auto start = check_it;
+                eat_numbers();
+                auto val = parse_int(start, check_it, 2);
+                it = start;
+                return val;
+            }
+        }
+
+        eat_sign();
+        check_no_leading_zero();
+
+        if (check_it != end && check_it + 1 != end && check_it + 2 != end) {
+            if (check_it[0] == 'i' && check_it[1] == 'n' &&
+                check_it[2] == 'f') {
+                auto val = std::numeric_limits<double>::infinity();
+                if (*it == '-')
+                    val = -val;
+                it = check_it + 3;
+                return make_value(val);
+            } else if (
+                check_it[0] == 'n' && check_it[1] == 'a' &&
+                check_it[2] == 'n') {
+                auto val = std::numeric_limits<double>::quiet_NaN();
+                if (*it == '-')
+                    val = -val;
+                it = check_it + 3;
+                return make_value(val);
+            }
+        }
+
+        eat_numbers();
+
+        if (check_it != end &&
+            (*check_it == '.' || *check_it == 'e' || *check_it == 'E')) {
+            bool is_exp = *check_it == 'e' || *check_it == 'E';
+
+            ++check_it;
+            if (check_it == end)
+                throw_parse_exception("Floats must have trailing digits");
+
+            auto eat_exp = [&]() {
+                eat_sign();
+                check_no_leading_zero();
+                eat_numbers();
+            };
+
+            if (is_exp)
+                eat_exp();
+            else
+                eat_numbers();
+
+            if (!is_exp && check_it != end &&
+                (*check_it == 'e' || *check_it == 'E')) {
+                ++check_it;
+                eat_exp();
+            }
+
+            return parse_float(it, check_it);
+        } else {
+            return parse_int(it, check_it);
+        }
+    }
+
+    std::shared_ptr<value<int64_t>> parse_int(
+        std::string::iterator &it,
+        const std::string::iterator &end,
+        int base = 10,
+        const char *prefix = "") {
+        std::string v{it, end};
+        v = prefix + v;
+        v.erase(std::remove(v.begin(), v.end(), '_'), v.end());
+        it = end;
+        try {
+            return make_value<int64_t>(std::stoll(v, nullptr, base));
+        } catch (const std::invalid_argument &ex) {
+            throw_parse_exception(
+                "Malformed number (invalid argument: " +
+                std::string{ex.what()} + ")");
+        } catch (const std::out_of_range &ex) {
+            throw_parse_exception(
+                "Malformed number (out of range: " + std::string{ex.what()} +
+                ")");
+        }
+    }
+
+    std::shared_ptr<value<double>>
+    parse_float(std::string::iterator &it, const std::string::iterator &end) {
+        std::string v{it, end};
+        v.erase(std::remove(v.begin(), v.end(), '_'), v.end());
+        it = end;
+        char decimal_point = std::localeconv()->decimal_point[0];
+        std::replace(v.begin(), v.end(), '.', decimal_point);
+        try {
+            return make_value<double>(std::stod(v));
+        } catch (const std::invalid_argument &ex) {
+            throw_parse_exception(
+                "Malformed number (invalid argument: " +
+                std::string{ex.what()} + ")");
+        } catch (const std::out_of_range &ex) {
+            throw_parse_exception(
+                "Malformed number (out of range: " + std::string{ex.what()} +
+                ")");
+        }
+    }
+
+    std::shared_ptr<value<bool>>
+    parse_bool(std::string::iterator &it, const std::string::iterator &end) {
+        auto eat = make_consumer(it, end, [this]() {
+            throw_parse_exception("Attempted to parse invalid boolean value");
+        });
+
+        if (*it == 't') {
+            eat("true");
+            return make_value<bool>(true);
+        } else if (*it == 'f') {
+            eat("false");
+            return make_value<bool>(false);
+        }
+
+        eat.error();
+        return nullptr;
+    }
+
+    std::string::iterator
+    find_end_of_number(std::string::iterator it, std::string::iterator end) {
+        auto ret = std::find_if(it, end, [](char c) {
+            return !is_number(c) && c != '_' && c != '.' && c != 'e' &&
+                   c != 'E' && c != '-' && c != '+' && c != 'x' && c != 'o' &&
+                   c != 'b';
+        });
+        if (ret != end && ret + 1 != end && ret + 2 != end) {
+            if ((ret[0] == 'i' && ret[1] == 'n' && ret[2] == 'f') ||
+                (ret[0] == 'n' && ret[1] == 'a' && ret[2] == 'n')) {
+                ret = ret + 3;
+            }
+        }
+        return ret;
+    }
+
+    std::string::iterator
+    find_end_of_date(std::string::iterator it, std::string::iterator end) {
+        auto end_of_date = std::find_if(
+            it, end, [](char c) { return !is_number(c) && c != '-'; });
+        if (end_of_date != end && *end_of_date == ' ' &&
+            end_of_date + 1 != end && is_number(end_of_date[1]))
+            end_of_date++;
+        return std::find_if(end_of_date, end, [](char c) {
+            return !is_number(c) && c != 'T' && c != 'Z' && c != ':' &&
+                   c != '-' && c != '+' && c != '.';
+        });
+    }
+
+    std::string::iterator
+    find_end_of_time(std::string::iterator it, std::string::iterator end) {
+        return std::find_if(it, end, [](char c) {
+            return !is_number(c) && c != ':' && c != '.';
+        });
+    }
+
+    local_time
+    read_time(std::string::iterator &it, const std::string::iterator &end) {
+        auto time_end = find_end_of_time(it, end);
+
+        auto eat = make_consumer(
+            it, time_end, [&]() { throw_parse_exception("Malformed time"); });
+
+        local_time ltime;
+
+        ltime.hour = eat.eat_digits(2);
+        eat(':');
+        ltime.minute = eat.eat_digits(2);
+        eat(':');
+        ltime.second = eat.eat_digits(2);
+
+        int power = 100000;
+        if (it != time_end && *it == '.') {
+            ++it;
+            while (it != time_end && is_number(*it)) {
+                ltime.microsecond += power * (*it++ - '0');
+                power /= 10;
+            }
+        }
+
+        if (it != time_end)
+            throw_parse_exception("Malformed time");
+
+        return ltime;
+    }
+
+    std::shared_ptr<value<local_time>>
+    parse_time(std::string::iterator &it, const std::string::iterator &end) {
+        return make_value(read_time(it, end));
+    }
+
+    std::shared_ptr<base>
+    parse_date(std::string::iterator &it, const std::string::iterator &end) {
+        auto date_end = find_end_of_date(it, end);
+
+        auto eat = make_consumer(
+            it, date_end, [&]() { throw_parse_exception("Malformed date"); });
+
+        local_date ldate;
+        ldate.year = eat.eat_digits(4);
+        eat('-');
+        ldate.month = eat.eat_digits(2);
+        eat('-');
+        ldate.day = eat.eat_digits(2);
+
+        if (it == date_end)
+            return make_value(ldate);
+
+        eat.eat_or('T', ' ');
+
+        local_datetime ldt;
+        static_cast<local_date &>(ldt) = ldate;
+        static_cast<local_time &>(ldt) = read_time(it, date_end);
+
+        if (it == date_end)
+            return make_value(ldt);
+
+        offset_datetime dt;
+        static_cast<local_datetime &>(dt) = ldt;
+
+        int hoff = 0;
+        int moff = 0;
+        if (*it == '+' || *it == '-') {
+            auto plus = *it == '+';
+            ++it;
+
+            hoff = eat.eat_digits(2);
+            dt.hour_offset = (plus) ? hoff : -hoff;
+            eat(':');
+            moff = eat.eat_digits(2);
+            dt.minute_offset = (plus) ? moff : -moff;
+        } else if (*it == 'Z') {
+            ++it;
+        }
+
+        if (it != date_end)
+            throw_parse_exception("Malformed date");
+
+        return make_value(dt);
+    }
+
+    std::shared_ptr<base>
+    parse_array(std::string::iterator &it, std::string::iterator &end) {
+        // this gets ugly because of the "homogeneity" restriction:
+        // arrays can either be of only one type, or contain arrays
+        // (each of those arrays could be of different types, though)
+        //
+        // because of the latter portion, we don't really have a choice
+        // but to represent them as arrays of base values...
+        ++it;
+
+        // ugh---have to read the first value to determine array type...
+        skip_whitespace_and_comments(it, end);
+
+        // edge case---empty array
+        if (*it == ']') {
+            ++it;
+            return make_array();
+        }
+
+        auto val_end = std::find_if(
+            it, end, [](char c) { return c == ',' || c == ']' || c == '#'; });
+        parse_type type = determine_value_type(it, val_end);
+        switch (type) {
+        case parse_type::STRING:
+            return parse_value_array<std::string>(it, end);
+        case parse_type::LOCAL_TIME:
+            return parse_value_array<local_time>(it, end);
+        case parse_type::LOCAL_DATE:
+            return parse_value_array<local_date>(it, end);
+        case parse_type::LOCAL_DATETIME:
+            return parse_value_array<local_datetime>(it, end);
+        case parse_type::OFFSET_DATETIME:
+            return parse_value_array<offset_datetime>(it, end);
+        case parse_type::INT:
+            return parse_value_array<int64_t>(it, end);
+        case parse_type::FLOAT:
+            return parse_value_array<double>(it, end);
+        case parse_type::BOOL:
+            return parse_value_array<bool>(it, end);
+        case parse_type::ARRAY:
+            return parse_object_array<array>(
+                &parser::parse_array, '[', it, end);
+        case parse_type::INLINE_TABLE:
+            return parse_object_array<table_array>(
+                &parser::parse_inline_table, '{', it, end);
+        default:
+            throw_parse_exception("Unable to parse array");
+        }
+    }
+
+    template <class Value>
+    std::shared_ptr<array>
+    parse_value_array(std::string::iterator &it, std::string::iterator &end) {
+        auto arr = make_array();
+        while (it != end && *it != ']') {
+            auto val = parse_value(it, end);
+            if (auto v = val->as<Value>())
+                arr->get().push_back(val);
+            else
+                throw_parse_exception("Arrays must be homogeneous");
+            skip_whitespace_and_comments(it, end);
+            if (*it != ',')
+                break;
+            ++it;
+            skip_whitespace_and_comments(it, end);
+        }
+        if (it != end)
+            ++it;
+        return arr;
+    }
+
+    template <class Object, class Function>
+    std::shared_ptr<Object> parse_object_array(
+        Function &&fun,
+        char delim,
+        std::string::iterator &it,
+        std::string::iterator &end) {
+        auto arr = detail::make_element<Object>();
+
+        while (it != end && *it != ']') {
+            if (*it != delim)
+                throw_parse_exception("Unexpected character in array");
+
+            arr->get().push_back(((*this).*fun)(it, end));
+            skip_whitespace_and_comments(it, end);
+
+            if (it == end || *it != ',')
+                break;
+
+            ++it;
+            skip_whitespace_and_comments(it, end);
+        }
+
+        if (it == end || *it != ']')
+            throw_parse_exception("Unterminated array");
+
+        ++it;
+        return arr;
+    }
+
+    std::shared_ptr<table>
+    parse_inline_table(std::string::iterator &it, std::string::iterator &end) {
+        auto tbl = make_table();
+        do {
+            ++it;
+            if (it == end)
+                throw_parse_exception("Unterminated inline table");
+
+            consume_whitespace(it, end);
+            if (it != end && *it != '}') {
+                parse_key_value(it, end, tbl.get());
+                consume_whitespace(it, end);
+            }
+        } while (*it == ',');
+
+        if (it == end || *it != '}')
+            throw_parse_exception("Unterminated inline table");
+
+        ++it;
+        consume_whitespace(it, end);
+
+        return tbl;
+    }
+
+    void skip_whitespace_and_comments(
+        std::string::iterator &start, std::string::iterator &end) {
+        consume_whitespace(start, end);
+        while (start == end || *start == '#') {
+            if (!detail::getline(input_, line_))
+                throw_parse_exception("Unclosed array");
+            line_number_++;
+            start = line_.begin();
+            end = line_.end();
+            consume_whitespace(start, end);
+        }
+    }
+
+    void consume_whitespace(
+        std::string::iterator &it, const std::string::iterator &end) {
+        while (it != end && (*it == ' ' || *it == '\t'))
+            ++it;
+    }
+
+    void consume_backwards_whitespace(
+        std::string::iterator &back, const std::string::iterator &front) {
+        while (back != front && (*back == ' ' || *back == '\t'))
+            --back;
+    }
+
+    void eol_or_comment(
+        const std::string::iterator &it, const std::string::iterator &end) {
+        if (it != end && *it != '#')
+            throw_parse_exception(
+                "Unidentified trailing character '" + std::string{*it} +
+                "'---did you forget a '#'?");
+    }
+
+    bool
+    is_time(const std::string::iterator &it, const std::string::iterator &end) {
+        auto time_end = find_end_of_time(it, end);
+        auto len = std::distance(it, time_end);
+
+        if (len < 8)
+            return false;
+
+        if (it[2] != ':' || it[5] != ':')
+            return false;
+
+        if (len > 8)
+            return it[8] == '.' && len > 9;
+
+        return true;
+    }
+
+    option<parse_type> date_type(
+        const std::string::iterator &it, const std::string::iterator &end) {
+        auto date_end = find_end_of_date(it, end);
+        auto len = std::distance(it, date_end);
+
+        if (len < 10)
+            return {};
+
+        if (it[4] != '-' || it[7] != '-')
+            return {};
+
+        if (len >= 19 && (it[10] == 'T' || it[10] == ' ') &&
+            is_time(it + 11, date_end)) {
+            // datetime type
+            auto time_end = find_end_of_time(it + 11, date_end);
+            if (time_end == date_end)
+                return {parse_type::LOCAL_DATETIME};
+            else
+                return {parse_type::OFFSET_DATETIME};
+        } else if (len == 10) {
+            // just a regular date
+            return {parse_type::LOCAL_DATE};
+        }
+
+        return {};
+    }
+
+    std::istream &input_;
+    std::string line_;
+    std::size_t line_number_ = 0;
+};
+
+/**
+ * Utility function to parse a file as a TOML file. Returns the root table.
+ * Throws a parse_exception if the file cannot be opened.
+ */
+inline std::shared_ptr<table> parse_file(const std::string &filename) {
+#if defined(BOOST_NOWIDE_FSTREAM_INCLUDED_HPP)
+    boost::nowide::ifstream file{filename.c_str()};
+#elif defined(NOWIDE_FSTREAM_INCLUDED_HPP)
+    nowide::ifstream file{filename.c_str()};
+#else
+    std::ifstream file{filename};
+#endif
+    if (!file.is_open())
+        throw parse_exception{filename + " could not be opened for parsing"};
+    parser p{file};
+    return p.parse();
+}
+
+template <class... Ts> struct value_accept;
+
+template <> struct value_accept<> {
+    template <class Visitor, class... Args>
+    static void accept(const base &, Visitor &&, Args &&...) {
+        // nothing
+    }
+};
+
+template <class T, class... Ts> struct value_accept<T, Ts...> {
+    template <class Visitor, class... Args>
+    static void accept(const base &b, Visitor &&visitor, Args &&... args) {
+        if (auto v = b.as<T>()) {
+            visitor.visit(*v, std::forward<Args>(args)...);
+        } else {
+            value_accept<Ts...>::accept(
+                b, std::forward<Visitor>(visitor), std::forward<Args>(args)...);
+        }
+    }
+};
+
+/**
+ * base implementation of accept() that calls visitor.visit() on the concrete
+ * class.
+ */
+template <class Visitor, class... Args>
+void base::accept(Visitor &&visitor, Args &&... args) const {
+    if (is_value()) {
+        using value_acceptor = value_accept<
+            std::string,
+            int64_t,
+            double,
+            bool,
+            local_date,
+            local_time,
+            local_datetime,
+            offset_datetime>;
+        value_acceptor::accept(
+            *this, std::forward<Visitor>(visitor), std::forward<Args>(args)...);
+    } else if (is_table()) {
+        visitor.visit(
+            static_cast<const table &>(*this), std::forward<Args>(args)...);
+    } else if (is_array()) {
+        visitor.visit(
+            static_cast<const array &>(*this), std::forward<Args>(args)...);
+    } else if (is_table_array()) {
+        visitor.visit(
+            static_cast<const table_array &>(*this),
+            std::forward<Args>(args)...);
+    }
+}
+
+/**
+ * Writer that can be passed to accept() functions of cpptoml objects and
+ * will output valid TOML to a stream.
+ */
+class toml_writer {
+  public:
+    /**
+     * Construct a toml_writer that will write to the given stream
+     */
+    toml_writer(std::ostream &s, const std::string &indent_space = "\t")
+        : stream_(s), indent_(indent_space), has_naked_endline_(false) {
+        // nothing
+    }
+
+  public:
+    /**
+     * Output a base value of the TOML tree.
+     */
+    template <class T> void visit(const value<T> &v, bool = false) { write(v); }
+
+    /**
+     * Output a table element of the TOML tree
+     */
+    void visit(const table &t, bool in_array = false) {
+        write_table_header(in_array);
+        std::vector<std::string> values;
+        std::vector<std::string> tables;
+
+        for (const auto &i : t) {
+            if (i.second->is_table() || i.second->is_table_array()) {
+                tables.push_back(i.first);
+            } else {
+                values.push_back(i.first);
+            }
+        }
+
+        for (unsigned int i = 0; i < values.size(); ++i) {
+            path_.push_back(values[i]);
+
+            if (i > 0)
+                endline();
+
+            write_table_item_header(*t.get(values[i]));
+            t.get(values[i])->accept(*this, false);
+            path_.pop_back();
+        }
+
+        for (unsigned int i = 0; i < tables.size(); ++i) {
+            path_.push_back(tables[i]);
+
+            if (values.size() > 0 || i > 0)
+                endline();
+
+            write_table_item_header(*t.get(tables[i]));
+            t.get(tables[i])->accept(*this, false);
+            path_.pop_back();
+        }
+
+        endline();
+    }
+
+    /**
+     * Output an array element of the TOML tree
+     */
+    void visit(const array &a, bool = false) {
+        write("[");
+
+        for (unsigned int i = 0; i < a.get().size(); ++i) {
+            if (i > 0)
+                write(", ");
+
+            if (a.get()[i]->is_array()) {
+                a.get()[i]->as_array()->accept(*this, true);
+            } else {
+                a.get()[i]->accept(*this, true);
+            }
+        }
+
+        write("]");
+    }
+
+    /**
+     * Output a table_array element of the TOML tree
+     */
+    void visit(const table_array &t, bool = false) {
+        for (unsigned int j = 0; j < t.get().size(); ++j) {
+            if (j > 0)
+                endline();
+
+            t.get()[j]->accept(*this, true);
+        }
+
+        endline();
+    }
+
+    /**
+     * Escape a string for output.
+     */
+    static std::string escape_string(const std::string &str) {
+        std::string res;
+        for (auto it = str.begin(); it != str.end(); ++it) {
+            if (*it == '\b') {
+                res += "\\b";
+            } else if (*it == '\t') {
+                res += "\\t";
+            } else if (*it == '\n') {
+                res += "\\n";
+            } else if (*it == '\f') {
+                res += "\\f";
+            } else if (*it == '\r') {
+                res += "\\r";
+            } else if (*it == '"') {
+                res += "\\\"";
+            } else if (*it == '\\') {
+                res += "\\\\";
+            } else if (static_cast<uint32_t>(*it) <= UINT32_C(0x001f)) {
+                res += "\\u";
+                std::stringstream ss;
+                ss << std::hex << static_cast<uint32_t>(*it);
+                res += ss.str();
+            } else {
+                res += *it;
+            }
+        }
+        return res;
+    }
+
+  protected:
+    /**
+     * Write out a string.
+     */
+    void write(const value<std::string> &v) {
+        write("\"");
+        write(escape_string(v.get()));
+        write("\"");
+    }
+
+    /**
+     * Write out a double.
+     */
+    void write(const value<double> &v) {
+        std::stringstream ss;
+        ss << std::showpoint
+           << std::setprecision(std::numeric_limits<double>::max_digits10)
+           << v.get();
+
+        auto double_str = ss.str();
+        auto pos = double_str.find("e0");
+        if (pos != std::string::npos)
+            double_str.replace(pos, 2, "e");
+        pos = double_str.find("e-0");
+        if (pos != std::string::npos)
+            double_str.replace(pos, 3, "e-");
+
+        stream_ << double_str;
+        has_naked_endline_ = false;
+    }
+
+    /**
+     * Write out an integer, local_date, local_time, local_datetime, or
+     * offset_datetime.
+     */
+    template <class T>
+    typename std::enable_if<is_one_of<
+        T,
+        int64_t,
+        local_date,
+        local_time,
+        local_datetime,
+        offset_datetime>::value>::type
+    write(const value<T> &v) {
+        write(v.get());
+    }
+
+    /**
+     * Write out a boolean.
+     */
+    void write(const value<bool> &v) { write((v.get() ? "true" : "false")); }
+
+    /**
+     * Write out the header of a table.
+     */
+    void write_table_header(bool in_array = false) {
+        if (!path_.empty()) {
+            indent();
+
+            write("[");
+
+            if (in_array) {
+                write("[");
+            }
+
+            for (unsigned int i = 0; i < path_.size(); ++i) {
+                if (i > 0) {
+                    write(".");
+                }
+
+                if (path_[i].find_first_not_of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcde"
+                                               "fghijklmnopqrstuvwxyz0123456789"
+                                               "_-") == std::string::npos) {
+                    write(path_[i]);
+                } else {
+                    write("\"");
+                    write(escape_string(path_[i]));
+                    write("\"");
+                }
+            }
+
+            if (in_array) {
+                write("]");
+            }
+
+            write("]");
+            endline();
+        }
+    }
+
+    /**
+     * Write out the identifier for an item in a table.
+     */
+    void write_table_item_header(const base &b) {
+        if (!b.is_table() && !b.is_table_array()) {
+            indent();
+
+            if (path_.back().find_first_not_of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcde"
+                                               "fghijklmnopqrstuvwxyz0123456789"
+                                               "_-") == std::string::npos) {
+                write(path_.back());
+            } else {
+                write("\"");
+                write(escape_string(path_.back()));
+                write("\"");
+            }
+
+            write(" = ");
+        }
+    }
+
+  private:
+    /**
+     * Indent the proper number of tabs given the size of
+     * the path.
+     */
+    void indent() {
+        for (std::size_t i = 1; i < path_.size(); ++i)
+            write(indent_);
+    }
+
+    /**
+     * Write a value out to the stream.
+     */
+    template <class T> void write(const T &v) {
+        stream_ << v;
+        has_naked_endline_ = false;
+    }
+
+    /**
+     * Write an endline out to the stream
+     */
+    void endline() {
+        if (!has_naked_endline_) {
+            stream_ << "\n";
+            has_naked_endline_ = true;
+        }
+    }
+
+  private:
+    std::ostream &stream_;
+    const std::string indent_;
+    std::vector<std::string> path_;
+    bool has_naked_endline_;
+};
+
+inline std::ostream &operator<<(std::ostream &stream, const base &b) {
+    toml_writer writer{stream};
+    b.accept(writer);
+    return stream;
+}
+
+template <class T>
+std::ostream &operator<<(std::ostream &stream, const value<T> &v) {
+    toml_writer writer{stream};
+    v.accept(writer);
+    return stream;
+}
+
+inline std::ostream &operator<<(std::ostream &stream, const table &t) {
+    toml_writer writer{stream};
+    t.accept(writer);
+    return stream;
+}
+
+inline std::ostream &operator<<(std::ostream &stream, const table_array &t) {
+    toml_writer writer{stream};
+    t.accept(writer);
+    return stream;
+}
+
+inline std::ostream &operator<<(std::ostream &stream, const array &a) {
+    toml_writer writer{stream};
+    a.accept(writer);
+    return stream;
+}
+} // namespace cpptoml
+#endif // CPPTOML_H

--- a/runs/example/log_conf.toml
+++ b/runs/example/log_conf.toml
@@ -1,0 +1,24 @@
+# level is optional for both sinks and loggers
+# level for error logging is 'err', not 'error'
+# _st => single threaded, _mt => multi threaded
+# syslog_sink is automatically thread-safe by default, no need for _mt suffix
+
+# max_size supports suffix
+# - T (terabyte)
+# - G (gigabyte)
+# - M (megabyte)
+# - K (kilobyte)
+# - or simply no suffix (byte)
+
+# check out https: // github.com/gabime/spdlog/wiki/3.-Custom-formatting
+
+[[sink]]
+name = "example_sink"
+type = "color_stdout_sink_mt"
+
+
+[[logger]]
+name = "example"
+sinks = ["example_sink"]
+level = "trace"
+

--- a/runs/example/run.sh
+++ b/runs/example/run.sh
@@ -6,9 +6,11 @@ WORKLOAD="${SCRIPT_DIR:?}"/workload/Resnet50_DataParallel
 SYSTEM="${SCRIPT_DIR:?}"/system.json
 NETWORK="${SCRIPT_DIR:?}"/network.yml
 MEMORY="${SCRIPT_DIR:?}"/memory.json
+LOGGING="${SCRIPT_DIR:?}"/log_conf.toml
 
 "${BINARY}" \
   --workload-configuration="${WORKLOAD}" \
   --system-configuration="${SYSTEM}" \
-  --network-configuration="${NETWORK}"\
-  --remote-memory-configuration="${MEMORY}"
+  --network-configuration="${NETWORK}" \
+  --remote-memory-configuration="${MEMORY}" \
+  --logging-configuration="${LOGGING}"

--- a/runs/example/workload/generate.sh
+++ b/runs/example/workload/generate.sh
@@ -4,9 +4,9 @@ SCRIPT_DIR=$(dirname "$(realpath $0)")
 CHAKRA_DIR=${SCRIPT_DIR}"/../../../extern/graph_frontend/chakra"
 ASTRASIM_DIR=${SCRIPT_DIR}"/../../.."
 
-cd ${CHAKRA_DIR}
-
 # if not install chakra package, uncomment following
+# cd ${CHAKRA_DIR}
 # python -m pip install . --user
 
-python -m et_converter.et_converter --input_type Text --input_filename ${ASTRASIM_DIR}/inputs/workload/ASTRA-sim-1.0/Resnet50_DataParallel.txt --output_filename ${ASTRASIM_DIR}/runs/example/workload/Resnet50_DataParallel --num_dims 1 --num_npus 64 --num_passes 1
+cd ${SCRIPT_DIR}
+python -m chakra.et_converter.et_converter --input_type Text --input_filename ${ASTRASIM_DIR}/inputs/workload/ASTRA-sim-1.0/Resnet50_DataParallel.txt --output_filename ${ASTRASIM_DIR}/runs/example/workload/Resnet50_DataParallel --num_dims 1 --num_npus 64 --num_passes 1


### PR DESCRIPTION
## Summary
Here we provide a component that can be used for gathering system-level statistics, including resources utilizations, compute/memory bound percentages, resource runtime, as well as memory usage.

## Test Plan
Todo: 

## Additional Notes
Include contents from other PRs, Nees to clean it up.
Used on an "experimental" chakra etfeeder implementation that only load accesing node on memory+cache to avoid holding all nodes in memory until very end, thus high memory usage. Not tested with official etfeeder.
