### PR TITLE
Force upgrade protobuf to most recent

### DIFF
--- a/.github/workflows/setup.sh
+++ b/.github/workflows/setup.sh
@@ -26,6 +26,6 @@ cd ${PROJ_DIR}/extern/graph_frontend/chakra
 pip3 install .
 
 # Temporary workaround to resolve protobuf mismatch. Refer to the PR for more details.
-pip3 install protobuf==6.31.0
+pip3 install --upgrade protobuf
 
 ### ======================================================


### PR DESCRIPTION
## Summary
#314 only updated protobuf to a hardcoded `6.31.0`. This broke as a new `6.31.1` was introduced. 
As a response, force protobuf to upgrade to the most recent version (instead of a hardcoded version)

The proper solution is to change the chakra repo. 