### PR TITLE
Fix CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,3 +39,8 @@
 # NVIDIA
 * @TaekyungHeo
 ## =============================================================================
+
+## =============================================================================
+## For Pull Requests, this last line will override the above assignments.
+* @tushar-krishna @jinsun-yoo @changhai0109 @willjwon @feris-amd
+## =============================================================================


### PR DESCRIPTION
Let's free @TaekyungHeo from being endlessly pinged as the only reviewer :)

The `CODEOWNERS` file works such that the last entry overrides everything above it, when determining who to automatically designate as the reviewer. Therefore, below the human readable codeowners, add a machine readable codeowners list. 