### PR TITLE
add spdlog library and improve logging

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "extern/network_backend/ns-3"]
 	path = extern/network_backend/ns-3
 	url = git@github.com:astra-sim/astra-network-ns3.git
+[submodule "extern/helper/spdlog"]
+	path = extern/helper/spdlog
+	url = git@github.com:gabime/spdlog.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ target_include_directories(AstraSim PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/extern/gr
 target_include_directories(AstraSim PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/extern/graph_frontend/chakra/src/third_party/utils)
 target_include_directories(AstraSim PUBLIC ${Protobuf_INCLUDE_DIRS})
 target_include_directories(AstraSim PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/extern/helper/)
+target_include_directories(AstraSim PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/extern/helper/spdlog/include/)
 
 # Properties
 set_target_properties(AstraSim PROPERTIES COMPILE_WARNING_AS_ERROR ON)

--- a/astra-sim/network_frontend/analytical/CMakeLists.txt
+++ b/astra-sim/network_frontend/analytical/CMakeLists.txt
@@ -42,6 +42,7 @@ if (BUILDTARGET STREQUAL "all" OR BUILDTARGET STREQUAL "congestion_unaware")
     target_include_directories(AstraSim_Analytical_Congestion_Unaware PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/)
     target_include_directories(AstraSim_Analytical_Congestion_Unaware PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../extern/)
     target_include_directories(AstraSim_Analytical_Congestion_Unaware PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../extern/helper)
+    target_include_directories(AstraSim_Analytical_Congestion_Unaware PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../extern/helper/spdlog/include)
 
     # Properties
     set_target_properties(AstraSim_Analytical_Congestion_Unaware PROPERTIES COMPILE_WARNING_AS_ERROR ON)
@@ -66,6 +67,7 @@ if (BUILDTARGET STREQUAL "all" OR BUILDTARGET STREQUAL "congestion_aware")
     target_include_directories(AstraSim_Analytical_Congestion_Aware PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/)
     target_include_directories(AstraSim_Analytical_Congestion_Aware PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../extern/)
     target_include_directories(AstraSim_Analytical_Congestion_Aware PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../extern/helper)
+    target_include_directories(AstraSim_Analytical_Congestion_Aware PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../extern/helper/spdlog/include)
 
     # Properties
     set_target_properties(AstraSim_Analytical_Congestion_Aware PROPERTIES COMPILE_WARNING_AS_ERROR ON)

--- a/astra-sim/network_frontend/analytical/congestion_aware/main.cc
+++ b/astra-sim/network_frontend/analytical/congestion_aware/main.cc
@@ -9,6 +9,8 @@ LICENSE file in the root directory of this source tree.
 #include <remote_memory_backend/analytical/AnalyticalRemoteMemory.hh>
 #include "common/CmdLineParser.hh"
 #include "congestion_aware/CongestionAwareNetworkApi.hh"
+#include "spdlog/spdlog.h"
+#include "spdlog/sinks/basic_file_sink.h"
 
 using namespace AstraSim;
 using namespace Analytical;
@@ -39,6 +41,17 @@ int main(int argc, char* argv[]) {
   const auto injection_scale = cmd_line_parser.get<double>("injection-scale");
   const auto rendezvous_protocol =
       cmd_line_parser.get<bool>("rendezvous-protocol");
+
+  try {
+    auto logger =
+        spdlog::basic_logger_mt("trace", "log/simulated-trace.txt", true);
+    // Set an empty pattern to remove any formatting
+    logger->set_pattern("%v"); // '%v' is just the log message itself
+    logger->flush_on(
+        spdlog::level::info); // Automatically flush on 'info' or higher
+  } catch (const spdlog::spdlog_ex& ex) {
+    std::cout << "Log init failed: " << ex.what() << std::endl;
+  }
 
   // Instantiate event queue
   const auto event_queue = std::make_shared<EventQueue>();

--- a/astra-sim/network_frontend/analytical/congestion_unaware/main.cc
+++ b/astra-sim/network_frontend/analytical/congestion_unaware/main.cc
@@ -9,6 +9,8 @@ LICENSE file in the root directory of this source tree.
 #include <remote_memory_backend/analytical/AnalyticalRemoteMemory.hh>
 #include "common/CmdLineParser.hh"
 #include "congestion_unaware/CongestionUnawareNetworkApi.hh"
+#include "spdlog/spdlog.h"
+#include "spdlog/sinks/basic_file_sink.h"
 
 using namespace AstraSim;
 using namespace Analytical;
@@ -39,6 +41,17 @@ int main(int argc, char* argv[]) {
   const auto injection_scale = cmd_line_parser.get<double>("injection-scale");
   const auto rendezvous_protocol =
       cmd_line_parser.get<bool>("rendezvous-protocol");
+
+  try {
+    auto logger =
+        spdlog::basic_logger_mt("trace", "log/simulated-trace.txt", true);
+    // Set an empty pattern to remove any formatting
+    logger->set_pattern("%v"); // '%v' is just the log message itself
+    logger->flush_on(
+        spdlog::level::info); // Automatically flush on 'info' or higher
+  } catch (const spdlog::spdlog_ex& ex) {
+    std::cout << "Log init failed: " << ex.what() << std::endl;
+  }
 
   // Instantiate event queue
   const auto event_queue = std::make_shared<EventQueue>();

--- a/astra-sim/network_frontend/ns3/AstraSimNetwork.cc
+++ b/astra-sim/network_frontend/ns3/AstraSimNetwork.cc
@@ -18,6 +18,8 @@
 #include "ns3/csma-module.h"
 #include "ns3/internet-module.h"
 #include "ns3/network-module.h"
+#include "spdlog/spdlog.h"
+#include "spdlog/sinks/basic_file_sink.h"
 
 using namespace std;
 using namespace ns3;
@@ -231,6 +233,15 @@ void parse_args(int argc, char* argv[]) {
 int main(int argc, char* argv[]) {
   LogComponentEnable("OnOffApplication", LOG_LEVEL_INFO);
   LogComponentEnable("PacketSink", LOG_LEVEL_INFO);
+
+  try {
+    auto logger = spdlog::basic_logger_mt("trace", "log/simulated-trace.txt", true);
+    // Set an empty pattern to remove any formatting
+    logger->set_pattern("%v"); // '%v' is just the log message itself
+    logger->flush_on(spdlog::level::info);  // Automatically flush on 'info' or higher
+  } catch (const spdlog::spdlog_ex& ex) {
+    std::cout << "Log init failed: " << ex.what() << std::endl;
+  }
 
   cout << "ASTRA-sim + NS3" << endl;
 

--- a/astra-sim/workload/Workload.cc
+++ b/astra-sim/workload/Workload.cc
@@ -12,6 +12,8 @@ LICENSE file in the root directory of this source tree.
 #include "astra-sim/system/SendPacketEventHandlerData.hh"
 #include "astra-sim/system/WorkloadLayerHandlerData.hh"
 
+#include "spdlog/spdlog.h"
+
 #include <stdlib.h>
 #include <unistd.h>
 #include <iostream>
@@ -119,9 +121,10 @@ void Workload::issue(shared_ptr<Chakra::ETFeederNode> node) {
     if ((node->type() == ChakraNodeType::MEM_LOAD_NODE) ||
         (node->type() == ChakraNodeType::MEM_STORE_NODE)) {
       if (sys->trace_enabled) {
-        cout << "issue,sys->id=" << sys->id << ",tick=" << Sys::boostedTick()
-             << ",node->id=" << node->id() << ",node->name=" << node->name()
-             << endl;
+        stringstream ss;
+        ss << "issue,sys->id=" << sys->id << ",tick=" << Sys::boostedTick()
+           << ",node->id=" << node->id() << ",node->name=" << node->name();
+        spdlog::get("trace")->info(ss.str());
       }
       issue_remote_mem(node);
     } else if (
@@ -131,9 +134,10 @@ void Workload::issue(shared_ptr<Chakra::ETFeederNode> node) {
         skip_invalid(node);
       } else {
         if (sys->trace_enabled) {
-          cout << "issue,sys->id=" << sys->id << ",tick=" << Sys::boostedTick()
-               << ",node->id=" << node->id() << ",node->name=" << node->name()
-               << endl;
+          stringstream ss;
+          ss << "issue,sys->id=" << sys->id << ",tick=" << Sys::boostedTick()
+             << ",node->id=" << node->id() << ",node->name=" << node->name();
+          spdlog::get("trace")->info(ss.str());
         }
         issue_comp(node);
       }
@@ -143,9 +147,10 @@ void Workload::issue(shared_ptr<Chakra::ETFeederNode> node) {
          (node->type() == ChakraNodeType::COMM_SEND_NODE) ||
          (node->type() == ChakraNodeType::COMM_RECV_NODE))) {
       if (sys->trace_enabled) {
-        cout << "issue,sys->id=" << sys->id << ",tick=" << Sys::boostedTick()
-             << ",node->id=" << node->id() << ",node->name=" << node->name()
-             << endl;
+        stringstream ss;
+        ss << "issue,sys->id=" << sys->id << ",tick=" << Sys::boostedTick()
+           << ",node->id=" << node->id() << ",node->name=" << node->name();
+        spdlog::get("trace")->info(ss.str());
       }
       issue_comm(node);
     } else if (node->type() == ChakraNodeType::INVALID_NODE) {
@@ -330,9 +335,10 @@ void Workload::call(EventType event, CallData* data) {
     shared_ptr<Chakra::ETFeederNode> node = et_feeder->lookupNode(node_id);
 
     if (sys->trace_enabled) {
-      cout << "callback,sys->id=" << sys->id << ",tick=" << Sys::boostedTick()
-           << ",node->id=" << node->id() << ",node->name=" << node->name()
-           << endl;
+      stringstream ss;
+      ss << "callback,sys->id=" << sys->id << ",tick=" << Sys::boostedTick()
+         << ",node->id=" << node->id() << ",node->name=" << node->name();
+      spdlog::get("trace")->info(ss.str());
     }
 
     hw_resource->release(node);
@@ -357,9 +363,10 @@ void Workload::call(EventType event, CallData* data) {
           et_feeder->lookupNode(wlhd->node_id);
 
       if (sys->trace_enabled) {
-        cout << "callback,sys->id=" << sys->id << ",tick=" << Sys::boostedTick()
-             << ",node->id=" << node->id() << ",node->name=" << node->name()
-             << endl;
+        stringstream ss;
+        ss << "callback,sys->id=" << sys->id << ",tick=" << Sys::boostedTick()
+           << ",node->id=" << node->id() << ",node->name=" << node->name();
+        spdlog::get("trace")->info(ss.str());
       }
 
       hw_resource->release(node);


### PR DESCRIPTION
## Summary
This PR integrates the [spdlog](https://github.com/gabime/spdlog) library to enhance the logging functionality within the project. The `spdlog` library has been added as a git submodule under `extern/helper/spdlog` and incorporated into the build system via the `CMakeLists.txt` configuration.

## Test Plan
To activate trace logging, the `trace-enabled` argument can be set in the system input file. The corresponding trace logs will be generated and stored in `log/simulated-trace.txt`.

## Additional Notes
At this stage, the logging enhancements are limited to trace-related output. Future iterations may extend this logging improvement to cover all logging operations across the project.