### PR TITLE
Temporarily Disable Warnings in build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ target_include_directories(AstraSim PUBLIC ${Protobuf_INCLUDE_DIRS})
 target_include_directories(AstraSim PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/extern/helper/)
 
 # Properties
-set_target_properties(AstraSim PROPERTIES COMPILE_WARNING_AS_ERROR ON)
+set_target_properties(AstraSim PROPERTIES COMPILE_WARNING_AS_ERROR OFF)
 set_target_properties(AstraSim
         PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../bin/

--- a/astra-sim/network_frontend/analytical/CMakeLists.txt
+++ b/astra-sim/network_frontend/analytical/CMakeLists.txt
@@ -44,7 +44,8 @@ if (BUILDTARGET STREQUAL "all" OR BUILDTARGET STREQUAL "congestion_unaware")
     target_include_directories(AstraSim_Analytical_Congestion_Unaware PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../extern/helper)
 
     # Properties
-    set_target_properties(AstraSim_Analytical_Congestion_Unaware PROPERTIES COMPILE_WARNING_AS_ERROR ON)
+    # TODO: Switch to OFF after binary_function deprecation has been resolved
+    set_target_properties(AstraSim_Analytical_Congestion_Unaware PROPERTIES COMPILE_WARNING_AS_ERROR OFF)
     set_target_properties(AstraSim_Analytical_Congestion_Unaware
             PROPERTIES
             RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../bin/
@@ -68,7 +69,8 @@ if (BUILDTARGET STREQUAL "all" OR BUILDTARGET STREQUAL "congestion_aware")
     target_include_directories(AstraSim_Analytical_Congestion_Aware PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../extern/helper)
 
     # Properties
-    set_target_properties(AstraSim_Analytical_Congestion_Aware PROPERTIES COMPILE_WARNING_AS_ERROR ON)
+    # TODO: Switch to OFF after binary_function deprecation has been resolved
+    set_target_properties(AstraSim_Analytical_Congestion_Aware PROPERTIES COMPILE_WARNING_AS_ERROR OFF)
     set_target_properties(AstraSim_Analytical_Congestion_Aware
             PROPERTIES
             RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../bin/

--- a/build/astra_analytical/CMakeLists.txt
+++ b/build/astra_analytical/CMakeLists.txt
@@ -12,6 +12,9 @@ endif ()
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -Wall -Wextra -Wuninitialized -Wunused-function -Wno-unused-parameter -Wno-empty-body -fsanitize=address,undefined,leak -g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
+# TODO: Remove this once binary_function deprecation is resolved.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error")
+
 # Setup project
 project(AstraSim_Analytical)
 


### PR DESCRIPTION
## Summary
TEMPORARILY solves issue #212 
`binary_function`  is deprecated starting C++17 and causes a Warning/error starting Ubuntu 24. 
https://github.com/mlcommons/chakra/blob/f256593aaa2213afc89269aa6e4e32d8fdde930f/src/feeder/et_feeder.h#L13-L22

Since this is within the Chakra repo, do not let warning trigger errors FOR NOW (still show them as warning, not error), to be reverted after fix is made within Chakra repo.

## Test Plan
Tested locally in Ubuntu 24
To test with Github action for Ubuntu 22

## Additional Notes
