### PR TITLE
Update protobuf version to 5.29.0

### DIFF
--- a/.github/workflows/setup.sh
+++ b/.github/workflows/setup.sh
@@ -19,7 +19,7 @@ apt -y install openmpi-bin openmpi-doc libopenmpi-dev
 pip3 install --upgrade pip
 
 ## Install Python protobuf package
-pip3 install protobuf==5.28.2
+pip3 install protobuf==5.29.0
 
 ### ============= Install Chakra ==================
 cd ${PROJ_DIR}/extern/graph_frontend/chakra

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,8 @@ ENV absl_DIR="/opt/abseil-cpp-${ABSL_VER}/install"
 
 
 ### ============= Protobuf Installation ==================
-## Download Protobuf 28.3 (=v5.28.3, latest version as of 10/31/2024)
-ARG PROTOBUF_VER=28.3
+## Download Protobuf 29.0 (=v5.29.0, latest stable version as of Feb/01/2025)
+ARG PROTOBUF_VER=29.0
 
 # Download source
 WORKDIR /opt


### PR DESCRIPTION
## Summary
In reaction to failed build test here: https://github.com/astra-sim/astra-sim/actions/runs/13085401314/job/36515898252?pr=288

>  google.protobuf.runtime_version.VersionError: Detected incompatible Protobuf Gencode/Runtime versions when loading et_def.proto: gencode 5.29.0 runtime 5.28.2. Runtime version cannot be older than the linked gencode version. See Protobuf version guarantees at https://protobuf.dev/support/cross-version-runtime-guarantee[.](https://protobuf.dev/support/cross-version-runtime-guarantee.)
> [19](https://github.com/astra-sim/astra-sim/actions/runs/13085401314/job/36515898252?pr=288#step:5:20)
> 

Update protobuf version to 5.29.0 in both github workflow & Dockerfile

## Test Plan
Rebuilt dockerfile & tested build, runs, and the test script `tests/run_all.sh`. 

## Additional Notes
This is a hotfix. In the long term, we should look at stable solutions, including, but not limited to `pip install protobuf > 5.29.0`