### PR TITLE
Enable multiple communicator groups

### DIFF
--- a/astra-sim/system/CommunicatorGroup.cc
+++ b/astra-sim/system/CommunicatorGroup.cc
@@ -19,8 +19,6 @@ CommunicatorGroup::CommunicatorGroup(int id,
     this->involved_NPUs = involved_NPUs;
     this->generator = generator;
     std::sort(involved_NPUs.begin(), involved_NPUs.end());
-    assert(std::find(involved_NPUs.begin(), involved_NPUs.end(),
-                     generator->id) != involved_NPUs.end());
 }
 
 CommunicatorGroup::~CommunicatorGroup() {

--- a/astra-sim/workload/Workload.hh
+++ b/astra-sim/workload/Workload.hh
@@ -28,7 +28,9 @@ class Workload : public Callable {
     ~Workload();
 
     // communicator groups
-    void initialize_comm_group(std::string comm_group_filename);
+    // Parse the user provided 'comm_group_filename' and extract the list of communicator groups.
+    // Refer to the wiki for the format.
+    void initialize_comm_groups(std::string comm_group_filename);
 
     // event-based simulation
     void issue_dep_free_nodes();
@@ -45,12 +47,17 @@ class Workload : public Callable {
     void report();
 
     Chakra::ETFeeder* et_feeder;
-    CommunicatorGroup* comm_group;
+    std::unordered_map<int, CommunicatorGroup*> comm_groups;
     HardwareResource* hw_resource;
     Sys* sys;
     std::unordered_map<int, uint64_t> collective_comm_node_id_map;
     std::unordered_map<int, DataSet*> collective_comm_wrapper_map;
     bool is_finished;
+
+    private:
+    // From the ET node, find out the corresponding communicator group, and return the pointer.
+    // If no communicator group is specified for this ET node, return nullptr.
+    CommunicatorGroup* extract_comm_group(std::shared_ptr<Chakra::ETFeederNode> node);
 };
 
 }  // namespace AstraSim


### PR DESCRIPTION
## Summary
ASTRA-sim's communication group does not follow what is defined in the [documentation](https://astra-sim.github.io/astra-sim-docs/getting-started/argument-workload-config.html#enable-communicator-groups)

Previously, even if we had the `--comm-group-configuration`, we only accepted a file that defined one arbitrary communicator group. That communicator group was applied to all of the collectives. 

What we really want is for each of the collective node(operation) in the chakra ET to have their own collective group, and ASTRA-sim is able to use the collective group intended for that collective node(operation). 

Therefore, fix two things
1) Parsing the commgroup file: Instead of parsing a single list of NPUs (one comm group) parse multiple comm groups
2) Parsing a communication ET node: when comm group is specified using `pg_name`, use that as a key to look up the communication group to use.

## Test Plan
Created & tested with example comm group input file. 

## Additional Notes
Slightly updated the wiki documentation to show how the communicator group is encoded in chakra ET [PR26](https://github.com/astra-sim/astra-sim-docs/pull/26)