### PR TITLE
fixed workflow to use ubuntu 22.04

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -4,8 +4,6 @@ set -e
 SCRIPT_DIR=$(dirname "$(realpath $0)")
 PROJ_DIR=${SCRIPT_DIR}/../..
 
-source ${PROJ_DIR}/.astra_sim_env/bin/activate
-
 ### ============= Build Analytical ==================
 ${PROJ_DIR}/build/astra_analytical/build.sh
 

--- a/.github/workflows/setup.sh
+++ b/.github/workflows/setup.sh
@@ -12,13 +12,9 @@ apt -y install coreutils wget vim git
 apt -y install gcc-11 g++-11 make cmake 
 apt -y install clang-format 
 apt -y install libboost-dev libboost-program-options-dev
-apt -y install python3.12 python3-pip python3-venv
+apt -y install python3.10 python3-pip
 apt -y install libprotobuf-dev protobuf-compiler
 apt -y install openmpi-bin openmpi-doc libopenmpi-dev
-
-## Create Python venv: Required for Python 3.12
-python3 -m venv ${PROJ_DIR}/.astra_sim_env
-source ${PROJ_DIR}/.astra_sim_env/bin/activate
 
 pip3 install --upgrade pip
 

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -4,8 +4,6 @@ set -e
 SCRIPT_DIR=$(dirname "$(realpath $0)")
 PROJ_DIR=${SCRIPT_DIR}/../..
 
-source ${PROJ_DIR}/.astra_sim_env/bin/activate
-
 ### ============= Run Tests ==================
 ${PROJ_DIR}/tests/run_all.sh
 

--- a/.github/workflows/workflow_main.yml
+++ b/.github/workflows/workflow_main.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3

--- a/build/astra_ns3/build.sh
+++ b/build/astra_ns3/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 # Absolue path to this script
 SCRIPT_DIR=$(dirname "$(realpath $0)")
 # Absolute paths to useful directories
@@ -14,8 +15,8 @@ NETWORK="../../../ns-3/scratch/config/config.txt"
 # Functions
 function setup {
     protoc et_def.proto\
-        --proto_path ${SCRIPT_DIR}/../../extern/graph_frontend/chakra/et_def/\
-        --cpp_out ${SCRIPT_DIR}/../../extern/graph_frontend/chakra/et_def/
+        --proto_path ${SCRIPT_DIR}/../../extern/graph_frontend/chakra/schema/protobuf/\
+        --cpp_out ${SCRIPT_DIR}/../../extern/graph_frontend/chakra/schema/protobuf/
 }
 function compile {
     cd "${NS3_DIR}"


### PR DESCRIPTION
- Changed workflow to run on Ubuntu 22.04, due to the compatibility issue of NS-3 and Ubuntu 24.04, 
- Changed Python version from 3.12 to 3.10, due to Ubuntu downgrading. 
- Added "set -e" to NS-3 build script to avoid silent failure. 
- Updated Chakra protobuf schema path in NS-3 build script.