### PR TITLE
Symbolic Representation of Collective Size

### DIFF
--- a/astra-sim/system/Sys.cc
+++ b/astra-sim/system/Sys.cc
@@ -669,9 +669,9 @@ DataSet* Sys::generate_collective(
     int explicit_priority,
     CommunicatorGroup* communicator_group) {
     // TODO(jinsun): For custom collective, we do not need the chunk_size here (since the chunk size is already determined)
-    // Therefore, we also do not need the 'preferred-dataset-splits' value from the system JSON input. 
+    // Therefore, we also do not need the 'preferred-dataset-splits' value from the system JSON input.
     // However, this variable is intertwined deeply in this function so that we cannot remove it for now.
-    // Therefore, we have to keep that value in the JSON input. TODO: Refactor and remove. 
+    // Therefore, we have to keep that value in the JSON input. TODO: Refactor and remove.
     uint64_t chunk_size = determine_chunk_size(size, collective_type);
     uint64_t recommended_chunk_size = chunk_size;
     int streams = ceil(((double)size) / chunk_size);
@@ -997,7 +997,7 @@ CollectivePhase Sys::generate_collective_phase(
         return vn;
     } else if (collective_impl->type == CollectiveImplType::CustomCollectiveImpl) {
         string filename = ((CustomCollectiveImpl*)collective_impl)->filename;
-        CollectivePhase vn(this, 0, new CustomAlgorithm(filename, id, queue_id, comm_group));
+        CollectivePhase vn(this, queue_id, new CustomAlgorithm(filename, id, data_size, queue_id, comm_group, this));
         return vn;
     } else {
         LoggerFactory::get_logger("system")->critical(

--- a/astra-sim/system/astraccl/custom_collectives/CustomAlgorithm.cc
+++ b/astra-sim/system/astraccl/custom_collectives/CustomAlgorithm.cc
@@ -18,7 +18,7 @@ using namespace Chakra;
 
 typedef ChakraProtoMsg::NodeType ChakraNodeType;
 
-CustomAlgorithm::CustomAlgorithm(std::string et_filename, int id, int pos_in_comm, CommunicatorGroup* comm_group) : Algorithm() {
+CustomAlgorithm::CustomAlgorithm(std::string et_filename, int id, uint64_t data_size, int pos_in_comm, CommunicatorGroup* comm_group, Sys* sys) : Algorithm() {
     try {
         et_filename = et_filename + "." + to_string(pos_in_comm) + ".et";
         this->et_feeder = new Chakra::FeederV3::ETFeeder(et_filename);
@@ -34,6 +34,113 @@ CustomAlgorithm::CustomAlgorithm(std::string et_filename, int id, int pos_in_com
         std::exit(1);
     }
     this->id = id;
+    this->data_size = data_size;
+    this->sys = sys;
+}
+
+// Get attributes specific to the custom collective from ETFeederNode
+int get_msg_chunk_cnt(shared_ptr<Chakra::FeederV3::ETFeederNode> node) {
+    const Chakra::FeederV3::ChakraAttr* attr;
+    if (node->get_attr_msg("msg_chunk_cnt", &attr)) {
+        return attr->int32_val();
+    } else {
+        throw std::runtime_error("CustomAlgorithm: Node " + to_string(node->id()) +
+                                 " does not have 'msg_chunk_cnt' attribute.");
+    }
+}
+
+int get_total_chunk_cnt(shared_ptr<Chakra::FeederV3::ETFeederNode> node) {
+    const Chakra::FeederV3::ChakraAttr* attr;
+    if (node->get_attr_msg("total_chunk_cnt", &attr)) {
+        return attr->int32_val();
+    } else {
+        throw std::runtime_error("CustomAlgorithm: Node " + to_string(node->id()) +
+                                 " does not have 'total_chunk_cnt' attribute.");
+    }
+}
+
+int get_msg_chunk_idx(shared_ptr<Chakra::FeederV3::ETFeederNode> node) {
+    const Chakra::FeederV3::ChakraAttr* attr;
+    if (node->get_attr_msg("msg_chunk_idx", &attr)) {
+        return attr->int32_val();
+    } else {
+        throw std::runtime_error("CustomAlgorithm: Node " + to_string(node->id()) +
+                                 " does not have 'msg_chunk_idx' attribute.");
+    }
+}
+
+uint64_t CustomAlgorithm::get_msg_size(shared_ptr<Chakra::FeederV3::ETFeederNode> node) {
+    auto logger = AstraSim::LoggerFactory::get_logger("system::astraccl::custom_collectives");
+    uint64_t msg_size = 0;
+    uint64_t coll_comm_size = this->data_size;
+    int msg_chunk_cnt = get_msg_chunk_cnt(node);
+    int msg_chunk_idx = get_msg_chunk_idx(node);
+    int total_chunk_cnt = get_total_chunk_cnt(node);
+    int num_involved_npus = this->sys->all_sys.size();
+    if (this->comm_group != nullptr) {
+        int num_involved_npus = this->comm_group->involved_NPUs.size();
+    }
+
+    // Custom collective generated with old converter. 
+    // Fallback to using the hardcoded message size.
+    if (msg_chunk_cnt == -1 || msg_chunk_idx == -1 || total_chunk_cnt == -1) {
+        logger->warn("Node {} of custom algorithm with filename {} has invalid inputs:"
+                     "  - msg_chunk_cnt ({})\n  - msg_chunk_idx ({})\n  - total_chunk_cnt ({})"
+                     "This et was generated with old et_converter that does not support chunking."
+                     "Falling back to original 'comm_size' attribute for message size."
+                     "The 'comm_size' in custom collectives will be deprecated soon. Please refer to PR #343 and update the custom collective generator",
+                     node->id(), this->et_filename, msg_chunk_cnt, msg_chunk_idx, total_chunk_cnt);
+
+        uint64_t comm_size = node->get_attr<uint64_t>("comm_size", 0);
+        if (comm_size == 0) {
+            logger->error("Node {} of custom algorithm with filename {} does not even have valid 'comm_size' attribute. Throwing",
+                           node->id(), this->et_filename);
+            throw std::runtime_error("Custom collective without valid attributes");
+        }
+        return comm_size;
+    }
+
+    // Very unlikely this is a valid case. Don't implement for now.
+    if (total_chunk_cnt % num_involved_npus != 0) {
+        logger->error("Node {} of custom algorithm with filename {} has total number of chunks ({}) not divisible by involved NPUs ({}).",
+                        node->id(), this->et_filename, total_chunk_cnt, num_involved_npus);
+        throw std::runtime_error("UNIMPLEMENTED");
+    }
+    
+    // The collective is cleanly divisible into the total number of chunks.
+    uint64_t chunk_size = 0;
+    if (coll_comm_size % total_chunk_cnt == 0) {
+        chunk_size = coll_comm_size / total_chunk_cnt;
+        // In AllGather, coll_comm_size points to the input buffer, not the total output buffer.
+        // However, total_chunk_cnt points to the total number of chunks in the output buffer.
+        if (this->comType == ComType::All_Gather) {
+            if ((coll_comm_size * num_involved_npus) % total_chunk_cnt != 0) {
+                logger->error("Node {} of custom algorithm with filename {} has non-divisible coll_comm_size ({} bytes) and num_involved_npus ({}). "
+                             "Calculating message size with remainder handling.",
+                             node->id(), this->et_filename, coll_comm_size, num_involved_npus);
+                // Very unlikely. Don't implement for now.
+                throw std::runtime_error("UNIMPLEMENTED");
+            }
+            // The input buffer to AG may break down into more than 1 chunk.
+            // We validated before that total_chunk_cnt % num_involved_npus == 0.
+            int chunks_per_input_buffer = total_chunk_cnt / num_involved_npus;
+            chunk_size = coll_comm_size / chunks_per_input_buffer;
+        }
+        return chunk_size * msg_chunk_cnt;
+    }
+
+    // Unlikely, but still: the collective is *not* cleanly divisible into the total number of chunks.
+    logger->warn("Node {} of custom algorithm with filename {} has non-divisible coll_comm_size ({} bytes) and total_chunk_cnt ({}). "
+                 "Calculating message size with remainder handling.",
+                 node->id(), this->et_filename, coll_comm_size, total_chunk_cnt);
+    // coll_comm_size = basic_chunk_size * total_chunk_cnt + remainder.
+    uint64_t basic_chunk_size = coll_comm_size / total_chunk_cnt;
+    uint64_t remainder = coll_comm_size % total_chunk_cnt;
+    // Is the last chunk included in this message?
+    if (msg_chunk_idx + msg_chunk_cnt > total_chunk_cnt) {
+        return basic_chunk_size * msg_chunk_cnt + remainder;
+    }
+    return basic_chunk_size * msg_chunk_cnt;
 }
 
 int CustomAlgorithm::convert_algo_rank_to_real_rank(int algo_rank) {
@@ -50,6 +157,7 @@ void CustomAlgorithm::issue(shared_ptr<Chakra::FeederV3::ETFeederNode> node) {
     this->et_feeder->getDependancyResolver().take_node(node->id());
     ChakraNodeType type = node->type();
     if (type == ChakraNodeType::COMM_SEND_NODE) {
+        uint64_t msg_size = get_msg_size(node);
         sim_request snd_req;
         int dst_rank = convert_algo_rank_to_real_rank(node->comm_dst());
         snd_req.srcRank = node->comm_src(this->stream->owner->id);
@@ -62,13 +170,11 @@ void CustomAlgorithm::issue(shared_ptr<Chakra::FeederV3::ETFeederNode> node) {
         sehd->event = EventType::PacketSent;
         stream->owner->front_end_sim_send(
             0, Sys::dummy_data,
-            // Note that we're using the comm size as hardcoded in the Impl
-            // Chakra et, ed through the comm. api, and ignore the comm.size fed
-            // in the workload chakra et. TODO: fix.
-            node->comm_size(), UINT8, dst_rank, node->comm_tag(),
+            msg_size, UINT8, dst_rank, node->comm_tag(),
             &snd_req, Sys::FrontEndSendRecvType::NATIVE, &Sys::handleEvent,
             sehd);
     } else if (type == ChakraNodeType::COMM_RECV_NODE) {
+        uint64_t msg_size = get_msg_size(node);
         sim_request rcv_req;
         int src_rank = convert_algo_rank_to_real_rank(node->comm_src());
         RecvPacketEventHandlerData* rcehd = new RecvPacketEventHandlerData;
@@ -77,7 +183,7 @@ void CustomAlgorithm::issue(shared_ptr<Chakra::FeederV3::ETFeederNode> node) {
         rcehd->custom_algorithm = this;
         rcehd->event = EventType::PacketReceived;
         stream->owner->front_end_sim_recv(
-            0, Sys::dummy_data, node->comm_size(), UINT8, src_rank,
+            0, Sys::dummy_data, msg_size, UINT8, src_rank,
             node->comm_tag(), &rcv_req, Sys::FrontEndSendRecvType::NATIVE,
             &Sys::handleEvent, rcehd);
     } else if (type == ChakraNodeType::COMP_NODE) {
@@ -86,9 +192,15 @@ void CustomAlgorithm::issue(shared_ptr<Chakra::FeederV3::ETFeederNode> node) {
         WorkloadLayerHandlerData* wlhd = new WorkloadLayerHandlerData;
         wlhd->node_id = node->id();
         uint64_t runtime = 1ul;
+        // TODO: Take the bandwidth from system/input.json and calculate the runtime
+        // following PacketBundle::call
+        // TODO: Find a way to propagate the message size resolved in COMM_RECV_NODE to here, 
+        // So that we can use that message size to calculate the compute time. 
+        // Ignore for now.
         if (node->runtime() != 0ul) {
             // chakra runtimes are in microseconds and we should convert it into
             // nanoseconds.
+            // Following Workload::issue_replay
             runtime = node->runtime() * 1000;
         }
         stream->owner->register_event(this, EventType::General, wlhd, runtime);

--- a/astra-sim/system/astraccl/custom_collectives/CustomAlgorithm.hh
+++ b/astra-sim/system/astraccl/custom_collectives/CustomAlgorithm.hh
@@ -35,7 +35,7 @@ namespace AstraSim {
  */
 class CustomAlgorithm : public Algorithm {
   public:
-    CustomAlgorithm(std::string et_filename, int id, int pos_in_comm, CommunicatorGroup* comm_group);
+    CustomAlgorithm(std::string et_filename, int id, uint64_t data_size, int pos_in_comm, CommunicatorGroup* comm_group, Sys* sys);
 
     // Runs the collective algorithm. This function is only called once to start
     // the algorithm.
@@ -55,7 +55,17 @@ class CustomAlgorithm : public Algorithm {
      */
     void issue(std::shared_ptr<Chakra::FeederV3::ETFeederNode> node);
     void issue_dep_free_nodes();
+    
 
+    /* 
+     * Find out the message size of the p2p send/receive operation.
+     * A *collective* is split into multiple *chunks*. 
+     * Each p2p send/receive message may consist of one or more chunks.
+     */
+    uint64_t get_msg_size(std::shared_ptr<Chakra::FeederV3::ETFeederNode> node);
+
+    // Path to the Chakra ET file representing the custom collective algorithm.
+    std::string et_filename;
     // Rank Id
     int id;
     // ET Feeder for the Chakra ET for this specific communication & rank.
@@ -63,6 +73,9 @@ class CustomAlgorithm : public Algorithm {
     // to traverse the whole workload Chakra ET.
     Chakra::ETFeeder* et_feeder;
     CommunicatorGroup* comm_group;
+    // Size of the collective as defined in the workload's COLL_COMM_NODE Chakra node.
+    uint64_t data_size;
+    Sys* sys;
 };
 
 }  // namespace AstraSim


### PR DESCRIPTION
Ref: collectiveapi [PR 1](https://github.com/astra-sim/collectiveapi/pull/1)

## Summary
Previously custom collectives had the message size of each send/recv message hardcoded into the custom collective et, which overrode the message size in the *workload* chakra ET (undesirable!)

This PR resolves this by replacing the hardcoded message size with a symbolic representation of the message size in the custom collective et. The custom collective et now holds `SEND 1 chunk out of 8 chunks` insead of `SEND 1MB of data`.  The system layer then resolves the message size. 

## DRAFT PR
This is a draft PR. The feature is functional, but some stuff needs to be done: 
- Add more examples. 
- Add reproducing scripts. 
- Comments/documentation
- Validate how the collective size works for all gather (local buffer v. global buffer)