### PR TITLE
Add run scripts to ns3 examples

### DIFF
--- a/build/astra_ns3/build.sh
+++ b/build/astra_ns3/build.sh
@@ -5,13 +5,7 @@ SCRIPT_DIR=$(dirname "$(realpath $0)")
 # Absolute paths to useful directories
 ASTRA_SIM_DIR="${SCRIPT_DIR:?}"/../../astra-sim
 NS3_DIR="${SCRIPT_DIR:?}"/../../extern/network_backend/ns-3
-# Inputs - change as necessary.
-WORKLOAD="${SCRIPT_DIR:?}"/../../extern/graph_frontend/chakra/one_comm_coll_node_allgather
-SYSTEM="${SCRIPT_DIR:?}"/../../inputs/system/Switch.json
-MEMORY="${SCRIPT_DIR:?}"/../../inputs/remote_memory/analytical/no_memory_expansion.json
-LOGICAL_TOPOLOGY="${SCRIPT_DIR:?}"/../../inputs/network/ns3/sample_8nodes_1D.json
-# Note that ONLY this file is relative to NS3_DIR/simulation
-NETWORK="../../../ns-3/scratch/config/config.txt"
+
 # Functions
 function setup {
     protoc et_def.proto\
@@ -22,17 +16,6 @@ function compile {
     cd "${NS3_DIR}"
     ./ns3 configure --enable-mpi
     ./ns3 build AstraSimNetwork -j $(nproc)
-    cd "${SCRIPT_DIR:?}"
-}
-function run {
-    cd "${NS3_DIR}/build/scratch"
-    ./ns3.42-AstraSimNetwork-default \
-        --workload-configuration=${WORKLOAD} \
-        --system-configuration=${SYSTEM} \
-        --network-configuration=${NETWORK} \
-        --remote-memory-configuration=${MEMORY} \
-        --logical-topology-configuration=${LOGICAL_TOPOLOGY} \
-        --comm-group-configuration=\"empty\"
     cd "${SCRIPT_DIR:?}"
 }
 function cleanup {
@@ -48,23 +31,6 @@ function debug {
     ./ns3 configure --enable-mpi --build-profile debug
     ./ns3 build AstraSimNetwork -j 12 -v
     cd "${NS3_DIR}/build/scratch"
-    gdb --args "${NS3_DIR}/build/scratch/ns3.42-AstraSimNetwork-debug" \
-        --workload-configuration=${WORKLOAD} \
-        --system-configuration=${SYSTEM} \
-        --network-configuration=${NETWORK} \
-        --remote-memory-configuration=${MEMORY} \
-        --logical-topology-configuration=${LOGICAL_TOPOLOGY} \
-        --comm-group-configuration=\"empty\"
-}
-function special_debug {
-    cd "${NS3_DIR}/build/scratch"
-    valgrind --leak-check=yes "${NS3_DIR}/build/scratch/ns3.42-AstraSimNetwork-default" \
-        --workload-configuration=${WORKLOAD} \
-        --system-configuration=${SYSTEM} \
-        --network-configuration=${NETWORK} \
-        --remote-memory-configuration=${MEMORY} \
-        --logical-topology-configuration=${LOGICAL_TOPOLOGY} \
-        --comm-group-configuration=\"empty\"
 }
 # Main Script
 case "$1" in
@@ -79,10 +45,6 @@ case "$1" in
 -c|--compile|"")
     setup
     compile;;
--r|--run)
-    # setup
-    # compile
-    run;;
 -h|--help|*)
-    printf "Prints help message";;
+    printf "Invalid option '$1'.\n";;
 esac

--- a/examples/run_scripts/ns3/Ring_allgather_16npus.sh
+++ b/examples/run_scripts/ns3/Ring_allgather_16npus.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+set -x
+
+SCRIPT_DIR=$(dirname "$(realpath $0)")
+ASTRA_SIM_DIR="${SCRIPT_DIR:?}"/../../..
+EXAMPLES_DIR="${ASTRA_SIM_DIR:?}"/examples
+NS3_DIR="${ASTRA_SIM_DIR:?}"/extern/network_backend/ns-3
+
+WORKLOAD="${EXAMPLES_DIR:?}"/workload/microbenchmarks/all_gather/16npus_1MB/all_gather
+SYSTEM="${EXAMPLES_DIR:?}"/system/native_collectives/Ring_4chunks.json
+NETWORK="${NS3_DIR:?}"/scratch/config/config_clos.txt
+LOGICAL_TOPOLOGY="${EXAMPLES_DIR:?}"/network/ns3/sample_16nodes_1D.json
+
+MEMORY="${EXAMPLES_DIR:?}"/remote_memory/analytical/no_memory_expansion.json
+COMM_GROUP_CONFIGURATION="empty"
+
+cd "${NS3_DIR}/build/scratch"
+
+echo "Running simulation with WORKLOAD: ${WORKLOAD}"
+
+./ns3.42-AstraSimNetwork-default \
+    --workload-configuration=${WORKLOAD} \
+    --system-configuration=${SYSTEM} \
+    --network-configuration=${NETWORK} \
+    --remote-memory-configuration=${MEMORY} \
+    --logical-topology-configuration=${LOGICAL_TOPOLOGY} \
+    --comm-group-configuration=${COMM_GROUP_CONFIGURATION}
+
+cd "${SCRIPT_DIR:?}"

--- a/examples/run_scripts/ns3/debug_ns3.sh
+++ b/examples/run_scripts/ns3/debug_ns3.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR=$(dirname "$(realpath $0)")
+ASTRA_SIM_DIR="${SCRIPT_DIR:?}"/../../..
+EXAMPLES_DIR="${ASTRA_SIM_DIR:?}"/examples
+NS3_DIR="${ASTRA_SIM_DIR:?}"/extern/network_backend/ns-3
+
+WORKLOAD="${EXAMPLES_DIR:?}"/workload/microbenchmarks/all_gather/16npus_1MB/all_gather
+SYSTEM="${EXAMPLES_DIR:?}"/system/native_collectives/Ring_4chunks.json
+NETWORK="${NS3_DIR:?}"/scratch/config/config_clos.txt
+LOGICAL_TOPOLOGY="${EXAMPLES_DIR:?}"/network/ns3/sample_16nodes_1D.json
+
+MEMORY="${EXAMPLES_DIR:?}"/remote_memory/analytical/no_memory_expansion.json
+COMM_GROUP_CONFIGURATION="empty"
+
+cd "${NS3_DIR}/build/scratch"
+
+echo "Running simulation with WORKLOAD: ${WORKLOAD}"
+
+gdb --args \
+    ./ns3.42-AstraSimNetwork-debug \
+    --workload-configuration=${WORKLOAD} \
+    --system-configuration=${SYSTEM} \
+    --network-configuration=${NETWORK} \
+    --remote-memory-configuration=${MEMORY} \
+    --logical-topology-configuration=${LOGICAL_TOPOLOGY} \
+    --comm-group-configuration=${COMM_GROUP_CONFIGURATION}
+
+cd "${SCRIPT_DIR:?}"

--- a/examples/run_scripts/ns3/run_ns3_with_custom_collective.sh
+++ b/examples/run_scripts/ns3/run_ns3_with_custom_collective.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+set -x
+
+SCRIPT_DIR=$(dirname "$(realpath $0)")
+ASTRA_SIM_DIR="${SCRIPT_DIR:?}"/../../..
+EXAMPLES_DIR="${ASTRA_SIM_DIR:?}"/examples
+NS3_DIR="${ASTRA_SIM_DIR:?}"/extern/network_backend/ns-3
+
+WORKLOAD="${EXAMPLES_DIR:?}"/workload/microbenchmarks/all_reduce/8npus_1MB/all_reduce
+SYSTEM="${EXAMPLES_DIR:?}/system/custom_collectives/custom_collective.json"
+NETWORK="${NS3_DIR:?}"/scratch/config/config_clos.txt
+LOGICAL_TOPOLOGY="${EXAMPLES_DIR:?}"/network/ns3/sample_8nodes_1D.json
+
+MEMORY="${EXAMPLES_DIR:?}"/remote_memory/analytical/no_memory_expansion.json
+COMM_GROUP_CONFIGURATION="empty"
+
+cd "${NS3_DIR}/build/scratch"
+
+echo "Running simulation with WORKLOAD: ${WORKLOAD}"
+
+./ns3.42-AstraSimNetwork-default \
+    --workload-configuration=${WORKLOAD} \
+    --system-configuration=${SYSTEM} \
+    --network-configuration=${NETWORK} \
+    --remote-memory-configuration=${MEMORY} \
+    --logical-topology-configuration=${LOGICAL_TOPOLOGY} \
+    --comm-group-configuration=${COMM_GROUP_CONFIGURATION}
+
+cd "${SCRIPT_DIR:?}"


### PR DESCRIPTION
## Summary
Extract the run commands from build scripts into independent run scripts. 

## Test Plan
- Run the scripts to confirm they work 
- Run the build scripts to confirm they no longer actually execute the simulation.

## Additional Notes
- The script to run custom collectives, `run_ns3_with_custom_collective.sh` will not work as-is. This is because the path in the custom collectives directory is a relative path, which is different from analytical backend. 
- For now, print a message showing the issue. 
- TODO: Fix