### PR TITLE
Use Python3.11 for 'Main' Github workflow

### DIFF
--- a/.github/workflows/setup.sh
+++ b/.github/workflows/setup.sh
@@ -12,7 +12,7 @@ apt -y install coreutils wget vim git
 apt -y install gcc-11 g++-11 make cmake 
 apt -y install clang-format 
 apt -y install libboost-dev libboost-program-options-dev
-apt -y install python3.10 python3-pip
+apt -y install python3.11 python3-pip
 apt -y install libprotobuf-dev protobuf-compiler
 apt -y install openmpi-bin openmpi-doc libopenmpi-dev
 


### PR DESCRIPTION
## Summary
Issue: #358 

The 'Main' github workflow uses `python3.10` while the default Dockerfile uses `python3.11`.

For some reason, perhaps due to the old versions, installing python3.10 in the workflow fails after timing out at ~30 mins (check the issue linked above). 

For now, update to `python3.11`. Long term fix needed. 

## Test Plan
Retrigger build workflow

## Additional Notes
Need to fix workflow so that we use a 'prebuilt' version with all dependencies installed.