### PR TITLE
Add cstdint header for uint64_t

### DIFF
--- a/astra-sim/system/CSVWriter.hh
+++ b/astra-sim/system/CSVWriter.hh
@@ -10,6 +10,7 @@ LICENSE file in the root directory of this source tree.
 #include <fstream>
 #include <list>
 #include <string>
+#include <cstdint>
 
 namespace AstraSim {
 


### PR DESCRIPTION
## Summary
Solves issue #220 
Ubuntu 24 explicitly requires cstdint header to be included for uint64_t for a successful build

## Test Plan
Test locally on Ubuntu 24
Test with Github action on Ubuntu 22
