### PR TITLE
[Hotfix] Update Github regression test to use protobuf==6.31 for Python scripts

### DIFF
--- a/.github/workflows/setup.sh
+++ b/.github/workflows/setup.sh
@@ -25,4 +25,7 @@ pip3 install protobuf==5.29.0
 cd ${PROJ_DIR}/extern/graph_frontend/chakra
 pip3 install .
 
+# Temporary workaround to resolve protobuf mismatch. Refer to the PR for more details.
+pip3 install protobuf==6.31.0
+
 ### ======================================================


### PR DESCRIPTION
## Summary
Previously failed test workflows :https://github.com/astra-sim/astra-sim/actions/runs/15528421857/job/43945698127

Within the test workflow, we also build Chakra & run python scripts to generate input traces. 
However, there is a version issue when building & running python within Chakra (that is not relevant to ASTRA-sim) (details below)
As a hotfix, in the setup script for the github action, increase the `protobuf` package _within pip_ to 6.31.

This is a temporary fix. The fundamental solution is to 1) Fix `requirements.txt` in the Chakra repo to accept higher versions, and/or, 2) Remove tests in ASTRA-sim that install & run python code within Chakra. As an alternative, provide sample ET traces for regression test purposes. 

## Test Plan
```bash
docker run -it --rm -v $(pwd):/work -w /work ubuntu:22.04 bash                                                                                                                                      
bash .github/workflows/^C                                                                                                                                                                                 
cd .github/workflows/                                                                                                                                                                                     
bash setup.sh ; bash build.sh ; bash test.sh 
```
## Additional Notes - Details on the "version error" above: 
> TL, DR: As long as Chakra uses `setuptools-grpc` in the build process to compile `.proto` files, regardless of what is written in `pyproject.toml`, the generated `pb2.py` file will always be compiled with whatever `protoc` the `grpc` repo points to (which is v.6.31.0 as of today)


From the [workflow scripts](https://github.com/astra-sim/astra-sim/tree/15a4334ade00fe1040fd00495cd13fd1ea5177e4/.github/workflows) a minimal reproducible script is as follows 

```
# From setup.sh 
apt -y install python3.10 python3-pip
pip3 install protobuf==5.29.0
cd ${PROJ_DIR}/extern/graph_frontend/chakra
pip3 install .

# (Skip build.sh)
# From test.sh, and eventually tests/run_all.sh
python tests/rt_template/inputs/workload/gen_chakra_traces.py
```

From here, we get the following error message:

```
google.protobuf.runtime_version.VersionError: Detected mismatched Protobuf Gencode/Runtime major versions when loading et_def.proto: gencode 6.31.0 runtime 5.29.0. Same major version is required. See Protobuf version guarantees at https://protobuf.dev/support/cross-version-runtime-guarantee.
```
Here, 
- `gencode 6.31.0` refers to the `protoc` version used to convert `et_def.proto` into `et_def_pb2.py`. 
- `runtime 5.29.0` refers to the pip `protobuf` package, that is triggered when running python scripts like `python gen_chakra_traces.py`. 

We know that `pip install .` installs protobuf v5.29.0 and uses it, as it is the dependency defined in Chakra's [pyproject.toml](https://github.com/mlcommons/chakra/blob/bf222b23caf7b6972da17ab7b419d02083c2d2e0/pyproject.toml#L15)  file. 
Then where does the `6.31.0` come from?

When running `pip install .`, Chakra's `pyproject.toml` declares that it will use setuptools, specifically a plugin called `setuptools-grpc` whose repo is available (here)[https://github.com/CZ-NIC/setuptools-grpc]. `setuptools-grpc` [imports and uses](https://github.com/CZ-NIC/setuptools-grpc/blob/22ea60bb589d2cd42afed6c8f51325ebc0cf9cd6/setuptools_grpc/build_grpc.py#L9) `grpc_tools.protoc`. That is, *setuptools-grpc does not use the system installed, or even the pip installed protobuf/protoc to compile et_def.proto into et_def_pb2.py*. This can be verified by trying to run `pip install .` without installing protoc in either the system (apt-get -y ...) or pip. You can see that the `pb2.py` files are created nontheless.

Then what protoc version does `setuptools-grpc` use? If you go into the `grpc` [repo](https://github.com/grpc/grpc) which holds `grpc_tools`, you can see that it imports the source code of the protocol buffer as a [submodule](https://github.com/grpc/grpc/tree/bd9dd6cb6feaa135fc20ed9639aed80508143323/third_party), and compiles `protoc` *from source*. That is, any code calling `grpc_tools.protoc` is fixed to whichever protoc version is submoduled in the `grpc` repo. 

Looking into the code, we see that currently (2025-JUN-12), the grpc repo points to [commit 3d4adad of the protobuf repo](https://github.com/protocolbuffers/protobuf/tree/3d4adad5c4c4e6a6f9f038769b8c90716065b0e4). This commit has a tag of v31.0, which corresponds to v6.31.0 in Python. *That's* where the `gencode 6.31.0` comes from. 

### More notes: Why does `v31.0` correspond to `v6.31.0` "in Python"?
Ref: https://protobuf.dev/support/version-support/

The protobuf repo has a repo-wide version, which consists only of minor/patch numbers (`v31.0`, `v29.5`, etc). 
For each repo-wide version, each language may use different major versions. For example, for the *repo-wide* version `v31.0`, C++ and Python calls it `v6.31.0`, while Ruby calls it `v4.31.0`. This is because the same repo-wide update may have a groundbreaking change in one language, while it has minimal effect in another language. That is, C++ v6.31.0 and Ruby v4.31.0 points to the *same* commit in the protobuf repo. 

So, once we know the repo-wide version `v31.0`, we look up the table in the link above to find the major number for Python


### More notes: Why is this not relevant to ASTRA-sim? 
Running `pip install .` in the Chakra repo only generates the Python code `_pb2.py`. ASTRA-sim does not directly use the Python generated code. Instead, it relies on C++ generated code `pb.cc`. This code is generated by ASTRA-sim's build commands `buid/astra_analytical/build.sh`, which uses the system installed `protoc`. 

If you look closely at `build/astra_analytical/build.sh` you will see that it also seems to generate `pb2.py` code within the same location (`external/graph_frontend/chakra/schema/protobuf`). However, this is irrelevent. When running `pip install .` the generated `pb2.py` code has already been copied/installed into the system wide python. (As proof, go to the failed action run above and look at the stacktrace). Now matter now much you run `build/astra_analytical/build.sh`, the `pb2.py` code it generates overwrites a meaningless location. 

In other words, we need to remove that part from the script.