### PR TITLE
Use nprocs to build ns-3 backend

### DIFF
--- a/build/astra_ns3/build.sh
+++ b/build/astra_ns3/build.sh
@@ -21,7 +21,7 @@ function setup {
 function compile {
     cd "${NS3_DIR}"
     ./ns3 configure --enable-mpi
-    ./ns3 build AstraSimNetwork -j 12
+    ./ns3 build AstraSimNetwork -j $(nproc)
     cd "${SCRIPT_DIR:?}"
 }
 function run {


### PR DESCRIPTION
Co-authored-by: vamsiDT <vamsiaddanki666@gmail.com>

## Summary
Instead of a hardcoded number of processors, use `$(nproc)`.

This PR was originally submitted in #272

## Test Plan
`bash build/astra_ns3/build.sh`

## Additional Notes
