### PR TITLE
Remove unnecessary inputs from system input for custom collectives

### DIFF
--- a/astra-sim/common/Common.hh
+++ b/astra-sim/common/Common.hh
@@ -63,7 +63,7 @@ enum class CollectiveImplType {
     DoubleBinaryTree,
     HalvingDoubling,
     OneHalvingDoubling,
-    ChakraImpl,
+    CustomCollectiveImpl,
 };
 
 enum class CollectiveBarrier { Blocking = 0, Non_Blocking };
@@ -138,6 +138,7 @@ class CloneInterface {
 /*
  * CollectiveImpl holds the user's description on how a collective algorithm is
  * implemented, provided in the System layer input.
+ * TODO: Move to astraccl/
  */
 class CollectiveImpl : public CloneInterface {
   public:
@@ -171,16 +172,16 @@ class DirectCollectiveImpl : public CollectiveImpl {
 };
 
 /*
- * ChakraCollectiveImpl contains information about a collective implementation
+ * CustomCollectiveImpl contains information about a collective implementation
  * represented using the Chakra ET format. It containes the filename of the
  * Chakra ET which holds the implementation, provided in the System layer input.
  */
-class ChakraCollectiveImpl : public CollectiveImpl {
+class CustomCollectiveImpl : public CollectiveImpl {
   public:
     CloneInterface* clone() const {
-        return new ChakraCollectiveImpl(*this);
+        return new CustomCollectiveImpl(*this);
     };
-    ChakraCollectiveImpl(CollectiveImplType type, std::string filename)
+    CustomCollectiveImpl(CollectiveImplType type, std::string filename)
         : CollectiveImpl(type) {
         this->filename = filename;
     }

--- a/astra-sim/system/Common.hh
+++ b/astra-sim/system/Common.hh
@@ -63,7 +63,7 @@ enum class CollectiveImplType {
     DoubleBinaryTree,
     HalvingDoubling,
     OneHalvingDoubling,
-    ChakraImpl,
+    CustomCollectiveImpl,
 };
 
 enum class CollectiveBarrier { Blocking = 0, Non_Blocking };
@@ -138,6 +138,7 @@ class CloneInterface {
 /*
  * CollectiveImpl holds the user's description on how a collective algorithm is
  * implemented, provided in the System layer input.
+ * TODO: Move to astraccl/
  */
 class CollectiveImpl : public CloneInterface {
   public:
@@ -171,16 +172,16 @@ class DirectCollectiveImpl : public CollectiveImpl {
 };
 
 /*
- * ChakraCollectiveImpl contains information about a collective implementation
+ * CustomCollectiveImpl contains information about a collective implementation
  * represented using the Chakra ET format. It containes the filename of the
  * Chakra ET which holds the implementation, provided in the System layer input.
  */
-class ChakraCollectiveImpl : public CollectiveImpl {
+class CustomCollectiveImpl : public CollectiveImpl {
   public:
     CloneInterface* clone() const {
-        return new ChakraCollectiveImpl(*this);
+        return new CustomCollectiveImpl(*this);
     };
-    ChakraCollectiveImpl(CollectiveImplType type, std::string filename)
+    CustomCollectiveImpl(CollectiveImplType type, std::string filename)
         : CollectiveImpl(type) {
         this->filename = filename;
     }

--- a/astra-sim/system/Sys.cc
+++ b/astra-sim/system/Sys.cc
@@ -780,6 +780,10 @@ DataSet* Sys::generate_collective(
     ComType collective_type,
     int explicit_priority,
     CommunicatorGroup* communicator_group) {
+    // TODO(jinsun): For custom collective, we do not need the chunk_size here (since the chunk size is already determined)
+    // Therefore, we also do not need the 'preferred-dataset-splits' value from the system JSON input. 
+    // However, this variable is intertwined deeply in this function so that we cannot remove it for now.
+    // Therefore, we have to keep that value in the JSON input. TODO: Refactor and remove. 
     uint64_t chunk_size = determine_chunk_size(size, collective_type);
     uint64_t recommended_chunk_size = chunk_size;
     int streams = ceil(((double)size) / chunk_size);

--- a/astra-sim/system/Sys.cc
+++ b/astra-sim/system/Sys.cc
@@ -535,7 +535,7 @@ CollectiveImpl* Sys::generate_collective_impl_from_input(
 CollectiveImpl* Sys::generate_custom_collective_impl(
     string chakra_filepath) {
     string filename = chakra_filepath + "." + to_string(id) + ".et";
-    return new ChakraCollectiveImpl(CollectiveImplType::ChakraImpl, filename);
+    return new CustomCollectiveImpl(CollectiveImplType::CustomCollectiveImpl, filename);
 }
 
 Tick Sys::boostedTick() {
@@ -1071,8 +1071,8 @@ CollectivePhase Sys::generate_collective_phase(
                                                (RingTopology*)topology,
                                                data_size));
         return vn;
-    } else if (collective_impl->type == CollectiveImplType::ChakraImpl) {
-        string filename = ((ChakraCollectiveImpl*)collective_impl)->filename;
+    } else if (collective_impl->type == CollectiveImplType::CustomCollectiveImpl) {
+        string filename = ((CustomCollectiveImpl*)collective_impl)->filename;
         CollectivePhase vn(this, queue_id, new CustomAlgorithm(filename, id));
         return vn;
     } else {

--- a/astra-sim/system/astraccl/native_collectives/logical_topology/GeneralComplexTopology.cc
+++ b/astra-sim/system/astraccl/native_collectives/logical_topology/GeneralComplexTopology.cc
@@ -34,7 +34,7 @@ GeneralComplexTopology::GeneralComplexTopology(
             // the logical topology. (Refer to functions involving
             // 'Sys.cc::generate_collective') Therefore, we fill in the logical
             // topology with a dummy, default value.
-            collective_impl[dim]->type == CollectiveImplType::ChakraImpl) {
+            collective_impl[dim]->type == CollectiveImplType::CustomCollectiveImpl) {
             RingTopology* ring = new RingTopology(
                 RingTopology::Dimension::NA, id, dimension_size[dim],
                 (id % (offset * dimension_size[dim])) / offset, offset);

--- a/examples/system/custom_collectives/custom_collective.json
+++ b/examples/system/custom_collectives/custom_collective.json
@@ -1,10 +1,6 @@
 {
   "scheduling-policy": "FIFO",
-  "endpoint-delay": 10,
-  "active-chunks-per-dimension": 1,
   "preferred-dataset-splits": 1,
   "all-reduce-implementation-custom": ["../../../../examples/system/custom_collectives/custom_ring_allreduce_8npus_1MB/custom_allreduce"],
-  "collective-optimization": "localBWAware",
-  "local-mem-bw": 50,
-  "boost-mode": 0
+  "local-mem-bw": 50
 }


### PR DESCRIPTION
## Summary
Some system layer inputs are irrelevant when using custom collective.  Remove them. 

## Test Plan
Build, run, test

## Additional Notes
Order of merge: #332 -> #331 -> #333

The `preferred-dataset-split` option is not semantically necessary, but its use is deeply ingrained in the code that we cannot remove it. Refer to the comment in the code. 