### PR TITLE
Per node custom collective

### DIFF
--- a/astra-sim/system/Common.hh
+++ b/astra-sim/system/Common.hh
@@ -181,13 +181,18 @@ class CustomCollectiveImpl : public CollectiveImpl {
     CloneInterface* clone() const {
         return new CustomCollectiveImpl(*this);
     };
-    CustomCollectiveImpl(CollectiveImplType type, std::string filename)
+    // TODO: Comments. general_et_filename: specific filename for this rank, to apply to all collectives unless overridden by the pernode config.
+    // pernode_config_filename: the yaml file
+    CustomCollectiveImpl(CollectiveImplType type, std::string general_et_filename, std::string pernode_config_filename = "")
         : CollectiveImpl(type) {
-        this->filename = filename;
+        this->general_et_filename = general_et_filename;
+        this->pernode_config_filename = pernode_config_filename;
     }
 
     /* The filename of the corresponding Chakra ET file */
-    std::string filename;
+    std::string general_et_filename;
+    /* The filename of the per-node configuration file */
+    std::string pernode_config_filename;
 };
 }  // namespace AstraSim
 

--- a/astra-sim/system/Sys.hh
+++ b/astra-sim/system/Sys.hh
@@ -81,8 +81,10 @@ class Sys : public Callable {
     bool initialize_sys(std::string name);
     CollectiveImpl* generate_collective_impl_from_input(
         std::string collective_impl_str);
+    // TODO: parameter documentation. Better name.
     CollectiveImpl* generate_custom_collective_impl(
-        std::string collective_impl_str);
+        std::string collective_impl_str,
+        std::string pernode_config_filename = "");
     //---------------------------------------------------------------------------
 
     // Helper Functions

--- a/astra-sim/system/astraccl/custom_collectives/CustomAlgorithm.hh
+++ b/astra-sim/system/astraccl/custom_collectives/CustomAlgorithm.hh
@@ -34,7 +34,7 @@ namespace AstraSim {
  */
 class CustomAlgorithm : public Algorithm {
   public:
-    CustomAlgorithm(std::string et_filename, int id);
+    CustomAlgorithm(std::string et_filename, std::string pernode_config_filename, int id);
 
     // Runs the collective algorithm. This function is only called once to start
     // the algorithm.

--- a/examples/system/custom_collectives/custom_collective.json
+++ b/examples/system/custom_collectives/custom_collective.json
@@ -1,6 +1,8 @@
 {
   "scheduling-policy": "FIFO",
   "preferred-dataset-splits": 1,
-  "all-reduce-implementation-custom": ["examples/system/custom_collectives/custom_ring_allreduce_8npus_1MB/custom_allreduce"],
-  "local-mem-bw": 50
+  "all-reduce-implementation-custom": ["examples/system/custom_collectives/custom_ring_allreduce_symbolic_8npus/allreduce_ring_8"],
+  "all-reduce-implementation-per-node-custom": ["examples/system/custom_collectives/custom_collective_pernode_config.yml"],
+  "local-mem-bw": 50,
+  "trace-enabled": true
 }

--- a/examples/system/custom_collectives/custom_collective_pernode_config.yml
+++ b/examples/system/custom_collectives/custom_collective_pernode_config.yml
@@ -1,0 +1,5 @@
+# Mapping from 'chakra node id of original workload' to 'custom collective etfile prefix'
+# Relative path to astra-sim
+# 0: Just use the general as defined in custom_collective.json
+1: "examples/system/custom_collectives/allreduce_8npus/allreduce_tacos_8"
+2: "examples/system/custom_collectives/allreduce_8npus/allreduce_tree_8"


### PR DESCRIPTION
## Summary
Previously, the custom collective API would force one collective algorithm to *all* AllReduce/AllGather/... in the workload graph. This could cause 1) inefficiencies, and 2) bugs, because the number of nodes is baked into the custom collective algorithm, regardless of the PG size actually participating in the collective. 

This PR fixes this by allowing users to define a 'per-node' mapping of custom collectives. That is, when the System layer is deciding which collective algorithm to use for a collective node in the *workload* chakra graph, it will look at the following

- If a user specified custom collective algorithm for that specific chakra node exists, use it
- If a user specified custom collective algorithm for that specific collective *type* exists, use it (previous behavior of collective api)
- Use the native collective algorithm. 


In order to do this, the user needs to specify a new yaml file that holds the mapping between chakra node id & custom collective algorithm. The user needs to update the system input to point to this new yaml file. 


## Draft PR
This is a draft PR and WILL NOT BUILD. We need the following: 
- Provide the node id of the COLL_COMM_NODE in the *workload* chakra file to the custom collective layer. This requires piping all the way from `Workload::issue_comm()` through `generate_all-reduce` -> `generate_collective` -> `generate_collective_phase` -> `CustomAlgorithm()`
- Better documentation/comments
- Testing
- Examples
- Fallback to native collective if necessary
- Refactoring of `initialize_sys` and the `all_reduce_implementation_per_dimension` data structure