### PR TITLE
Fix: use stop_time NS3 config mentioned

### DIFF
--- a/astra-sim/network_frontend/ns3/AstraSimNetwork.cc
+++ b/astra-sim/network_frontend/ns3/AstraSimNetwork.cc
@@ -253,8 +253,8 @@ int main(int argc, char* argv[]) {
     }
 
     // Run the simulation by triggering the ns3 event queue.
+    Simulator::Stop(Seconds(simulator_stop_time));
     Simulator::Run();
-    Simulator::Stop(Seconds(2000000000));
     Simulator::Destroy();
     return 0;
 }


### PR DESCRIPTION
Cherry-picked from 95898d9

## Summary

As is discussed in #240. https://github.com/astra-sim/astra-sim/issues/240#issuecomment-2421455206

> [NS3 Docs](https://www.nsnam.org/docs/doxygen/dd/de5/classns3_1_1_simulator.html#a65dc79a818e73430090a63b63037e16c) mentions the stop conditions and [Tutorial](https://www.nsnam.org/docs/tutorial/html/conceptual-overview.html#when-the-simulator-will-stop) says
> 
> > It is important to call `Simulator::Stop` before calling `Simulator::Run`; otherwise, `Simulator::Run` may never return control to the main program to execute the stop!
> 
> So the code above may run into a wrong state. I'm not sure why it's able to run.

So use the `stop_time` NS3 config mentioned.
