### PR TITLE
Fix wrong ID when accessing collective_comm_wrapper_map. Fix memory leak in DataSet.cc

### DIFF
--- a/astra-sim/system/DataSet.cc
+++ b/astra-sim/system/DataSet.cc
@@ -43,6 +43,7 @@ void DataSet::notify_stream_finished(StreamStat* data) {
             IntData* int_data = new IntData(my_id);
             int_data->execution_time = finish_tick - creation_tick;
             c->call(ev, int_data);
+            delete int_data;
         }
     }
 }

--- a/astra-sim/workload/Workload.cc
+++ b/astra-sim/workload/Workload.cc
@@ -352,8 +352,10 @@ void Workload::call(EventType event, CallData* data) {
 
     if (event == EventType::CollectiveCommunicationFinished) {
         IntData* int_data = (IntData*)data;
+        uint64_t coll_comm_id = int_data->data;
+
         hw_resource->tics_gpu_comms += int_data->execution_time;
-        uint64_t node_id = collective_comm_node_id_map[int_data->data];
+        uint64_t node_id = collective_comm_node_id_map[coll_comm_id];
         shared_ptr<Chakra::ETFeederNode> node = et_feeder->lookupNode(node_id);
 
         if (sys->trace_enabled) {
@@ -374,8 +376,8 @@ void Workload::call(EventType event, CallData* data) {
 
         // The Dataset class provides statistics that should be used later to
         // dump more statistics in the workload layer
-        delete collective_comm_wrapper_map[node_id];
-        collective_comm_wrapper_map.erase(node_id);
+        delete collective_comm_wrapper_map[coll_comm_id];
+        collective_comm_wrapper_map.erase(coll_comm_id);
 
     } else {
         if (data == nullptr) {


### PR DESCRIPTION
## Summary
Noticed that my simulation was crashing with Chakra traces containing more than one back to back CommColl. 
Found out you were using the chakra node_id as index to the map containing the CommColl Dataset instead of using the unique ID (my_id) generated by the Dataset class. 

Additionally you forgot to free the IntData argument passed to Sys that was causing a memory leak.



