### PR TITLE
Install library and headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ cmake_minimum_required(VERSION 3.22)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 # Set the build type to Release if not specified
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
@@ -66,7 +68,7 @@ file(GLOB srcs
     "${CMAKE_CURRENT_SOURCE_DIR}/extern/remote_memory_backend/analytical/*.cc")
 
 # Compile AstraSim Library
-add_library(AstraSim STATIC ${srcs})
+add_library(AstraSim ${srcs})
 
 # Link libraries
 target_link_libraries(AstraSim PUBLIC fmt::fmt)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,3 +112,13 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/astra-sim
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         FILES_MATCHING
         PATTERN "*.hh")
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/extern/helper/spdlog/include/spdlog
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        FILES_MATCHING
+        PATTERN "*.h")
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/extern/helper/spdlog_setup
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        FILES_MATCHING
+        PATTERN "*.h")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ project(AstraSim)
 
 # Add libraries.
 include(FetchContent)
+include(GNUInstallDirs)
 
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/extern/helper/fmt")
 option(SPDLOG_FMT_EXTERNAL ON) # override default option for spdlog.
@@ -101,3 +102,11 @@ set_target_properties(AstraSim
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../lib/
     ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../lib/
 )
+
+install(TARGETS AstraSim
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/astra-sim
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        FILES_MATCHING
+        PATTERN "*.hh")


### PR DESCRIPTION
## Summary
This PR does two things:
1. Installs `libAstraSim` and all `.hh` files
2. Allows the user to build a shared library

## Details
Currently, only `libfmt` gets installed at `$CMAKE_INSTALL_PREFIX`. This PR will install `libAstraSim` as well as all header files in `astra-sim/`. This will make the files easier to find so that it is easier to integrate with other projects.